### PR TITLE
Update mapping rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ See `src/torchada/_mapping.py` for the complete mapping table (380+ mappings).
 
 ```
 # pyproject.toml or requirements.txt
-torchada>=0.1.27
+torchada>=0.1.28
 ```
 
 ### Step 2: Conditional Import

--- a/README_CN.md
+++ b/README_CN.md
@@ -254,7 +254,7 @@ if torchada.is_gpu_device(device):  # 在 CUDA 和 MUSA 上都能工作
 
 ```
 # pyproject.toml 或 requirements.txt
-torchada>=0.1.27
+torchada>=0.1.28
 ```
 
 ### 步骤 2：条件导入

--- a/benchmarks/benchmark_history.json
+++ b/benchmarks/benchmark_history.json
@@ -3,7 +3,7 @@
   "description": "Historical benchmark results for torchada performance tracking",
   "results": [
     {
-      "version": "0.1.27",
+      "version": "0.1.28",
       "date": "2026-01-29",
       "platform": "MUSA",
       "pytorch_version": "2.7.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torchada"
-version = "0.1.27"
+version = "0.1.28"
 description = "Adapter package for torch_musa to act exactly like PyTorch CUDA"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/torchada/__init__.py
+++ b/src/torchada/__init__.py
@@ -23,7 +23,7 @@ Usage:
     from torch.utils.cpp_extension import CUDAExtension, BuildExtension, CUDA_HOME
 """
 
-__version__ = "0.1.27"
+__version__ = "0.1.28"
 
 from . import cuda, utils
 from ._patch import apply_patches, get_original_init_process_group, is_patched

--- a/src/torchada/_mapping.py
+++ b/src/torchada/_mapping.py
@@ -30,7 +30,6 @@ _MAPPING_RULE = {
     "#include <ATen/cuda/detail/UnpackRaw.cuh>": '#include "torch_musa/csrc/aten/musa/UnpackRaw.muh"',
     "#include <ATen/cuda/Exceptions.h>": '#include "torch_musa/csrc/aten/musa/Exceptions.h"',
     "at::cuda": "at::musa",
-    "torch::kCUDA": "torch::kMUSA",
     # File extension mappings for include statements (.cuh -> .muh)
     '.cuh"': '.muh"',
     ".cuh>": ".muh>",
@@ -63,12 +62,15 @@ _MAPPING_RULE = {
     "#include <cuda/": "#include <musa/",
     # =========================================================================
     # CUDA namespaces and device types
+    # Note: MUSA uses PrivateUse1 as its device type, not a separate MUSA type.
+    # torch_musa defines: constexpr DeviceType kMUSA = DeviceType::PrivateUse1;
+    # We use at::kPrivateUse1 which is available in standard PyTorch headers.
     # =========================================================================
     "torch::cuda": "torch::musa",
     "torch.cuda": "torch.musa",
-    "at::kCUDA": "at::kMUSA",
-    "at::DeviceType::CUDA": "at::DeviceType::MUSA",
-    "c10::DeviceType::CUDA": "c10::DeviceType::MUSA",
+    "at::kCUDA": "at::kPrivateUse1",
+    "at::DeviceType::CUDA": "at::DeviceType::PrivateUse1",
+    "c10::DeviceType::CUDA": "c10::DeviceType::PrivateUse1",
     # =========================================================================
     # cuBLAS -> muBLAS
     # =========================================================================
@@ -189,26 +191,35 @@ _MAPPING_RULE = {
     # =========================================================================
     # Data types
     # =========================================================================
-    # Note: __half and half are the same in MUSA, no mapping needed
+    # BFloat16 types (Note: __half and half are the same in MUSA, no mapping needed)
     "__nv_bfloat16": "__mt_bfloat16",
     "__nv_bfloat162": "__mt_bfloat162",
+    "__nv_half": "__half",
     "nv_bfloat16": "__mt_bfloat16",
     "nv_bfloat162": "__mt_bfloat162",
-    "__nv_half": "__half",
     "nv_half": "__half",
-    # FP8 data types
+    # FP8 data types - constants
     "__NV_E4M3": "__MT_E4M3",
     "__NV_E5M2": "__MT_E5M2",
     "__NV_SATFINITE": "__MT_SATFINITE",
-    "__nv_cvt_float2_to_fp8x2": "__musa_cvt_float2_to_fp8x2",
+    # FP8 data types - types (alphabetical)
     "__nv_fp8_e4m3": "__mt_fp8_e4m3",
     "__nv_fp8_e5m2": "__mt_fp8_e5m2",
+    "__nv_fp8_interpretation_t": "__mt_fp8_interpretation_t",
+    "__nv_fp8_storage_t": "__mt_fp8_storage_t",
     "__nv_fp8x2_e4m3": "__mt_fp8x2_e4m3",
     "__nv_fp8x2_e5m2": "__mt_fp8x2_e5m2",
     "__nv_fp8x2_storage_t": "__mt_fp8x2_storage_t",
     "__nv_fp8x4_e4m3": "__mt_fp8x4_e4m3",
     "__nv_fp8x4_e5m2": "__mt_fp8x4_e5m2",
     "__nv_fp8x4_storage_t": "__mt_fp8x4_storage_t",
+    # FP8 data types - conversion functions (alphabetical)
+    "__nv_cvt_bfloat16raw_to_fp8": "__musa_cvt_bfloat16raw_to_fp8",
+    "__nv_cvt_float2_to_fp8x2": "__musa_cvt_float2_to_fp8x2",
+    "__nv_cvt_float_to_fp8": "__musa_cvt_float_to_fp8",
+    "__nv_cvt_fp8_to_halfraw": "__musa_cvt_fp8_to_halfraw",
+    "__nv_cvt_fp8x2_to_halfraw2": "__musa_cvt_fp8x2_to_halfraw2",
+    # FP8 data types - includes and enums
     "#include <cuda_fp8.h>": "#include <musa_fp8.h>",
     "CUDA_R_8F_E4M3": "MUSA_R_8F_E4M3",
     "CUDA_R_8F_E5M2": "MUSA_R_8F_E5M2",
@@ -442,38 +453,60 @@ _MAPPING_RULE = {
     "torch::cuda::getCurrentCUDAStream": "torch::musa::getCurrentMUSAStream",
     "torch::cuda::getDefaultCUDAStream": "torch::musa::getDefaultMUSAStream",
     "torch::cuda::getStreamFromPool": "torch::musa::getStreamFromPool",
-    # torch::kCUDA maps to c10::DeviceType::PrivateUse1 (MUSA uses PrivateUse1)
-    "torch::kCUDA": "c10::DeviceType::PrivateUse1",
+    "torch::kCUDA": "torch::kPrivateUse1",
     "cudaDeviceIndex": "musaDeviceIndex",
     "CUDADeviceIndex": "MUSADeviceIndex",
     # =========================================================================
     # CUDA driver API -> MUSA driver API
     # =========================================================================
-    "CUdeviceptr": "MUdeviceptr",
-    "CUdevice": "MUdevice",
+    # Types (alphabetical)
     "CUcontext": "MUcontext",
-    "CUmodule": "MUmodule",
-    "CUfunction": "MUfunction",
-    "CUstream": "MUstream",
+    "CUdevice": "MUdevice",
+    "CUdeviceptr": "MUdeviceptr",
     "CUevent": "MUevent",
+    "CUfunction": "MUfunction",
+    "CUmemAccessDesc": "MUmemAccessDesc",
+    "CUmemAllocationProp": "MUmemAllocationProp",
+    "CUmemGenericAllocationHandle": "MUmemGenericAllocationHandle",
+    "CUmodule": "MUmodule",
     "CUresult": "MUresult",
-    "cuPointerGetAttribute": "muPointerGetAttribute",
-    "cuMemGetAddressRange": "muMemGetAddressRange",
+    "CUstream": "MUstream",
+    # Functions (alphabetical)
     "cuCtxGetCurrent": "muCtxGetCurrent",
     "cuCtxSetCurrent": "muCtxSetCurrent",
     "cuDeviceGet": "muDeviceGet",
     "cuDeviceGetCount": "muDeviceGetCount",
+    "cuDevicePrimaryCtxRetain": "muDevicePrimaryCtxRetain",
+    "cuGetErrorString": "muGetErrorString",
     "cuInit": "muInit",
-    "CU_POINTER_ATTRIBUTE_RANGE_START_ADDR": "MU_POINTER_ATTRIBUTE_RANGE_START_ADDR",
-    "CU_POINTER_ATTRIBUTE_RANGE_SIZE": "MU_POINTER_ATTRIBUTE_RANGE_SIZE",
-    "CU_POINTER_ATTRIBUTE_MEMORY_TYPE": "MU_POINTER_ATTRIBUTE_MEMORY_TYPE",
+    "cuMemAddressFree": "muMemAddressFree",
+    "cuMemAddressReserve": "muMemAddressReserve",
+    "cuMemCreate": "muMemCreate",
+    "cuMemGetAddressRange": "muMemGetAddressRange",
+    "cuMemGetAllocationGranularity": "muMemGetAllocationGranularity",
+    "cuMemMap": "muMemMap",
+    "cuMemRelease": "muMemRelease",
+    "cuMemSetAccess": "muMemSetAccess",
+    "cuMemUnmap": "muMemUnmap",
+    "cuPointerGetAttribute": "muPointerGetAttribute",
+    # Constants - memory allocation
+    "CU_MEM_ACCESS_FLAGS_PROT_READWRITE": "MU_MEM_ACCESS_FLAGS_PROT_READWRITE",
+    "CU_MEM_ALLOC_GRANULARITY_MINIMUM": "MU_MEM_ALLOC_GRANULARITY_MINIMUM",
+    "CU_MEM_ALLOCATION_COMP_NONE": "MU_MEM_ALLOCATION_COMP_NONE",
+    "CU_MEM_ALLOCATION_TYPE_PINNED": "MU_MEM_ALLOCATION_TYPE_PINNED",
+    "CU_MEM_LOCATION_TYPE_DEVICE": "MU_MEM_LOCATION_TYPE_DEVICE",
+    # Constants - pointer attributes
+    "CU_POINTER_ATTRIBUTE_CONTEXT": "MU_POINTER_ATTRIBUTE_CONTEXT",
     "CU_POINTER_ATTRIBUTE_DEVICE_POINTER": "MU_POINTER_ATTRIBUTE_DEVICE_POINTER",
     "CU_POINTER_ATTRIBUTE_HOST_POINTER": "MU_POINTER_ATTRIBUTE_HOST_POINTER",
-    "CU_POINTER_ATTRIBUTE_CONTEXT": "MU_POINTER_ATTRIBUTE_CONTEXT",
-    "CUDA_SUCCESS": "MUSA_SUCCESS",
+    "CU_POINTER_ATTRIBUTE_MEMORY_TYPE": "MU_POINTER_ATTRIBUTE_MEMORY_TYPE",
+    "CU_POINTER_ATTRIBUTE_RANGE_SIZE": "MU_POINTER_ATTRIBUTE_RANGE_SIZE",
+    "CU_POINTER_ATTRIBUTE_RANGE_START_ADDR": "MU_POINTER_ATTRIBUTE_RANGE_START_ADDR",
+    # Error codes
     "CUDA_ERROR_INVALID_VALUE": "MUSA_ERROR_INVALID_VALUE",
-    "CUDA_ERROR_OUT_OF_MEMORY": "MUSA_ERROR_OUT_OF_MEMORY",
     "CUDA_ERROR_NOT_INITIALIZED": "MUSA_ERROR_NOT_INITIALIZED",
+    "CUDA_ERROR_OUT_OF_MEMORY": "MUSA_ERROR_OUT_OF_MEMORY",
+    "CUDA_SUCCESS": "MUSA_SUCCESS",
     # =========================================================================
     # THC headers
     # =========================================================================
@@ -502,6 +535,7 @@ _MAPPING_RULE = {
     # =========================================================================
     # CUDA arch guards
     # =========================================================================
+    "__CUDA_ARCH__ >= 800": "__MUSA_ARCH__ >= 220",
     "(__CUDA_ARCH__ < 800)": "(__MUSA_ARCH__ < 220)",
     "(__CUDA_ARCH__ >= 900)": "(__MUSA_ARCH__ >= 310)",
     "cuda::std::numeric_limits": "musa::std::numeric_limits",

--- a/tests/csrc/device_type_test.cu
+++ b/tests/csrc/device_type_test.cu
@@ -1,0 +1,76 @@
+/*
+ * Device type test CUDA kernel for testing torchada mapping rules.
+ *
+ * This file specifically tests the device type mappings:
+ * - at::kCUDA -> at::kPrivateUse1
+ * - at::DeviceType::CUDA -> at::DeviceType::PrivateUse1
+ * - c10::DeviceType::CUDA -> c10::DeviceType::PrivateUse1
+ * - torch::kCUDA -> torch::kPrivateUse1
+ *
+ * The test verifies that after porting, the code compiles and runs correctly.
+ */
+
+#include <torch/extension.h>
+#include <ATen/ATen.h>
+#include <c10/core/DeviceType.h>
+
+// Test function that checks device types using various CUDA symbols
+torch::Tensor check_device_type(torch::Tensor input) {
+    // Test at::DeviceType::CUDA - should be ported to at::DeviceType::PrivateUse1
+    TORCH_CHECK(
+        input.device().type() == at::DeviceType::CUDA,
+        "Input tensor must be on CUDA device"
+    );
+
+    // Test c10::DeviceType::CUDA - should be ported to c10::DeviceType::PrivateUse1
+    c10::DeviceType device_type = input.device().type();
+    bool is_cuda_c10 = (device_type == c10::DeviceType::CUDA);
+    TORCH_CHECK(is_cuda_c10, "Device type check with c10:: failed");
+
+    // Create output tensor on same device as input
+    // Use c10::Device with DeviceType::CUDA which becomes PrivateUse1 after porting
+    auto output = at::empty({1}, input.options());
+
+    // Copy input value to output (just a simple operation to verify it works)
+    output.copy_(input.slice(0, 0, 1));
+
+    return output;
+}
+
+// Test function that creates a tensor on CUDA device
+torch::Tensor create_cuda_tensor(int size) {
+    // Test torch::kCUDA - should be ported to c10::DeviceType::PrivateUse1
+    // Use c10::Device constructor which accepts DeviceType
+    auto device = c10::Device(torch::kCUDA);
+    auto options = torch::TensorOptions().device(device).dtype(torch::kFloat32);
+    auto tensor = torch::ones({size}, options);
+
+    // Verify device type
+    TORCH_CHECK(
+        tensor.device().type() == at::DeviceType::CUDA,
+        "Created tensor should be on CUDA device"
+    );
+
+    return tensor;
+}
+
+// Test function that returns device type information
+std::tuple<bool, bool, bool> get_device_info(torch::Tensor input) {
+    // Check if tensor is on CUDA using different methods
+    bool check1 = input.device().type() == at::DeviceType::CUDA;
+    bool check2 = input.device().type() == c10::DeviceType::CUDA;
+    bool check3 = input.is_cuda();
+
+    return std::make_tuple(check1, check2, check3);
+}
+
+// Python bindings
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    m.def("check_device_type", &check_device_type,
+          "Check device type using various CUDA symbols");
+    m.def("create_cuda_tensor", &create_cuda_tensor,
+          "Create a tensor on CUDA device");
+    m.def("get_device_info", &get_device_info,
+          "Get device type info using different check methods");
+}
+


### PR DESCRIPTION
### Problem
The previous device type mappings (`at::DeviceType::CUDA` → `at::DeviceType::MUSA`, etc.) didn't work because `at::DeviceType::MUSA` and similar symbols **don't exist** in torch_musa. MUSA uses `PrivateUse1` as its device type.

### Solution
Updated all device type mappings to use `PrivateUse1`:

| Before (broken) | After (working) |
|-----------------|-----------------|
| `at::kCUDA` → `at::kMUSA` | `at::kCUDA` → `at::kPrivateUse1` |
| `at::DeviceType::CUDA` → `at::DeviceType::MUSA` | `at::DeviceType::CUDA` → `at::DeviceType::PrivateUse1` |
| `c10::DeviceType::CUDA` → `c10::DeviceType::MUSA` | `c10::DeviceType::CUDA` → `c10::DeviceType::PrivateUse1` |
| `torch::kCUDA` → `torch::kMUSA` | `torch::kCUDA` → `torch::kPrivateUse1` |

### Additional Changes
1. **Reorganized mapping sections** for better maintainability:
   - Data types section: grouped by BFloat16, FP8 constants, FP8 types, FP8 conversion functions
   - CUDA driver API section: grouped by types, functions, memory constants, pointer attributes, error codes
   - All entries sorted alphabetically within groups

2. **Added new mappings**:
   - CUDA driver API: memory allocation functions (`cuMemCreate`, `cuMemMap`, etc.)
   - CUDA driver API: memory types (`CUmemGenericAllocationHandle`, etc.)
   - CUDA driver API: memory constants (`CU_MEM_LOCATION_TYPE_DEVICE`, etc.)
   - CUDA arch guard: `__CUDA_ARCH__ >= 800` → `__MUSA_ARCH__ >= 220`

3. **Added compilation tests**:
   - New test file `tests/csrc/device_type_test.cu` to verify device type mappings compile correctly
   - New test class `TestDeviceTypeMappingCompilation` with 4 tests

### Test Results
- **Regular tests**: 251 passed, 13 skipped (both containers)
- **Compilation tests**: 3 passed, 1 skipped (run test skipped due to MUDNN issues in test containers)