### PR TITLE
Fix UT on NV

### DIFF
--- a/tests/test_cuda_patching.py
+++ b/tests/test_cuda_patching.py
@@ -251,7 +251,10 @@ class TestCUDAGraph:
         import torchada
 
         assert hasattr(torch.cuda, "CUDAGraph")
-        assert hasattr(torch.cuda, "MUSAGraph")
+        # MUSAGraph only exists on MUSA platform (torch_musa specific class)
+        # On CUDA platforms, only CUDAGraph exists
+        if torchada.is_musa_platform():
+            assert hasattr(torch.cuda, "MUSAGraph")
 
     def test_cuda_graph_is_musa_graph(self):
         """Test torch.cuda.CUDAGraph is aliased to MUSAGraph on MUSA."""
@@ -320,7 +323,11 @@ class TestCUDAGraph:
         # Should accept cuda_graph= keyword argument
         ctx = torch.cuda.graph(cuda_graph=g)
         assert ctx is not None
-        assert hasattr(ctx, "_wrapped")
+        # _wrapped attribute only exists on MUSA platform where torchada wraps
+        # the context manager to translate cuda_graph= to musa_graph=
+        # On CUDA platforms, no wrapping is needed
+        if torchada.is_musa_platform():
+            assert hasattr(ctx, "_wrapped")
 
     def test_graph_context_manager_positional(self):
         """Test torch.cuda.graph accepts positional argument."""
@@ -343,6 +350,11 @@ class TestCUDAGraph:
 
         import torchada
 
+        # This test only applies on MUSA platform where musa_graph= is valid
+        # On CUDA platforms, only cuda_graph= keyword is valid (no musa_graph=)
+        if not torchada.is_musa_platform():
+            pytest.skip("musa_graph= keyword only valid on MUSA platform")
+
         if torch.cuda.device_count() == 0:
             pytest.skip("No GPU available")
 
@@ -358,7 +370,10 @@ class TestCUDAGraph:
 
         import torchada  # noqa: F401
 
-        with pytest.raises(TypeError, match="missing required argument"):
+        # Error message differs between CUDA and MUSA platforms
+        with pytest.raises(
+            TypeError, match="(missing required argument|required positional argument)"
+        ):
             torch.cuda.graph()
 
     def test_graph_context_manager_with_pool_and_stream(self):
@@ -878,6 +893,11 @@ class TestAutotuneProcess:
         except ImportError:
             pytest.skip("torch._inductor.autotune_process not available")
 
+        # CUDA_VISIBLE_DEVICES constant was added in PyTorch 2.2.0
+        # It does NOT exist in PyTorch 2.1.x and earlier versions
+        if not hasattr(autotune_process, "CUDA_VISIBLE_DEVICES"):
+            pytest.skip("CUDA_VISIBLE_DEVICES not available (requires PyTorch >= 2.2.0)")
+
         if torchada.is_musa_platform():
             # On MUSA platform, CUDA_VISIBLE_DEVICES should be patched to MUSA_VISIBLE_DEVICES
             assert autotune_process.CUDA_VISIBLE_DEVICES == "MUSA_VISIBLE_DEVICES"
@@ -894,6 +914,11 @@ class TestAutotuneProcess:
         except ImportError:
             pytest.skip("torch._inductor.autotune_process not available")
 
+        # CUDA_VISIBLE_DEVICES constant was added in PyTorch 2.2.0
+        # It does NOT exist in PyTorch 2.1.x and earlier versions
+        if not hasattr(autotune_process, "CUDA_VISIBLE_DEVICES"):
+            pytest.skip("CUDA_VISIBLE_DEVICES not available (requires PyTorch >= 2.2.0)")
+
         assert isinstance(autotune_process.CUDA_VISIBLE_DEVICES, str)
 
     def test_cuda_visible_devices_env_var_format(self):
@@ -904,6 +929,11 @@ class TestAutotuneProcess:
             import torch._inductor.autotune_process as autotune_process
         except ImportError:
             pytest.skip("torch._inductor.autotune_process not available")
+
+        # CUDA_VISIBLE_DEVICES constant was added in PyTorch 2.2.0
+        # It does NOT exist in PyTorch 2.1.x and earlier versions
+        if not hasattr(autotune_process, "CUDA_VISIBLE_DEVICES"):
+            pytest.skip("CUDA_VISIBLE_DEVICES not available (requires PyTorch >= 2.2.0)")
 
         env_var = autotune_process.CUDA_VISIBLE_DEVICES
         # Env var should be uppercase and use underscores
@@ -1096,6 +1126,12 @@ class TestIsCompiledAndBackends:
 
         import torchada  # noqa: F401 - ensure patches are applied
 
+        # fp32_precision is a torchada addition for MUSA compatibility
+        # It wraps torch.get/set_float32_matmul_precision() for convenient access
+        # This attribute does NOT exist in standard PyTorch on CUDA platforms
+        if not hasattr(torch.backends.cuda.matmul, "fp32_precision"):
+            pytest.skip("fp32_precision not available (torchada MUSA-specific attribute)")
+
         # Should be accessible
         original = torch.backends.cuda.matmul.fp32_precision
         assert original in ("highest", "high", "medium")
