### PR TITLE
fix(patch): preserve device index when wrapping torch.device

### DIFF
--- a/src/torchada/_patch.py
+++ b/src/torchada/_patch.py
@@ -775,9 +775,7 @@ def _patch_profiler_activity():
 
         def __init__(self, *args, activities=None, **kwargs):
             translated_activities = _translate_activities(activities)
-            self._profiler = original_profile(
-                *args, activities=translated_activities, **kwargs
-            )
+            self._profiler = original_profile(*args, activities=translated_activities, **kwargs)
 
         def __enter__(self):
             return self._profiler.__enter__()

--- a/src/torchada/_patch.py
+++ b/src/torchada/_patch.py
@@ -225,8 +225,8 @@ class DeviceFactoryWrapper(metaclass=_DeviceFactoryMeta):
         # Handle the case where device is already a torch.device
         if isinstance(device, original):
             if device.type == "cuda":
-                device = "musa"
                 index = device.index if index is None else index
+                device = "musa"
             else:
                 return device
 
@@ -775,7 +775,9 @@ def _patch_profiler_activity():
 
         def __init__(self, *args, activities=None, **kwargs):
             translated_activities = _translate_activities(activities)
-            self._profiler = original_profile(*args, activities=translated_activities, **kwargs)
+            self._profiler = original_profile(
+                *args, activities=translated_activities, **kwargs
+            )
 
         def __enter__(self):
             return self._profiler.__enter__()

--- a/tests/test_device_strings.py
+++ b/tests/test_device_strings.py
@@ -379,6 +379,22 @@ class TestDeviceIndexVariants:
             assert device.type == "cuda"
             assert device.index == 0
 
+    def test_torch_device_from_original_cuda_device(self):
+        """Test torch.device(torch.device('cuda:1')) translation on MUSA."""
+        import torch
+
+        import torchada
+        from torchada._patch import _original_torch_device
+
+        if not torchada.is_musa_platform() or _original_torch_device is None:
+            pytest.skip("MUSA platform required with patched torch.device")
+
+        cuda_device = _original_torch_device("cuda:1")
+        wrapped = torch.device(cuda_device)
+
+        assert wrapped.type == "musa"
+        assert wrapped.index == 1
+
 
 class TestDeviceContextManager:
     """Test device context manager (with torch.device(...):) works."""


### PR DESCRIPTION
### Description

The DeviceFactoryWrapper.new method had a critical logic error when handling torch.device objects. The original code attempted to extract the device index after reassigning the device variable to a string, which would fail since strings don't have an index attribute.

### Before (Buggy):

```
if device.type == "cuda":
    device = "musa"  # device is now a string
    index = device.index if index is None else index  # ERROR: strings have no .index attribute
```

### After (Fixed):

```
if device.type == "cuda":
    index = device.index if index is None else index  # Extract index BEFORE reassigning
    device = "musa"
```

### Changes:
- Core Fix: Reordered lines in DeviceFactoryWrapper.new to extract the device index before reassigning the device variable
- Test Coverage: Added new test case test_torch_device_from_original_cuda_device to validate the fix for the scenario where a CUDA torch.device object is passed to the wrapper

### Testing

```
========================================================== test session starts ==========================================================
platform linux -- Python 3.10.12, pytest-9.0.1, pluggy-1.6.0 -- /usr/bin/python
cachedir: .pytest_cache
rootdir: /home/dist/xxxxxx/torchada
configfile: pyproject.toml
plugins: anyio-4.11.0
collected 1 item                                                                                                                        

tests/test_device_strings.py::TestDeviceIndexVariants::test_torch_device_from_original_cuda_device PASSED                         [100%]

===================================================== 1 passed in 0.01s ======================================================
```