### PR TITLE
Support torch.cuda._device_count_nvml()

### DIFF
--- a/src/torchada/_patch.py
+++ b/src/torchada/_patch.py
@@ -361,6 +361,12 @@ class _CudaModuleWrapper(ModuleType):
         "StreamContext": "core.stream.StreamContext",
     }
 
+    # Attribute name remappings (CUDA name -> MUSA name)
+    # For CUDA-specific APIs that have different names in MUSA
+    _REMAP_ATTRS = {
+        "_device_count_nvml": "device_count",  # NVML is NVIDIA-specific
+    }
+
     def __init__(self, original_cuda, musa_module):
         super().__init__("torch.cuda")
         self._original_cuda = original_cuda
@@ -377,6 +383,10 @@ class _CudaModuleWrapper(ModuleType):
             for part in self._SPECIAL_ATTRS[name].split("."):
                 obj = getattr(obj, part)
             return obj
+
+        # Handle attribute name remapping (CUDA-specific names -> MUSA equivalents)
+        if name in self._REMAP_ATTRS:
+            return getattr(self._musa_module, self._REMAP_ATTRS[name])
 
         # Redirect everything else to torch.musa
         return getattr(self._musa_module, name)

--- a/tests/test_cuda_patching.py
+++ b/tests/test_cuda_patching.py
@@ -64,6 +64,20 @@ class TestTorchCudaModule:
 
             assert count == torch_musa.device_count()
 
+    def test_torch_cuda_device_count_nvml(self):
+        """Test torch.cuda._device_count_nvml() maps to torch.musa.device_count()."""
+        import torch
+
+        import torchada
+
+        if torchada.is_musa_platform():
+            # _device_count_nvml is NVIDIA-specific, should map to device_count on MUSA
+            nvml_count = torch.cuda._device_count_nvml()
+            musa_count = torch.musa.device_count()
+            assert nvml_count == musa_count
+            assert isinstance(nvml_count, int)
+            assert nvml_count >= 0
+
     def test_torch_cuda_current_device(self):
         """Test torch.cuda.current_device() works when GPU available."""
         import torch

--- a/tests/test_extension_build.py
+++ b/tests/test_extension_build.py
@@ -74,6 +74,17 @@ setup(
             assert result.returncode == 0, f"Setup.py syntax error: {result.stderr}"
 
 
+def _is_gpu_available():
+    """Check if CUDA or MUSA GPU is available."""
+    import torch
+
+    if torch.cuda.is_available():
+        return True
+    if hasattr(torch, "musa") and torch.musa.is_available():
+        return True
+    return False
+
+
 @pytest.mark.skipif(
     not os.environ.get("TORCHADA_TEST_BUILD", "0") == "1",
     reason="Extension build tests are slow; set TORCHADA_TEST_BUILD=1 to run",
@@ -83,9 +94,7 @@ class TestExtensionBuild:
 
     def test_build_vector_add_extension(self):
         """Test building the vector_add extension."""
-        import torch
-
-        if not torch.cuda.is_available():
+        if not _is_gpu_available():
             pytest.skip("CUDA/MUSA not available")
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -138,7 +147,7 @@ setup(
         """Test running the vector_add extension after building."""
         import torch
 
-        if not torch.cuda.is_available():
+        if not _is_gpu_available():
             pytest.skip("CUDA/MUSA not available")
 
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
Remap `torch.cuda._device_count_nvml` to `torch.musa.device_count`.

### Testing Done

| torch | torch_musa | Tests
| -- | -- | --
| 2.7.1 | 2.7.0+8ae54fa | ✅ 213 passed, 2 skipped
| 2.7.1 | 2.7.1+5ee0a64 | ✅ 213 passed, 2 skipped