@@ -1135,7 +1171,11 @@ class TestProfilerActivity:
 
         assert hasattr(torch.profiler, "ProfilerActivity")
         assert hasattr(torch.profiler.ProfilerActivity, "CUDA")
-        assert hasattr(torch.profiler.ProfilerActivity, "PrivateUse1")
+        # ProfilerActivity.PrivateUse1 is MUSA-specific (for PrivateUse1 backend)
+        # This attribute does NOT exist in standard PyTorch on CUDA platforms
+        # torch_musa adds this to support profiling on MUSA GPUs
+        if torchada.is_musa_platform():
+            assert hasattr(torch.profiler.ProfilerActivity, "PrivateUse1")
 
     def test_profiler_with_cuda_activity(self):
         """Test profiler can be created with CUDA activity on MUSA."""

--- a/tests/test_cuda_patching.py
+++ b/tests/test_cuda_patching.py
@@ -1129,7 +1129,11 @@ class TestIsCompiledAndBackends:
         # fp32_precision is a torchada addition for MUSA compatibility
         # It wraps torch.get/set_float32_matmul_precision() for convenient access
         # This attribute does NOT exist in standard PyTorch on CUDA platforms
-        if not hasattr(torch.backends.cuda.matmul, "fp32_precision"):
+        # Note: torch.backends.cuda.matmul.__getattr__ raises AssertionError for
+        # unknown attributes, so we need to catch that instead of using hasattr()
+        try:
+            _ = torch.backends.cuda.matmul.fp32_precision
+        except (AttributeError, AssertionError):
             pytest.skip("fp32_precision not available (torchada MUSA-specific attribute)")
 
         # Should be accessible


