### PR TITLE
Support torch.cuda.graph(cuda_graph=g)

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,11 +327,11 @@ Add `torchada` to your project's dependencies:
 ```python
 # pyproject.toml
 dependencies = [
-    "torchada>=0.1.11",
+    "torchada>=0.1.16",
 ]
 
 # Or requirements.txt
-torchada>=0.1.11
+torchada>=0.1.16
 ```
 
 #### Pattern 3: Device Availability Check
@@ -405,7 +405,7 @@ This pattern is used by **LightX2V**.
 
 ### Common Integration Steps
 
-1. **Add dependency**: Add `torchada>=0.1.11` to your project dependencies
+1. **Add dependency**: Add `torchada>=0.1.16` to your project dependencies
 
 2. **Import early**: Import `torchada` before using any `torch.cuda` APIs
    ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torchada"
-version = "0.1.15"
+version = "0.1.16"
 description = "Adapter package for torch_musa to act exactly like PyTorch CUDA"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/torchada/__init__.py
+++ b/src/torchada/__init__.py
@@ -23,7 +23,7 @@ Usage:
     from torch.utils.cpp_extension import CUDAExtension, BuildExtension, CUDA_HOME
 """
 
-__version__ = "0.1.15"
+__version__ = "0.1.16"
 
 from . import cuda, utils
 from ._patch import apply_patches, get_original_init_process_group, is_patched


### PR DESCRIPTION
`torch.cuda.graph(cuda_graph=g)` => `torch.musa.graph(musa_graph=g)`.

### Testing Done

| torch_musa | Tests
| -- | --
| 2.7.0 | ✅ 220 passed, 2 skipped
| 2.7.1 | ✅ 220 passed, 2 skipped

