### PR TITLE
Support torch.cuda.cudart().cudaHostRegister() and etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ See `src/torchada/_mapping.py` for the complete mapping table (380+ mappings).
 
 ```
 # pyproject.toml or requirements.txt
-torchada>=0.1.20
+torchada>=0.1.21
 ```
 
 ### Step 2: Conditional Import

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ That's it! All `torch.cuda.*` APIs are automatically redirected to `torch.musa.*
 | Synchronization | `torch.cuda.synchronize()`, `Stream`, `Event` |
 | Mixed precision | `torch.cuda.amp.autocast()`, `GradScaler()` |
 | CUDA Graphs | `torch.cuda.CUDAGraph`, `torch.cuda.graph()` |
+| CUDA Runtime | `torch.cuda.cudart()` → uses MUSA runtime |
 | Profiler | `ProfilerActivity.CUDA` → uses PrivateUse1 |
 | Custom Ops | `Library.impl(..., "CUDA")` → uses PrivateUse1 |
 | Distributed | `dist.init_process_group(backend='nccl')` → uses MCCL |

--- a/README_CN.md
+++ b/README_CN.md
@@ -55,6 +55,7 @@ torch.cuda.synchronize()
 | 同步 | `torch.cuda.synchronize()`, `Stream`, `Event` |
 | 混合精度 | `torch.cuda.amp.autocast()`, `GradScaler()` |
 | CUDA Graphs | `torch.cuda.CUDAGraph`, `torch.cuda.graph()` |
+| CUDA 运行时 | `torch.cuda.cudart()` → 使用 MUSA 运行时 |
 | 性能分析 | `ProfilerActivity.CUDA` → 使用 PrivateUse1 |
 | 自定义算子 | `Library.impl(..., "CUDA")` → 使用 PrivateUse1 |
 | 分布式训练 | `dist.init_process_group(backend='nccl')` → 使用 MCCL |

--- a/README_CN.md
+++ b/README_CN.md
@@ -216,7 +216,7 @@ if torchada.is_gpu_device(device):  # 在 CUDA 和 MUSA 上都能工作
 
 ```
 # pyproject.toml 或 requirements.txt
-torchada>=0.1.20
+torchada>=0.1.21
 ```
 
 ### 步骤 2：条件导入

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torchada"
-version = "0.1.20"
+version = "0.1.21"
 description = "Adapter package for torch_musa to act exactly like PyTorch CUDA"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/torchada/__init__.py
+++ b/src/torchada/__init__.py
@@ -23,7 +23,7 @@ Usage:
     from torch.utils.cpp_extension import CUDAExtension, BuildExtension, CUDA_HOME
 """
 
-__version__ = "0.1.20"
+__version__ = "0.1.21"
 
 from . import cuda, utils
 from ._patch import apply_patches, get_original_init_process_group, is_patched


### PR DESCRIPTION
Added a `_CudartWrapper` class that translates CUDA runtime calls to MUSA runtime calls:
CUDA Runtime | MUSA Runtime
-- | --
cudaHostRegister | musaHostRegister
cudaHostUnregister | musaHostUnregister
cudaMemGetInfo | musaMemGetInfo
cudaGetErrorString | musaGetErrorString
cudaStreamCreate | musaStreamCreate
cudaStreamDestroy | musaStreamDestroy

