### PR TITLE
Fix .muh/.mu lookup in building MUSAExtension

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ See `src/torchada/_mapping.py` for the complete mapping table (380+ mappings).
 
 ```
 # pyproject.toml or requirements.txt
-torchada>=0.1.25
+torchada>=0.1.26
 ```
 
 ### Step 2: Conditional Import

--- a/README_CN.md
+++ b/README_CN.md
@@ -238,7 +238,7 @@ if torchada.is_gpu_device(device):  # 在 CUDA 和 MUSA 上都能工作
 
 ```
 # pyproject.toml 或 requirements.txt
-torchada>=0.1.25
+torchada>=0.1.26
 ```
 
 ### 步骤 2：条件导入

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torchada"
-version = "0.1.25"
+version = "0.1.26"
 description = "Adapter package for torch_musa to act exactly like PyTorch CUDA"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/torchada/__init__.py
+++ b/src/torchada/__init__.py
@@ -23,7 +23,7 @@ Usage:
     from torch.utils.cpp_extension import CUDAExtension, BuildExtension, CUDA_HOME
 """
 
-__version__ = "0.1.25"
+__version__ = "0.1.26"
 
 from . import cuda, utils
 from ._patch import apply_patches, get_original_init_process_group, is_patched

--- a/src/torchada/utils/cpp_extension.py
+++ b/src/torchada/utils/cpp_extension.py
@@ -476,7 +476,7 @@ def _get_build_extension_class():
 
                     Returns:
                         tuple: (converted_path, needs_porting)
-                            - converted_path: Path to ported file (e.g., "csrc_musa/kernel.cu")
+                            - converted_path: Path to ported file (e.g., "csrc_musa/kernel.mu")
                             - needs_porting: True if the source directory needs porting
                     """
                     source_path = os.path.abspath(source)
@@ -494,6 +494,17 @@ def _get_build_extension_class():
                         musa_dir = source_dir + "_musa"
                         new_source = os.path.join(musa_dir, base_name + "." + new_ext)
                         return new_source, True
+                    # Handle .mu/.muh files that don't exist at original path
+                    # Try to find them in the _musa directory (already ported files)
+                    elif ext_name_lower in [".mu", ".muh"]:
+                        if not os.path.exists(source_path):
+                            musa_dir = source_dir + "_musa"
+                            musa_source = os.path.join(musa_dir, source_file)
+                            if os.path.exists(musa_source):
+                                # File exists in _musa dir, use it (no porting needed)
+                                return musa_source, False
+                        # File exists at original path, use it as-is
+                        return source, False
                     else:
                         return source, False
 

--- a/src/torchada/utils/cpp_extension.py
+++ b/src/torchada/utils/cpp_extension.py
@@ -447,6 +447,9 @@ def _get_build_extension_class():
                     """
                     Port a directory containing CUDA sources to MUSA.
 
+                    When both .cu and .mu files exist with the same base name,
+                    the .mu file takes precedence (it's the hand-written MUSA version).
+
                     Args:
                         source_dir: Path to directory containing CUDA sources
                         mapping_rule: Optional custom mapping rules (uses get_mapping_rule() if None)
@@ -458,6 +461,8 @@ def _get_build_extension_class():
                         mapping_rule = self.get_mapping_rule()
 
                     source_dir = os.path.abspath(source_dir)
+                    musa_dir = source_dir + "_musa"
+
                     if source_dir not in self._ported_dirs:
                         musa_sp.LOGGER.setLevel(logging.ERROR)
                         musa_sp.SimplePorting(
@@ -465,7 +470,24 @@ def _get_build_extension_class():
                         ).run()
                         self._ported_dirs.add(source_dir)
 
-                    return source_dir + "_musa"
+                        # After porting, copy any original .mu/.muh files to ensure
+                        # hand-written MUSA files take precedence over ported .cu files.
+                        # This fixes the case where both foo.cu and foo.mu exist -
+                        # SimplePorting processes both, but order is non-deterministic.
+                        import shutil
+
+                        for root, _, files in os.walk(source_dir):
+                            for file in files:
+                                ext = os.path.splitext(file)[1].lower()
+                                if ext in [".mu", ".muh"]:
+                                    src_path = os.path.join(root, file)
+                                    rel_path = os.path.relpath(root, source_dir)
+                                    dst_dir = os.path.join(musa_dir, rel_path)
+                                    dst_path = os.path.join(dst_dir, file)
+                                    os.makedirs(dst_dir, exist_ok=True)
+                                    shutil.copy2(src_path, dst_path)
+
+                    return musa_dir
 
                 def _convert_source_path(self, source):
                     """

