### PR TITLE
Support ProfilerActivity.CUDA

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ See `src/torchada/_mapping.py` for the complete mapping table (380+ mappings).
 
 ```
 # pyproject.toml or requirements.txt
-torchada>=0.1.16
+torchada>=0.1.17
 ```
 
 ### Step 2: Conditional Import

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ That's it! All `torch.cuda.*` APIs are automatically redirected to `torch.musa.*
 | Synchronization | `torch.cuda.synchronize()`, `Stream`, `Event` |
 | Mixed precision | `torch.cuda.amp.autocast()`, `GradScaler()` |
 | CUDA Graphs | `torch.cuda.CUDAGraph`, `torch.cuda.graph()` |
+| Profiler | `ProfilerActivity.CUDA` → uses PrivateUse1 |
 | Distributed | `dist.init_process_group(backend='nccl')` → uses MCCL |
 | torch.compile | `torch.compile(model)` with all backends |
 | C++ Extensions | `CUDAExtension`, `BuildExtension`, `load()` |

--- a/README_CN.md
+++ b/README_CN.md
@@ -55,6 +55,7 @@ torch.cuda.synchronize()
 | 同步 | `torch.cuda.synchronize()`, `Stream`, `Event` |
 | 混合精度 | `torch.cuda.amp.autocast()`, `GradScaler()` |
 | CUDA Graphs | `torch.cuda.CUDAGraph`, `torch.cuda.graph()` |
+| 性能分析 | `ProfilerActivity.CUDA` → 使用 PrivateUse1 |
 | 分布式训练 | `dist.init_process_group(backend='nccl')` → 使用 MCCL |
 | torch.compile | `torch.compile(model)` 支持所有后端 |
 | C++ 扩展 | `CUDAExtension`, `BuildExtension`, `load()` |

--- a/README_CN.md
+++ b/README_CN.md
@@ -190,7 +190,7 @@ if torchada.is_gpu_device(device):  # 在 CUDA 和 MUSA 上都能工作
 
 ```
 # pyproject.toml 或 requirements.txt
-torchada>=0.1.16
+torchada>=0.1.17
 ```
 
 ### 步骤 2：条件导入

--- a/examples/profiler_demo.py
+++ b/examples/profiler_demo.py
@@ -1,0 +1,53 @@
+"""
+Simple demo showing torch.profiler.ProfilerActivity.CUDA working on MUSA via torchada.
+
+Usage:
+    python examples/profiler_demo.py
+"""
+
+import torchada  # Must import before torch to apply patches
+import torch
+
+
+def main():
+    print("=== torchada Profiler Demo ===\n")
+
+    # Show that ProfilerActivity.CUDA is available
+    print(f"ProfilerActivity.CUDA: {torch.profiler.ProfilerActivity.CUDA}")
+    print(f"ProfilerActivity.PrivateUse1: {torch.profiler.ProfilerActivity.PrivateUse1}")
+
+    # Use standard CUDA activity - torchada translates to PrivateUse1 on MUSA
+    activities = [
+        torch.profiler.ProfilerActivity.CPU,
+        torch.profiler.ProfilerActivity.CUDA,  # Works on MUSA!
+    ]
+
+    print(f"\nUsing activities: {activities}")
+
+    # Create some tensors and run operations
+    device = "cuda" if torch.cuda.is_available() else "musa" if torch.musa.is_available() else "cpu"
+    print(f"Device: {device}")
+
+    x = torch.randn(1000, 1000, device=device)
+
+    # Profile with CUDA activity
+    print("\nRunning profiler...")
+    with torch.profiler.profile(
+        activities=activities,
+        record_shapes=True,
+        profile_memory=True,
+    ) as prof:
+        for _ in range(10):
+            y = torch.matmul(x, x)
+            z = y.sum()
+
+    # Print profiler results
+    print("\n=== Profiler Results ===")
+    print(prof.key_averages().table(sort_by="cpu_time_total", row_limit=10))
+
+    print("\nDemo complete!")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torchada"
-version = "0.1.16"
+version = "0.1.17"
 description = "Adapter package for torch_musa to act exactly like PyTorch CUDA"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/torchada/__init__.py
+++ b/src/torchada/__init__.py
@@ -23,7 +23,7 @@ Usage:
     from torch.utils.cpp_extension import CUDAExtension, BuildExtension, CUDA_HOME
 """
 
-__version__ = "0.1.16"
+__version__ = "0.1.17"
 
 from . import cuda, utils
 from ._patch import apply_patches, get_original_init_process_group, is_patched


### PR DESCRIPTION
```bash
root@worker3218:/ws/torchada/examples# python profiler_demo.py 
=== torchada Profiler Demo ===

ProfilerActivity.CUDA: ProfilerActivity.CUDA
ProfilerActivity.PrivateUse1: ProfilerActivity.PrivateUse1

Using activities: [<ProfilerActivity.CPU: 0>, <ProfilerActivity.CUDA: 2>]
Device: musa

Running profiler...

=== Profiler Results ===
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
                                                   Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg     Self MUSA   Self MUSA %    MUSA total  MUSA time avg       CPU Mem  Self CPU Mem      MUSA Mem  Self MUSA Mem    # of Calls  
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
                                           aten::matmul         0.00%      73.449us        57.87%        6.958s     695.814ms       0.000us         0.00%     373.133us      37.313us           0 b           0 b      38.15 Mb           0 b            10  
                                               aten::mm         0.06%       7.344ms        57.87%        6.958s     695.807ms     373.133us        74.64%     373.133us      37.313us           0 b           0 b      38.15 Mb           0 b            10  
                                    musaLaunchKernelExC        57.81%        6.950s        57.81%        6.950s     695.042ms       0.000us         0.00%       0.000us       0.000us           0 b           0 b           0 b           0 b            10  
                                              aten::sum         0.00%     545.508us        42.13%        5.065s     506.485ms     126.764us        25.36%     126.764us      12.676us           0 b           0 b       5.00 Kb       5.00 Kb            10  
                                       musaLaunchKernel        42.12%        5.064s        42.12%        5.064s     253.208ms       0.000us         0.00%       0.000us       0.000us           0 b           0 b           0 b           0 b            20  
                                            aten::empty         0.00%     209.449us         0.00%     209.449us      20.945us       0.000us         0.00%       0.000us       0.000us           0 b           0 b      38.15 Mb      38.15 Mb            10  
                                             musaMalloc         0.00%     153.937us         0.00%     153.937us     153.937us       0.000us         0.00%       0.000us       0.000us           0 b           0 b           0 b           0 b             1  
                                        aten::transpose         0.00%      52.899us         0.00%      87.431us       4.372us       0.000us         0.00%       0.000us       0.000us           0 b           0 b           0 b           0 b            20  
                                       aten::as_strided         0.00%      34.532us         0.00%      34.532us       1.727us       0.000us         0.00%       0.000us       0.000us           0 b           0 b           0 b           0 b            20  
                                  musaDeviceSynchronize         0.00%       1.956us         0.00%       1.956us       1.956us       0.000us         0.00%       0.000us       0.000us           0 b           0 b           0 b           0 b             1  
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
Self CPU time total: 12.023s
Self MUSA time total: 499.897us


Demo complete!
```