### PR DESCRIPTION
### Testing Done
```bash
$ python -m pytest -v ./tests/
==================================================================== test session starts =====================================================================
platform linux -- Python 3.8.10, pytest-8.3.5, pluggy-1.5.0 -- /usr/bin/python
cachedir: .pytest_cache
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /home/mt/.yeahdongcn/torchada
configfile: pyproject.toml
plugins: benchmark-4.0.0
collected 260 items                                                                                                                                          

tests/test_cpp_extension.py::TestCppExtensionImports::test_import_cuda_home PASSED                                                                     [  0%]
tests/test_cpp_extension.py::TestCppExtensionImports::test_import_cuda_extension PASSED                                                                [  0%]
tests/test_cpp_extension.py::TestCppExtensionImports::test_import_build_extension PASSED                                                               [  1%]
tests/test_cpp_extension.py::TestCppExtensionImports::test_cuda_home_on_musa PASSED                                                                    [  1%]
tests/test_cpp_extension.py::TestCppExtensionImports::test_torch_cpp_extension_is_patched PASSED                                                       [  1%]
tests/test_cpp_extension.py::TestCppExtensionImports::test_torch_cpp_extension_cuda_home_same_as_torchada PASSED                                       [  2%]
tests/test_cpp_extension.py::TestCUDAExtension::test_create_extension_basic PASSED                                                                     [  2%]
tests/test_cpp_extension.py::TestCUDAExtension::test_create_extension_with_include_dirs PASSED                                                         [  3%]
tests/test_cpp_extension.py::TestCUDAExtension::test_create_extension_with_extra_compile_args PASSED                                                   [  3%]
tests/test_cpp_extension.py::TestMusaPatches::test_is_musa_file_recognizes_cu PASSED                                                                   [  3%]
tests/test_cpp_extension.py::TestMusaPatches::test_is_musa_file_recognizes_cuh PASSED                                                                  [  4%]
tests/test_cpp_extension.py::TestMusaPatches::test_is_musa_file_recognizes_mu PASSED                                                                   [  4%]
tests/test_cpp_extension.py::TestMusaPatches::test_ext_replaced_mapping PASSED                                                                         [  5%]
tests/test_cpp_extension.py::TestMusaPatches::test_mapping_rule_exists PASSED                                                                          [  5%]
tests/test_cpp_extension.py::TestMusaPatches::test_mapping_rule_has_expected_entries PASSED                                                            [  5%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_is_patched_on_musa PASSED                                                            [  6%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_is_available PASSED                                                                  [  6%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_device_count PASSED                                                                  [  6%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_device_count_nvml PASSED                                                             [  7%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_current_device PASSED                                                                [  7%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_get_device_name PASSED                                                               [  8%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_synchronize PASSED                                                                   [  8%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_empty_cache PASSED                                                                   [  8%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_memory_allocated PASSED                                                              [  9%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_memory_reserved PASSED                                                               [  9%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_set_device PASSED                                                                    [ 10%]
tests/test_cuda_patching.py::TestTorchCudaLazyInit::test_import_lazy_call PASSED                                                                       [ 10%]
tests/test_cuda_patching.py::TestTorchCudaLazyInit::test_lazy_call_functionality PASSED                                                                [ 10%]
tests/test_cuda_patching.py::TestTorchCudaAmp::test_import_autocast PASSED                                                                             [ 11%]
tests/test_cuda_patching.py::TestTorchCudaAmp::test_import_grad_scaler PASSED                                                                          [ 11%]
tests/test_cuda_patching.py::TestTorchCudaAmp::test_autocast_context_manager PASSED                                                                    [ 11%]
tests/test_cuda_patching.py::TestTorchCudaAmp::test_grad_scaler_creation PASSED                                                                        [ 12%]
tests/test_cuda_patching.py::TestCUDAGraph::test_cuda_graph_alias PASSED                                                                               [ 12%]
tests/test_cuda_patching.py::TestCUDAGraph::test_cuda_graph_is_musa_graph PASSED                                                                       [ 13%]
tests/test_cuda_patching.py::TestCUDAGraph::test_cuda_graph_creation PASSED                                                                            [ 13%]
tests/test_cuda_patching.py::TestCUDAGraph::test_graphs_module PASSED                                                                                  [ 13%]
tests/test_cuda_patching.py::TestCUDAGraph::test_make_graphed_callables PASSED                                                                         [ 14%]
tests/test_cuda_patching.py::TestCUDAGraph::test_graph_pool_handle PASSED                                                                              [ 14%]
tests/test_cuda_patching.py::TestCUDAGraph::test_graph_context_manager_cuda_graph_keyword PASSED                                                       [ 15%]
tests/test_cuda_patching.py::TestCUDAGraph::test_graph_context_manager_positional PASSED                                                               [ 15%]
tests/test_cuda_patching.py::TestCUDAGraph::test_graph_context_manager_musa_graph_keyword SKIPPED (musa_graph= keyword only valid on MUSA platform)    [ 15%]
tests/test_cuda_patching.py::TestCUDAGraph::test_graph_context_manager_missing_arg_raises PASSED                                                       [ 16%]
tests/test_cuda_patching.py::TestCUDAGraph::test_graph_context_manager_with_pool_and_stream PASSED                                                     [ 16%]
tests/test_cuda_patching.py::TestDistributedBackend::test_original_init_available PASSED                                                               [ 16%]
tests/test_cuda_patching.py::TestDistributedBackend::test_mccl_backend_available PASSED                                                                [ 17%]
tests/test_cuda_patching.py::TestDistributedBackend::test_nccl_backend_available PASSED                                                                [ 17%]
tests/test_cuda_patching.py::TestDistributedBackend::test_new_group_patched PASSED                                                                     [ 18%]
tests/test_cuda_patching.py::TestNCCLModule::test_mccl_module_available PASSED                                                                         [ 18%]
tests/test_cuda_patching.py::TestRNGFunctions::test_get_rng_state PASSED                                                                               [ 18%]
tests/test_cuda_patching.py::TestRNGFunctions::test_set_rng_state PASSED                                                                               [ 19%]
tests/test_cuda_patching.py::TestRNGFunctions::test_manual_seed PASSED                                                                                 [ 19%]
tests/test_cuda_patching.py::TestRNGFunctions::test_manual_seed_all PASSED                                                                             [ 20%]
tests/test_cuda_patching.py::TestRNGFunctions::test_seed PASSED                                                                                        [ 20%]
tests/test_cuda_patching.py::TestRNGFunctions::test_initial_seed PASSED                                                                                [ 20%]
tests/test_cuda_patching.py::TestRNGFunctions::test_manual_seed_works PASSED                                                                           [ 21%]
tests/test_cuda_patching.py::TestMemoryFunctions::test_max_memory_allocated PASSED                                                                     [ 21%]
tests/test_cuda_patching.py::TestMemoryFunctions::test_max_memory_reserved PASSED                                                                      [ 21%]
tests/test_cuda_patching.py::TestMemoryFunctions::test_memory_stats PASSED                                                                             [ 22%]
tests/test_cuda_patching.py::TestMemoryFunctions::test_memory_summary PASSED                                                                           [ 22%]
tests/test_cuda_patching.py::TestMemoryFunctions::test_memory_snapshot PASSED                                                                          [ 23%]
tests/test_cuda_patching.py::TestMemoryFunctions::test_reset_peak_memory_stats PASSED                                                                  [ 23%]
tests/test_cuda_patching.py::TestMemoryFunctions::test_mem_get_info PASSED                                                                             [ 23%]
tests/test_cuda_patching.py::TestStreamAndEvent::test_stream_class PASSED                                                                              [ 24%]
tests/test_cuda_patching.py::TestStreamAndEvent::test_event_class PASSED                                                                               [ 24%]
tests/test_cuda_patching.py::TestStreamAndEvent::test_external_stream_class PASSED                                                                     [ 25%]
tests/test_cuda_patching.py::TestStreamAndEvent::test_current_stream PASSED                                                                            [ 25%]
tests/test_cuda_patching.py::TestStreamAndEvent::test_default_stream PASSED                                                                            [ 25%]
tests/test_cuda_patching.py::TestStreamAndEvent::test_set_stream PASSED                                                                                [ 26%]
tests/test_cuda_patching.py::TestStreamAndEvent::test_stream_context_manager PASSED                                                                    [ 26%]
tests/test_cuda_patching.py::TestStreamAndEvent::test_stream_context_class PASSED                                                                      [ 26%]
tests/test_cuda_patching.py::TestStreamAndEvent::test_stream_cuda_stream_property PASSED                                                               [ 27%]
tests/test_cuda_patching.py::TestContextManagers::test_device_context_manager PASSED                                                                   [ 27%]
tests/test_cuda_patching.py::TestContextManagers::test_device_of_context_manager PASSED                                                                [ 28%]
tests/test_cuda_patching.py::TestDeviceFunctions::test_get_device_properties PASSED                                                                    [ 28%]
tests/test_cuda_patching.py::TestDeviceFunctions::test_get_device_capability PASSED                                                                    [ 28%]
tests/test_cuda_patching.py::TestDeviceFunctions::test_is_initialized PASSED                                                                           [ 29%]
tests/test_cuda_patching.py::TestTorchGenerator::test_generator_cuda_device PASSED                                                                     [ 29%]
tests/test_cuda_patching.py::TestTorchGenerator::test_generator_cuda_device_index PASSED                                                               [ 30%]
tests/test_cuda_patching.py::TestTorchGenerator::test_generator_musa_device PASSED                                                                     [ 30%]
tests/test_cuda_patching.py::TestTorchGenerator::test_generator_no_device PASSED                                                                       [ 30%]
tests/test_cuda_patching.py::TestTorchGenerator::test_generator_manual_seed_chain PASSED                                                               [ 31%]
tests/test_cuda_patching.py::TestTorchGenerator::test_generator_isinstance_check PASSED                                                                [ 31%]
tests/test_cuda_patching.py::TestTorchGenerator::test_generator_isinstance_negative PASSED                                                             [ 31%]
tests/test_cuda_patching.py::TestTorchVersionCuda::test_torch_version_cuda_not_patched PASSED                                                          [ 32%]
tests/test_cuda_patching.py::TestTensorIsCuda::test_cpu_tensor_is_cuda_false PASSED                                                                    [ 32%]
tests/test_cuda_patching.py::TestTensorIsCuda::test_musa_tensor_is_cuda_true PASSED                                                                    [ 33%]
tests/test_cuda_patching.py::TestAutotuneProcess::test_cuda_visible_devices_patched SKIPPED (CUDA_VISIBLE_DEVICES not available (requires PyTorch ...) [ 33%]
tests/test_cuda_patching.py::TestAutotuneProcess::test_cuda_visible_devices_is_string SKIPPED (CUDA_VISIBLE_DEVICES not available (requires PyTorc...) [ 33%]
tests/test_cuda_patching.py::TestAutotuneProcess::test_cuda_visible_devices_env_var_format SKIPPED (CUDA_VISIBLE_DEVICES not available (requires P...) [ 34%]
tests/test_cuda_patching.py::TestNvtxStub::test_nvtx_module_available PASSED                                                                           [ 34%]
tests/test_cuda_patching.py::TestNvtxStub::test_nvtx_mark PASSED                                                                                       [ 35%]
tests/test_cuda_patching.py::TestNvtxStub::test_nvtx_range_push_pop PASSED                                                                             [ 35%]
tests/test_cuda_patching.py::TestNvtxStub::test_nvtx_range_context_manager PASSED                                                                      [ 35%]
tests/test_cuda_patching.py::TestPatchDecorators::test_patch_registry_is_populated PASSED                                                              [ 36%]
tests/test_cuda_patching.py::TestPatchDecorators::test_patch_registry_contains_expected_functions PASSED                                               [ 36%]
tests/test_cuda_patching.py::TestPatchDecorators::test_requires_import_decorator_guards_import PASSED                                                  [ 36%]
tests/test_cuda_patching.py::TestPatchDecorators::test_requires_import_decorator_allows_execution PASSED                                               [ 37%]
tests/test_cuda_patching.py::TestPatchDecorators::test_requires_import_multiple_modules PASSED                                                         [ 37%]
tests/test_cuda_patching.py::TestIsCompiledAndBackends::test_torch_musa_is_compiled PASSED                                                             [ 38%]
tests/test_cuda_patching.py::TestIsCompiledAndBackends::test_torch_cuda_is_compiled_redirects PASSED                                                   [ 38%]
tests/test_cuda_patching.py::TestIsCompiledAndBackends::test_torch_backends_cuda_is_built PASSED                                                       [ 38%]
tests/test_cuda_patching.py::TestIsCompiledAndBackends::test_torch_backends_cuda_matmul_allow_tf32 PASSED                                              [ 39%]
tests/test_cuda_patching.py::TestIsCompiledAndBackends::test_torch_backends_cuda_matmul_fp32_precision SKIPPED (fp32_precision not available (torc...) [ 39%]
tests/test_cuda_patching.py::TestIsCompiledAndBackends::test_torch_c_storage_use_count PASSED                                                          [ 40%]
tests/test_cuda_patching.py::TestProfilerActivity::test_profiler_activity_cuda_accessible PASSED                                                       [ 40%]
tests/test_cuda_patching.py::TestProfilerActivity::test_profiler_with_cuda_activity PASSED                                                             [ 40%]
tests/test_cuda_patching.py::TestProfilerActivity::test_profiler_context_manager PASSED                                                                [ 41%]
tests/test_cuda_patching.py::TestProfilerActivity::test_profiler_methods_accessible PASSED                                                             [ 41%]
tests/test_cuda_patching.py::TestMusaWarnings::test_musa_warnings_patch_applied PASSED                                                                 [ 41%]
tests/test_cuda_patching.py::TestMusaWarnings::test_autocast_warning_suppressed SKIPPED (Only applicable on MUSA platform)                             [ 42%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_cuda_translated SKIPPED (Only applicable on MUSA platform)                             [ 42%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_with_keyset SKIPPED (Only applicable on MUSA platform)                                 [ 43%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_with_keyset_false_explicit SKIPPED (Only applicable on MUSA platform)                  [ 43%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_op_name_as_keyword SKIPPED (Only applicable on MUSA platform)                          [ 43%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_fn_as_keyword SKIPPED (Only applicable on MUSA platform)                               [ 44%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_dispatch_key_as_keyword SKIPPED (Only applicable on MUSA platform)                     [ 44%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_cuda_with_keyset SKIPPED (Only applicable on MUSA platform)                            [ 45%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_autograd_cuda_translation SKIPPED (Only applicable on MUSA platform)                   [ 45%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_opoverload_as_op_name SKIPPED (Only applicable on MUSA platform)                       [ 45%]
tests/test_cuda_patching.py::TestCudart::test_cudart_returns_wrapper SKIPPED (Only applicable on MUSA platform)                                        [ 46%]
tests/test_cuda_patching.py::TestCudart::test_cudart_host_register SKIPPED (Only applicable on MUSA platform)                                          [ 46%]
tests/test_cuda_patching.py::TestCudart::test_cudart_in_dir SKIPPED (Only applicable on MUSA platform)                                                 [ 46%]
tests/test_device_strings.py::TestTensorDevicePatching::test_tensor_cuda_method PASSED                                                                 [ 47%]
tests/test_device_strings.py::TestTensorDevicePatching::test_tensor_to_cuda_string PASSED                                                              [ 47%]
tests/test_device_strings.py::TestTensorDevicePatching::test_tensor_to_cuda_device_index PASSED                                                        [ 48%]
tests/test_device_strings.py::TestTensorDevicePatching::test_tensor_to_torch_device PASSED                                                             [ 48%]
tests/test_device_strings.py::TestModuleDevicePatching::test_module_cuda_method PASSED                                                                 [ 48%]
tests/test_device_strings.py::TestModuleDevicePatching::test_module_to_cuda PASSED                                                                     [ 49%]
tests/test_device_strings.py::TestFactoryFunctions::test_torch_empty_device_cuda PASSED                                                                [ 49%]
tests/test_device_strings.py::TestFactoryFunctions::test_torch_zeros_device_cuda PASSED                                                                [ 50%]
tests/test_device_strings.py::TestFactoryFunctions::test_torch_ones_device_cuda PASSED                                                                 [ 50%]
tests/test_device_strings.py::TestFactoryFunctions::test_torch_randn_device_cuda PASSED                                                                [ 50%]
tests/test_device_strings.py::TestFactoryFunctions::test_torch_rand_device_cuda PASSED                                                                 [ 51%]
tests/test_device_strings.py::TestFactoryFunctions::test_torch_full_device_cuda PASSED                                                                 [ 51%]
tests/test_device_strings.py::TestFactoryFunctions::test_torch_arange_device_cuda PASSED                                                               [ 51%]
tests/test_device_strings.py::TestFactoryFunctions::test_torch_linspace_device_cuda PASSED                                                             [ 52%]
tests/test_device_strings.py::TestTranslateDeviceFunction::test_translate_device_none PASSED                                                           [ 52%]
tests/test_device_strings.py::TestTranslateDeviceFunction::test_translate_device_cuda_string PASSED                                                    [ 53%]
tests/test_device_strings.py::TestTranslateDeviceFunction::test_translate_device_cuda_with_index PASSED                                                [ 53%]
tests/test_device_strings.py::TestTranslateDeviceFunction::test_translate_device_cpu_unchanged PASSED                                                  [ 53%]
tests/test_device_strings.py::TestTranslateDeviceFunction::test_translate_device_musa_unchanged PASSED                                                 [ 54%]
tests/test_device_strings.py::TestTranslateDeviceFunction::test_translate_device_integer_unchanged PASSED                                              [ 54%]
tests/test_device_strings.py::TestTranslateDeviceFunction::test_translate_device_torch_device_cuda PASSED                                              [ 55%]
tests/test_device_strings.py::TestTranslateDeviceFunction::test_translate_device_torch_device_cuda_with_index PASSED                                   [ 55%]
tests/test_device_strings.py::TestTranslateDeviceFunction::test_translate_device_torch_device_cpu_unchanged PASSED                                     [ 55%]
tests/test_device_strings.py::TestDeviceIndexVariants::test_cuda_colon_zero PASSED                                                                     [ 56%]
tests/test_device_strings.py::TestDeviceIndexVariants::test_factory_with_cuda_index PASSED                                                             [ 56%]
tests/test_device_strings.py::TestDeviceIndexVariants::test_torch_device_cuda_zero PASSED                                                              [ 56%]
tests/test_device_strings.py::TestDeviceIndexVariants::test_torch_device_with_index_arg PASSED                                                         [ 57%]
tests/test_device_strings.py::TestDeviceIndexVariants::test_torch_device_from_original_cuda_device SKIPPED (MUSA platform required with patched to...) [ 57%]
tests/test_device_strings.py::TestDeviceIndexVariants::test_torch_device_type_keyword PASSED                                                           [ 58%]
tests/test_device_strings.py::TestDeviceContextManager::test_device_context_with_musa SKIPPED (MUSA platform required)                                 [ 58%]
tests/test_device_strings.py::TestDeviceContextManager::test_device_context_with_cuda_translated SKIPPED (MUSA platform required)                      [ 58%]
tests/test_device_strings.py::TestDeviceContextManager::test_original_functions_in_device_constructors SKIPPED (MUSA platform required)                [ 59%]
tests/test_extension_build.py::TestExtensionBuildSetup::test_vector_add_cu_exists PASSED                                                               [ 59%]
tests/test_extension_build.py::TestExtensionBuildSetup::test_can_create_setup_py PASSED                                                                [ 60%]
tests/test_extension_build.py::TestExtensionBuild::test_build_vector_add_extension SKIPPED (Extension build tests are slow; set TORCHADA_TEST_BUIL...) [ 60%]
tests/test_extension_build.py::TestExtensionBuild::test_run_vector_add_extension SKIPPED (Extension build tests are slow; set TORCHADA_TEST_BUILD=...) [ 60%]
tests/test_extension_build.py::TestMixedSourcesBuild::test_mixed_sources_dir_exists SKIPPED (Extension build tests are slow; set TORCHADA_TEST_BUI...) [ 61%]
tests/test_extension_build.py::TestMixedSourcesBuild::test_all_source_files_exist SKIPPED (Extension build tests are slow; set TORCHADA_TEST_BUILD...) [ 61%]
tests/test_extension_build.py::TestMixedSourcesBuild::test_build_mixed_sources_extension SKIPPED (Extension build tests are slow; set TORCHADA_TES...) [ 61%]
tests/test_extension_build.py::TestMixedSourcesBuild::test_run_mixed_sources_extension SKIPPED (Extension build tests are slow; set TORCHADA_TEST_...) [ 62%]
tests/test_extension_build.py::TestSameNameFilePrecedence::test_same_name_dir_exists SKIPPED (Extension build tests are slow; set TORCHADA_TEST_BU...) [ 62%]
tests/test_extension_build.py::TestSameNameFilePrecedence::test_both_cu_and_mu_exist SKIPPED (Extension build tests are slow; set TORCHADA_TEST_BU...) [ 63%]
tests/test_extension_build.py::TestSameNameFilePrecedence::test_mu_file_takes_precedence SKIPPED (Extension build tests are slow; set TORCHADA_TES...) [ 63%]
tests/test_mappings.py::TestMappingImports::test_import_mapping_rule PASSED                                                                            [ 63%]
tests/test_mappings.py::TestMappingImports::test_import_ext_replaced_mapping PASSED                                                                    [ 64%]
tests/test_mappings.py::TestATenMappings::test_aten_cuda_namespace PASSED                                                                              [ 64%]
tests/test_mappings.py::TestATenMappings::test_aten_cuda_includes PASSED                                                                               [ 65%]
tests/test_mappings.py::TestC10Mappings::test_c10_cuda_namespace PASSED                                                                                [ 65%]
tests/test_mappings.py::TestC10Mappings::test_c10_device_type PASSED                                                                                   [ 65%]
tests/test_mappings.py::TestTorchMappings::test_torch_cuda_namespace PASSED                                                                            [ 66%]
tests/test_mappings.py::TestTorchMappings::test_torch_device_type PASSED                                                                               [ 66%]
tests/test_mappings.py::TestCuBLASMappings::test_cublas_basic PASSED                                                                                   [ 66%]
tests/test_mappings.py::TestCuBLASMappings::test_cublas_types PASSED                                                                                   [ 67%]
tests/test_mappings.py::TestCuBLASMappings::test_cublas_functions PASSED                                                                               [ 67%]
tests/test_mappings.py::TestCuBLASMappings::test_cublas_gemm PASSED                                                                                    [ 68%]
tests/test_mappings.py::TestCuBLASMappings::test_cublas_batched PASSED                                                                                 [ 68%]
tests/test_mappings.py::TestCuBLASMappings::test_cublaslt PASSED                                                                                       [ 68%]
tests/test_mappings.py::TestCuRANDMappings::test_curand_basic PASSED                                                                                   [ 69%]
tests/test_mappings.py::TestCuRANDMappings::test_curand_types PASSED                                                                                   [ 69%]
tests/test_mappings.py::TestCuRANDMappings::test_curand_functions PASSED                                                                               [ 70%]
tests/test_mappings.py::TestCuDNNMappings::test_cudnn_basic PASSED                                                                                     [ 70%]
tests/test_mappings.py::TestCuDNNMappings::test_cudnn_types PASSED                                                                                     [ 70%]
tests/test_mappings.py::TestCuDNNMappings::test_cudnn_functions PASSED                                                                                 [ 71%]
tests/test_mappings.py::TestCUDARuntimeMappings::test_memory_functions PASSED                                                                          [ 71%]
tests/test_mappings.py::TestCUDARuntimeMappings::test_host_memory_functions PASSED                                                                     [ 71%]
tests/test_mappings.py::TestCUDARuntimeMappings::test_async_memory_functions PASSED                                                                    [ 72%]
tests/test_mappings.py::TestCUDARuntimeMappings::test_device_functions PASSED                                                                          [ 72%]
tests/test_mappings.py::TestCUDARuntimeMappings::test_memcpy_kinds PASSED                                                                              [ 73%]
tests/test_mappings.py::TestStreamEventMappings::test_stream_types PASSED                                                                              [ 73%]
tests/test_mappings.py::TestStreamEventMappings::test_stream_functions PASSED                                                                          [ 73%]
tests/test_mappings.py::TestStreamEventMappings::test_stream_flags PASSED                                                                              [ 74%]
tests/test_mappings.py::TestStreamEventMappings::test_event_functions PASSED                                                                           [ 74%]
tests/test_mappings.py::TestStreamEventMappings::test_event_flags PASSED                                                                               [ 75%]
tests/test_mappings.py::TestErrorHandlingMappings::test_error_types PASSED                                                                             [ 75%]
tests/test_mappings.py::TestErrorHandlingMappings::test_error_functions PASSED                                                                         [ 75%]
tests/test_mappings.py::TestNCCLMappings::test_nccl_basic PASSED                                                                                       [ 76%]
tests/test_mappings.py::TestNCCLMappings::test_nccl_types PASSED                                                                                       [ 76%]
tests/test_mappings.py::TestNCCLMappings::test_nccl_comm_functions PASSED                                                                              [ 76%]
tests/test_mappings.py::TestNCCLMappings::test_nccl_collective_functions PASSED                                                                        [ 77%]
tests/test_mappings.py::TestLibraryMappings::test_cusparse PASSED                                                                                      [ 77%]
tests/test_mappings.py::TestLibraryMappings::test_cusolver PASSED                                                                                      [ 78%]
tests/test_mappings.py::TestLibraryMappings::test_cufft PASSED                                                                                         [ 78%]
tests/test_mappings.py::TestLibraryMappings::test_cutlass PASSED                                                                                       [ 78%]
tests/test_mappings.py::TestLibraryMappings::test_cub PASSED                                                                                           [ 79%]
tests/test_mappings.py::TestLibraryMappings::test_thrust PASSED                                                                                        [ 79%]
tests/test_mappings.py::TestIntrinsicMappings::test_shuffle_intrinsics_not_mapped PASSED                                                               [ 80%]
tests/test_mappings.py::TestIntrinsicMappings::test_vote_intrinsics_not_mapped PASSED                                                                  [ 80%]
tests/test_mappings.py::TestIntrinsicMappings::test_sync_intrinsics_not_mapped PASSED                                                                  [ 80%]
tests/test_mappings.py::TestIntrinsicMappings::test_atomic_operations_not_mapped PASSED                                                                [ 81%]
tests/test_mappings.py::TestIntrinsicMappings::test_half_precision_not_mapped PASSED                                                                   [ 81%]
tests/test_mappings.py::TestIncludeMappings::test_cuda_headers PASSED                                                                                  [ 81%]
tests/test_mappings.py::TestPyTorchCppMappings::test_pytorch_stream_utils PASSED                                                                       [ 82%]
tests/test_mappings.py::TestPyTorchCppMappings::test_pytorch_guards PASSED                                                                             [ 82%]
tests/test_mappings.py::TestPyTorchCppMappings::test_pytorch_torch_namespace PASSED                                                                    [ 83%]
tests/test_mappings.py::TestMappingCount::test_mapping_count PASSED                                                                                    [ 83%]
tests/test_mappings.py::TestMappingCount::test_ext_replaced_mapping PASSED                                                                             [ 83%]
tests/test_mappings.py::TestMappingRobustness::test_no_identity_mappings PASSED                                                                        [ 84%]
tests/test_mappings.py::TestMappingRobustness::test_no_empty_keys_or_values PASSED                                                                     [ 84%]
tests/test_mappings.py::TestMappingRobustness::test_all_keys_and_values_are_strings PASSED                                                             [ 85%]
tests/test_mappings.py::TestMappingRobustness::test_cuda_to_musa_consistency PASSED                                                                    [ 85%]
tests/test_mappings.py::TestMappingApplication::test_port_cuda_source_basic PASSED                                                                     [ 85%]
tests/test_mappings.py::TestMappingApplication::test_port_cuda_source_includes PASSED                                                                  [ 86%]
tests/test_mappings.py::TestMappingApplication::test_port_cuda_source_types PASSED                                                                     [ 86%]
tests/test_mappings.py::TestMappingApplication::test_port_cuda_source_functions PASSED                                                                 [ 86%]
tests/test_mappings.py::TestMappingApplication::test_port_cuda_source_preserves_non_cuda PASSED                                                        [ 87%]
tests/test_mappings.py::TestMappingApplication::test_port_cuda_source_longer_patterns_first PASSED                                                     [ 87%]
tests/test_mappings.py::TestMappingApplication::test_port_cuda_source_c10_macros PASSED                                                                [ 88%]
tests/test_mappings.py::TestMappingApplication::test_port_cuda_source_nccl PASSED                                                                      [ 88%]
tests/test_mappings.py::TestMappingSubstringOrdering::test_specific_before_generic PASSED                                                              [ 88%]
tests/test_mappings.py::TestMappingSubstringOrdering::test_include_specific_paths PASSED                                                               [ 89%]
tests/test_mappings.py::TestRuntimeNameConversion::test_cuda_to_musa_name PASSED                                                                       [ 89%]
tests/test_mappings.py::TestRuntimeNameConversion::test_nccl_to_mccl_name PASSED                                                                       [ 90%]
tests/test_mappings.py::TestRuntimeNameConversion::test_cublas_to_mublas_name PASSED                                                                   [ 90%]
tests/test_mappings.py::TestRuntimeNameConversion::test_curand_to_murand_name PASSED                                                                   [ 90%]
tests/test_mappings.py::TestCDLLWrapper::test_cdll_wrapper_class_exists PASSED                                                                         [ 91%]
tests/test_mappings.py::TestCDLLWrapper::test_libmusart_cuda_to_musa_translation SKIPPED (MUSA platform required)                                      [ 91%]
tests/test_mappings.py::TestCDLLWrapper::test_libmccl_nccl_to_mccl_translation SKIPPED (MUSA platform required)                                        [ 91%]
tests/test_mappings.py::TestCDLLWrapper::test_libmublas_cublas_to_mublas_translation SKIPPED (MUSA platform required)                                  [ 92%]
tests/test_mappings.py::TestCDLLWrapper::test_libmurand_curand_to_murand_translation SKIPPED (MUSA platform required)                                  [ 92%]
tests/test_mappings.py::TestCDLLWrapper::test_non_musa_lib_no_translation SKIPPED (MUSA platform required)                                             [ 93%]
tests/test_mappings.py::TestCDLLWrapper::test_sglang_cuda_wrapper_pattern SKIPPED (MUSA platform required)                                             [ 93%]
tests/test_platform.py::TestPlatformDetection::test_import_torchada PASSED                                                                             [ 93%]
tests/test_platform.py::TestPlatformDetection::test_detect_platform PASSED                                                                             [ 94%]
tests/test_platform.py::TestPlatformDetection::test_platform_detection_functions PASSED                                                                [ 94%]
tests/test_platform.py::TestPlatformDetection::test_patches_applied PASSED                                                                             [ 95%]
tests/test_platform.py::TestPlatformDetection::test_get_version PASSED                                                                                 [ 95%]
tests/test_platform.py::TestPlatformDetection::test_get_platform PASSED                                                                                [ 95%]
tests/test_platform.py::TestPlatformDetection::test_get_backend PASSED                                                                                 [ 96%]
tests/test_platform.py::TestPlatformDetection::test_is_gpu_device PASSED                                                                               [ 96%]
tests/test_platform.py::TestPlatformDetection::test_is_cuda_like_device_alias PASSED                                                                   [ 96%]
tests/test_python_compat.py::TestPython38Compatibility::test_all_files_parse PASSED                                                                    [ 97%]
tests/test_python_compat.py::TestPython38Compatibility::test_all_modules_importable PASSED                                                             [ 97%]
tests/test_python_compat.py::TestPython38Compatibility::test_no_builtin_generic_types PASSED                                                           [ 98%]
tests/test_python_compat.py::TestPython38Compatibility::test_no_union_type_operator PASSED                                                             [ 98%]
tests/test_python_compat.py::TestPython38Compatibility::test_no_match_statement PASSED                                                                 [ 98%]
tests/test_python_compat.py::TestPython38Compatibility::test_no_removeprefix_removesuffix PASSED                                                       [ 99%]
tests/test_python_compat.py::TestPython38Compatibility::test_typing_imports_used PASSED                                                                [ 99%]
tests/test_python_compat.py::TestPython38Compatibility::test_python_version_requirement PASSED                                                         [100%]

============================================================== 223 passed, 37 skipped in 0.67s ===============================================================
```