--- a/tests/csrc/mixed_sources/add_kernel.cu
+++ b/tests/csrc/mixed_sources/add_kernel.cu
@@ -1,0 +1,45 @@
+/*
+ * CUDA kernel for addition - tests .cu file porting.
+ */
+
+#include <torch/extension.h>
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include "utils.cuh"
+
+__global__ void add_kernel(
+    const float* __restrict__ a,
+    const float* __restrict__ b,
+    float* __restrict__ c,
+    const int n
+) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n) {
+        c[idx] = test_utils::add_elements(a[idx], b[idx]);
+    }
+}
+
+torch::Tensor add_cuda(torch::Tensor a, torch::Tensor b) {
+    TORCH_CHECK(a.device().is_cuda(), "a must be a CUDA tensor");
+    TORCH_CHECK(b.device().is_cuda(), "b must be a CUDA tensor");
+    
+    auto c = torch::empty_like(a);
+    int n = a.numel();
+    
+    const int threads = 256;
+    const int blocks = (n + threads - 1) / threads;
+    
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+    add_kernel<<<blocks, threads, 0, stream>>>(
+        a.data_ptr<float>(),
+        b.data_ptr<float>(),
+        c.data_ptr<float>(),
+        n
+    );
+    
+    cudaError_t err = cudaGetLastError();
+    TORCH_CHECK(err == cudaSuccess, "CUDA kernel error: ", cudaGetErrorString(err));
+    
+    return c;
+}
+

--- a/tests/csrc/mixed_sources/add_kernel.cu
+++ b/tests/csrc/mixed_sources/add_kernel.cu
@@ -5,6 +5,7 @@
 #include <torch/extension.h>
 #include <cuda.h>
 #include <cuda_runtime.h>
+#include <c10/cuda/CUDAStream.h>
 #include "utils.cuh"
 
 __global__ void add_kernel(
@@ -22,24 +23,25 @@ __global__ void add_kernel(
 torch::Tensor add_cuda(torch::Tensor a, torch::Tensor b) {
     TORCH_CHECK(a.device().is_cuda(), "a must be a CUDA tensor");
     TORCH_CHECK(b.device().is_cuda(), "b must be a CUDA tensor");
-    
+
     auto c = torch::empty_like(a);
     int n = a.numel();
-    
+
     const int threads = 256;
     const int blocks = (n + threads - 1) / threads;
-    
-    cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+    // Use c10::cuda namespace which maps to c10::musa on MUSA platform
+    cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
     add_kernel<<<blocks, threads, 0, stream>>>(
         a.data_ptr<float>(),
         b.data_ptr<float>(),
         c.data_ptr<float>(),
         n
     );
-    
+
     cudaError_t err = cudaGetLastError();
     TORCH_CHECK(err == cudaSuccess, "CUDA kernel error: ", cudaGetErrorString(err));
-    
+
     return c;
 }
 

--- a/tests/csrc/mixed_sources/bindings.cpp
+++ b/tests/csrc/mixed_sources/bindings.cpp
@@ -1,0 +1,17 @@
+/*
+ * Python bindings for mixed source extension.
+ * This .cpp file references CUDA symbols that need porting.
+ */
+
+#include <torch/extension.h>
+
+// Forward declarations
+torch::Tensor add_cuda(torch::Tensor a, torch::Tensor b);
+torch::Tensor mul_musa(torch::Tensor a, torch::Tensor b);
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    m.doc() = "Mixed source extension test";
+    m.def("add", &add_cuda, "Element-wise addition");
+    m.def("mul", &mul_musa, "Element-wise multiplication");
+}
+

--- a/tests/csrc/mixed_sources/mul_kernel.mu
+++ b/tests/csrc/mixed_sources/mul_kernel.mu
@@ -1,0 +1,46 @@
+/*
+ * MUSA kernel for multiplication - tests .mu file handling.
+ * This file is already in MUSA format (no porting needed).
+ */
+
+#include <torch/extension.h>
+#include <musa.h>
+#include <musa_runtime.h>
+#include "utils.muh"
+
+__global__ void mul_kernel(
+    const float* __restrict__ a,
+    const float* __restrict__ b,
+    float* __restrict__ c,
+    const int n
+) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n) {
+        c[idx] = test_utils::mul_elements(a[idx], b[idx]);
+    }
+}
+
+torch::Tensor mul_musa(torch::Tensor a, torch::Tensor b) {
+    TORCH_CHECK(a.device().is_privateuseone(), "a must be a MUSA tensor");
+    TORCH_CHECK(b.device().is_privateuseone(), "b must be a MUSA tensor");
+    
+    auto c = torch::empty_like(a);
+    int n = a.numel();
+    
+    const int threads = 256;
+    const int blocks = (n + threads - 1) / threads;
+    
+    musaStream_t stream = at::musa::getCurrentMUSAStream();
+    mul_kernel<<<blocks, threads, 0, stream>>>(
+        a.data_ptr<float>(),
+        b.data_ptr<float>(),
+        c.data_ptr<float>(),
+        n
+    );
+    
+    musaError_t err = musaGetLastError();
+    TORCH_CHECK(err == musaSuccess, "MUSA kernel error: ", musaGetErrorString(err));
+    
+    return c;
+}
+

--- a/tests/csrc/mixed_sources/mul_kernel.mu
+++ b/tests/csrc/mixed_sources/mul_kernel.mu
@@ -6,6 +6,7 @@
 #include <torch/extension.h>
 #include <musa.h>
 #include <musa_runtime.h>
+#include "torch_musa/csrc/core/MUSAStream.h"
 #include "utils.muh"
 
 __global__ void mul_kernel(
@@ -23,24 +24,25 @@ __global__ void mul_kernel(
 torch::Tensor mul_musa(torch::Tensor a, torch::Tensor b) {
     TORCH_CHECK(a.device().is_privateuseone(), "a must be a MUSA tensor");
     TORCH_CHECK(b.device().is_privateuseone(), "b must be a MUSA tensor");
-    
+
     auto c = torch::empty_like(a);
     int n = a.numel();
-    
+
     const int threads = 256;
     const int blocks = (n + threads - 1) / threads;
-    
-    musaStream_t stream = at::musa::getCurrentMUSAStream();
+
+    // Use c10::musa namespace for MUSA stream
+    musaStream_t stream = c10::musa::getCurrentMUSAStream();
     mul_kernel<<<blocks, threads, 0, stream>>>(
         a.data_ptr<float>(),
         b.data_ptr<float>(),
         c.data_ptr<float>(),
         n
     );
-    
+
     musaError_t err = musaGetLastError();
     TORCH_CHECK(err == musaSuccess, "MUSA kernel error: ", musaGetErrorString(err));
-    
+
     return c;
 }
 

--- a/tests/csrc/mixed_sources/utils.cuh
+++ b/tests/csrc/mixed_sources/utils.cuh
@@ -1,0 +1,31 @@
+/*
+ * CUDA header file for testing mixed source extension building.
+ * This file uses CUDA syntax and should be ported to MUSA.
+ */
+
+#pragma once
+
+#include <cuda_runtime.h>
+
+namespace test_utils {
+
+// Simple device function for element-wise operations
+template <typename T>
+__device__ __forceinline__ T add_elements(T a, T b) {
+    return a + b;
+}
+
+template <typename T>
+__device__ __forceinline__ T mul_elements(T a, T b) {
+    return a * b;
+}
+
+// Check CUDA errors
+inline void check_cuda_error(cudaError_t err, const char* msg) {
+    if (err != cudaSuccess) {
+        throw std::runtime_error(std::string(msg) + ": " + cudaGetErrorString(err));
+    }
+}
+
+}  // namespace test_utils
+

--- a/tests/csrc/mixed_sources/utils.muh
+++ b/tests/csrc/mixed_sources/utils.muh
@@ -1,0 +1,31 @@
+/*
+ * MUSA header file - already ported version of utils.cuh.
+ * This file is used by .mu files directly.
+ */
+
+#pragma once
+
+#include <musa_runtime.h>
+
+namespace test_utils {
+
+// Simple device function for element-wise operations
+template <typename T>
+__device__ __forceinline__ T add_elements(T a, T b) {
+    return a + b;
+}
+
+template <typename T>
+__device__ __forceinline__ T mul_elements(T a, T b) {
+    return a * b;
+}
+
+// Check MUSA errors
+inline void check_musa_error(musaError_t err, const char* msg) {
+    if (err != musaSuccess) {
+        throw std::runtime_error(std::string(msg) + ": " + musaGetErrorString(err));
+    }
+}
+
+}  // namespace test_utils
+

--- a/tests/csrc/same_name/bindings.cpp
+++ b/tests/csrc/same_name/bindings.cpp
@@ -1,0 +1,13 @@
+// Python bindings for the same_name test.
+// This test verifies that when both .cu and .mu files exist with the same
+// base name, the .mu file takes precedence.
+
+#include <torch/extension.h>
+
+// Declaration of the function from kernel.cu or kernel.mu
+int get_magic_number();
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    m.def("get_magic_number", &get_magic_number, "Get the magic number to verify which file was used");
+}
+

--- a/tests/csrc/same_name/kernel.cu
+++ b/tests/csrc/same_name/kernel.cu
@@ -1,0 +1,13 @@
+// This is the CUDA version of the kernel.
+// When both kernel.cu and kernel.mu exist, the .mu file should take precedence.
+// This file should NOT be used - if it is, the test will fail because
+// the magic number returned is different.
+
+#include <torch/extension.h>
+#include <cuda_runtime.h>
+
+// Return 42 (wrong value - .mu version returns 123)
+int get_magic_number() {
+    return 42;  // CUDA version returns 42
+}
+

--- a/tests/csrc/same_name/kernel.mu
+++ b/tests/csrc/same_name/kernel.mu
@@ -1,0 +1,12 @@
+// This is the MUSA version of the kernel (hand-written).
+// When both kernel.cu and kernel.mu exist, this .mu file should take precedence.
+// This file should be used - the test verifies by checking the magic number.
+
+#include <torch/extension.h>
+#include <musa_runtime.h>
+
+// Return 123 (correct value - this is the hand-written MUSA version)
+int get_magic_number() {
+    return 123;  // MUSA version returns 123
+}
+

--- a/tests/test_extension_build.py
+++ b/tests/test_extension_build.py
@@ -399,3 +399,107 @@ setup(
                     raise
             finally:
                 sys.path.remove(tmpdir)
+
+
+# Path to same_name test directory (tests .cu and .mu with same base name)
+SAME_NAME_DIR = os.path.join(CSRC_DIR, "same_name")
+
+
+@pytest.mark.skipif(
+    not os.environ.get("TORCHADA_TEST_BUILD", "0") == "1",
+    reason="Extension build tests are slow; set TORCHADA_TEST_BUILD=1 to run",
+)
+class TestSameNameFilePrecedence:
+    """
+    Test that .mu files take precedence over .cu files when both exist.
+
+    This tests the fix for the issue where SimplePorting's file processing
+    order is non-deterministic, causing either the ported .cu or original .mu
+    to end up in the _musa directory depending on which is processed last.
+
+    The fix ensures that original .mu/.muh files are always copied after
+    porting, so they take precedence over auto-ported .cu/.cuh files.
+    """
+
+    def test_same_name_dir_exists(self):
+        """Test that same_name test directory exists."""
+        assert os.path.isdir(SAME_NAME_DIR), f"Test dir not found: {SAME_NAME_DIR}"
+
+    def test_both_cu_and_mu_exist(self):
+        """Test that both kernel.cu and kernel.mu exist."""
+        cu_path = os.path.join(SAME_NAME_DIR, "kernel.cu")
+        mu_path = os.path.join(SAME_NAME_DIR, "kernel.mu")
+        assert os.path.exists(cu_path), f"kernel.cu not found: {cu_path}"
+        assert os.path.exists(mu_path), f"kernel.mu not found: {mu_path}"
+
+    def test_mu_file_takes_precedence(self):
+        """
+        Test that .mu file takes precedence when both .cu and .mu exist.
+
+        This is the key test: after porting, the csrc_musa/kernel.mu file
+        should contain the content from the original kernel.mu (magic number 123),
+        not the ported kernel.cu (magic number 42).
+        """
+        if not _is_gpu_available():
+            pytest.skip("CUDA/MUSA not available")
+
+        if not torchada.is_musa_platform():
+            pytest.skip("Same name precedence test only applicable on MUSA platform")
+
+        import torch
+        from torch.utils.cpp_extension import BuildExtension, CUDAExtension
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create csrc directory and copy source files
+            csrc_dir = os.path.join(tmpdir, "csrc")
+            shutil.copytree(SAME_NAME_DIR, csrc_dir)
+
+            # Create setup.py that only specifies the .cu file
+            # (simulating user who wants to build CUDA code)
+            setup_content = f"""
+import torchada  # noqa: F401 - Apply MUSA patches
+from setuptools import setup
+from torch.utils.cpp_extension import CUDAExtension, BuildExtension
+
+setup(
+    name="test_same_name",
+    ext_modules=[
+        CUDAExtension(
+            name="test_same_name",
+            sources=[
+                "csrc/bindings.cpp",
+                "csrc/kernel.cu",  # .mu file exists too - should take precedence
+            ],
+        )
+    ],
+    cmdclass={{"build_ext": BuildExtension}},
+)
+"""
+            setup_path = os.path.join(tmpdir, "setup.py")
+            with open(setup_path, "w") as f:
+                f.write(setup_content)
+
+            # Build
+            result = subprocess.run(
+                [sys.executable, "setup.py", "build_ext", "--inplace"],
+                cwd=tmpdir,
+                capture_output=True,
+                text=True,
+                timeout=300,
+            )
+            assert result.returncode == 0, f"Build failed: {result.stderr}"
+
+            # Check that csrc_musa/kernel.mu contains the MUSA version (magic 123)
+            ported_mu_path = os.path.join(tmpdir, "csrc_musa", "kernel.mu")
+            assert os.path.exists(ported_mu_path), f"Ported file not found: {ported_mu_path}"
+
+            with open(ported_mu_path, "r") as f:
+                content = f.read()
+                # The MUSA version returns 123, CUDA version returns 42
+                assert "return 123" in content, (
+                    f".mu file should take precedence but found ported .cu content. "
+                    f"Expected 'return 123' but got:\n{content}"
+                )
+                assert "return 42" not in content, (
+                    f"Found ported .cu content instead of original .mu. " f"Content:\n{content}"
+                )

--- a/tests/test_extension_build.py
+++ b/tests/test_extension_build.py
@@ -208,3 +208,194 @@ setup(
                     raise
             finally:
                 sys.path.remove(tmpdir)
+
+
+# Path to mixed sources test directory
+MIXED_SOURCES_DIR = os.path.join(CSRC_DIR, "mixed_sources")
+
+
+@pytest.mark.skipif(
+    not os.environ.get("TORCHADA_TEST_BUILD", "0") == "1",
+    reason="Extension build tests are slow; set TORCHADA_TEST_BUILD=1 to run",
+)
+class TestMixedSourcesBuild:
+    """
+    Test building extensions with mixed source types (.cu, .cuh, .mu, .muh, .cpp).
+
+    This tests the fix for the issue where .mu files required manually specifying
+    the ported path (e.g., csrc_musa/foo.mu instead of csrc/foo.mu).
+    """
+
+    def test_mixed_sources_dir_exists(self):
+        """Test that mixed_sources test directory exists."""
+        assert os.path.isdir(MIXED_SOURCES_DIR), f"Test dir not found: {MIXED_SOURCES_DIR}"
+
+    def test_all_source_files_exist(self):
+        """Test that all mixed source files exist."""
+        expected_files = [
+            "utils.cuh",  # CUDA header
+            "add_kernel.cu",  # CUDA kernel
+            "utils.muh",  # MUSA header (already ported)
+            "mul_kernel.mu",  # MUSA kernel (already ported)
+            "bindings.cpp",  # C++ bindings
+        ]
+        for f in expected_files:
+            path = os.path.join(MIXED_SOURCES_DIR, f)
+            assert os.path.exists(path), f"Source file not found: {path}"
+
+    def test_build_mixed_sources_extension(self):
+        """
+        Test building an extension with mixed .cu/.cuh/.mu/.muh/.cpp sources.
+
+        This is the key e2e test that verifies:
+        1. .cu files are ported to .mu in the _musa directory
+        2. .cuh files are ported to .muh in the _musa directory
+        3. .mu files that don't exist at original path are found in _musa directory
+        4. .muh files are handled correctly
+        5. .cpp files are ported for CUDA symbol translation
+        """
+        if not _is_gpu_available():
+            pytest.skip("CUDA/MUSA not available")
+
+        if not torchada.is_musa_platform():
+            pytest.skip("Mixed sources test only applicable on MUSA platform")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Copy all source files to temp directory, preserving structure
+            src_dir = os.path.join(tmpdir, "csrc")
+            shutil.copytree(MIXED_SOURCES_DIR, src_dir)
+
+            # Create setup.py that uses CUDA-style paths for .mu files
+            # This tests the fix: users can specify csrc/mul_kernel.mu
+            # and torchada will find it in csrc_musa/mul_kernel.mu after porting
+            setup_content = """
+import torchada  # noqa: F401 - Apply MUSA patches
+from setuptools import setup
+from torch.utils.cpp_extension import CUDAExtension, BuildExtension
+
+setup(
+    name="test_mixed_sources",
+    ext_modules=[
+        CUDAExtension(
+            name="test_mixed_sources",
+            sources=[
+                "csrc/bindings.cpp",      # C++ file with CUDA symbols
+                "csrc/add_kernel.cu",     # CUDA kernel -> ported to csrc_musa/add_kernel.mu
+                "csrc/mul_kernel.mu",     # MUSA kernel -> found in csrc_musa/mul_kernel.mu
+            ],
+            include_dirs=["csrc"],        # Include dir for headers
+        )
+    ],
+    cmdclass={"build_ext": BuildExtension},
+)
+"""
+            setup_path = os.path.join(tmpdir, "setup.py")
+            with open(setup_path, "w") as f:
+                f.write(setup_content)
+
+            # Build the extension
+            result = subprocess.run(
+                [sys.executable, "setup.py", "build_ext", "--inplace"],
+                cwd=tmpdir,
+                capture_output=True,
+                text=True,
+                timeout=300,  # 5 minute timeout
+            )
+
+            if result.returncode != 0:
+                print("STDOUT:", result.stdout)
+                print("STDERR:", result.stderr)
+
+            assert result.returncode == 0, f"Build failed: {result.stderr}"
+
+            # Check that the extension was built
+            ext_files = [f for f in os.listdir(tmpdir) if f.endswith(".so") or f.endswith(".pyd")]
+            assert len(ext_files) > 0, "No extension file was built"
+
+            # Verify ported directory was created
+            ported_dir = os.path.join(tmpdir, "csrc_musa")
+            assert os.path.isdir(ported_dir), "Ported directory csrc_musa was not created"
+
+            # Verify ported files exist
+            assert os.path.exists(
+                os.path.join(ported_dir, "add_kernel.mu")
+            ), "add_kernel.cu was not ported to add_kernel.mu"
+            assert os.path.exists(
+                os.path.join(ported_dir, "utils.muh")
+            ), "utils.cuh was not ported to utils.muh"
+
+    def test_run_mixed_sources_extension(self):
+        """Test running the mixed sources extension after building."""
+        import torch
+
+        if not _is_gpu_available():
+            pytest.skip("CUDA/MUSA not available")
+
+        if not torchada.is_musa_platform():
+            pytest.skip("Mixed sources test only applicable on MUSA platform")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Copy all source files
+            src_dir = os.path.join(tmpdir, "csrc")
+            shutil.copytree(MIXED_SOURCES_DIR, src_dir)
+
+            # Create setup.py
+            setup_content = """
+import torchada  # noqa: F401
+from setuptools import setup
+from torch.utils.cpp_extension import CUDAExtension, BuildExtension
+
+setup(
+    name="test_mixed_sources",
+    ext_modules=[
+        CUDAExtension(
+            name="test_mixed_sources",
+            sources=[
+                "csrc/bindings.cpp",
+                "csrc/add_kernel.cu",
+                "csrc/mul_kernel.mu",
+            ],
+            include_dirs=["csrc"],
+        )
+    ],
+    cmdclass={"build_ext": BuildExtension},
+)
+"""
+            setup_path = os.path.join(tmpdir, "setup.py")
+            with open(setup_path, "w") as f:
+                f.write(setup_content)
+
+            # Build
+            result = subprocess.run(
+                [sys.executable, "setup.py", "build_ext", "--inplace"],
+                cwd=tmpdir,
+                capture_output=True,
+                text=True,
+                timeout=300,
+            )
+            assert result.returncode == 0, f"Build failed: {result.stderr}"
+
+            # Import and test
+            sys.path.insert(0, tmpdir)
+            try:
+                import test_mixed_sources
+
+                try:
+                    # Test add function (from .cu file)
+                    a = torch.randn(1000, device="cuda")
+                    b = torch.randn(1000, device="cuda")
+                    c = test_mixed_sources.add(a, b)
+                    expected = a + b
+                    assert torch.allclose(c, expected), "Add result incorrect"
+
+                    # Test mul function (from .mu file)
+                    d = test_mixed_sources.mul(a, b)
+                    expected_mul = a * b
+                    assert torch.allclose(d, expected_mul), "Mul result incorrect"
+
+                except RuntimeError as e:
+                    if "invalid device function" in str(e):
+                        pytest.skip("Kernel compiled for different architecture")
+                    raise
+            finally:
+                sys.path.remove(tmpdir)


### PR DESCRIPTION
### Testing Done
```bash
xiaodongye@xiaodongye-s80:~/ws/ggml/torchada$ docker exec -w /ws yeahdongcn1 bash -c "TORCHADA_TEST_BUILD=1 python -m pytest tests/test_extension_build.py -v -rs" 2>&1
============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-7.2.2, pluggy-1.6.0 -- /usr/bin/python
cachedir: .pytest_cache
hypothesis profile 'default'
rootdir: /ws
plugins: hypothesis-6.150.0, anyio-4.12.0
collecting ... collected 8 items

tests/test_extension_build.py::TestExtensionBuildSetup::test_vector_add_cu_exists PASSED [ 12%]
tests/test_extension_build.py::TestExtensionBuildSetup::test_can_create_setup_py PASSED [ 25%]
tests/test_extension_build.py::TestExtensionBuild::test_build_vector_add_extension PASSED [ 37%]
tests/test_extension_build.py::TestExtensionBuild::test_run_vector_add_extension SKIPPED [ 50%]
tests/test_extension_build.py::TestMixedSourcesBuild::test_mixed_sources_dir_exists PASSED [ 62%]
tests/test_extension_build.py::TestMixedSourcesBuild::test_all_source_files_exist PASSED [ 75%]
tests/test_extension_build.py::TestMixedSourcesBuild::test_build_mixed_sources_extension PASSED [ 87%]
tests/test_extension_build.py::TestMixedSourcesBuild::test_run_mixed_sources_extension SKIPPED [100%]

=========================== short test summary info ============================
SKIPPED [1] tests/test_extension_build.py:205: GPU not available or kernel compiled for different architecture
SKIPPED [1] tests/test_extension_build.py:398: Kernel compiled for different archite
```