### PR TITLE
Fix include_paths/library_paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ See `src/torchada/_mapping.py` for the complete mapping table (380+ mappings).
 
 ```
 # pyproject.toml or requirements.txt
-torchada>=0.1.28
+torchada>=0.1.29
 ```
 
 ### Step 2: Conditional Import

--- a/README_CN.md
+++ b/README_CN.md
@@ -254,7 +254,7 @@ if torchada.is_gpu_device(device):  # 在 CUDA 和 MUSA 上都能工作
 
 ```
 # pyproject.toml 或 requirements.txt
-torchada>=0.1.28
+torchada>=0.1.29
 ```
 
 ### 步骤 2：条件导入

--- a/benchmarks/benchmark_history.json
+++ b/benchmarks/benchmark_history.json
@@ -3,7 +3,7 @@
   "description": "Historical benchmark results for torchada performance tracking",
   "results": [
     {
-      "version": "0.1.28",
+      "version": "0.1.29",
       "date": "2026-01-29",
       "platform": "MUSA",
       "pytorch_version": "2.7.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torchada"
-version = "0.1.28"
+version = "0.1.29"
 description = "Adapter package for torch_musa to act exactly like PyTorch CUDA"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/torchada/__init__.py
+++ b/src/torchada/__init__.py
@@ -23,7 +23,7 @@ Usage:
     from torch.utils.cpp_extension import CUDAExtension, BuildExtension, CUDA_HOME
 """
 
-__version__ = "0.1.28"
+__version__ = "0.1.29"
 
 from . import cuda, utils
 from ._patch import apply_patches, get_original_init_process_group, is_patched

--- a/src/torchada/_patch.py
+++ b/src/torchada/_patch.py
@@ -1107,6 +1107,10 @@ def _patch_cpp_extension():
         from torch.utils.cpp_extension import CUDAExtension, BuildExtension
 
     And have them work transparently on MUSA platform.
+
+    Also patches include_paths and library_paths to support both:
+    - PyTorch < 2.6: include_paths(cuda=True)
+    - PyTorch 2.6+: include_paths(device_type="cuda")
     """
     import torch.utils.cpp_extension as torch_cpp_ext
 
@@ -1116,6 +1120,11 @@ def _patch_cpp_extension():
     torch_cpp_ext.CUDAExtension = torchada_cpp_ext.CUDAExtension
     torch_cpp_ext.BuildExtension = torchada_cpp_ext.BuildExtension
     torch_cpp_ext.CUDA_HOME = torchada_cpp_ext.CUDA_HOME
+
+    # Patch include_paths and library_paths to handle both old and new signatures
+    # and to correctly translate "cuda" to MUSA on MUSA platform
+    torch_cpp_ext.include_paths = torchada_cpp_ext.include_paths
+    torch_cpp_ext.library_paths = torchada_cpp_ext.library_paths
 
     # Also update sys.modules entry
     sys.modules["torch.utils.cpp_extension"] = torch_cpp_ext


### PR DESCRIPTION
### Root Cause

1. **PyTorch 2.6+** changed the `include_paths` and `library_paths` signature from `include_paths(cuda=bool)` to `include_paths(device_type=str)`
2. **torch_musa** uses a different parameter: `include_paths(musa=bool)`
3. **torchada** was calling `musa_ext.include_paths(cuda=cuda)` which failed because torch_musa expects `musa=` parameter
4. **torchada** wasn't patching `include_paths` and `library_paths` in `torch.utils.cpp_extension`

### Solution

- Updated `include_paths()` and `library_paths()` in `src/torchada/utils/cpp_extension.py` to support both:
  - Legacy: `include_paths(cuda=True)` (PyTorch < 2.6)
  - New: `include_paths(device_type="cuda")` (PyTorch 2.6+)
- Fixed the call to use `musa_ext.include_paths(musa=...)` instead of `cuda=...`
- Updated `_patch_cpp_extension()` to also patch `include_paths` and `library_paths` functions

### Testing

Added 9 new test cases in `TestCppExtensionPaths`:
- `test_include_paths_with_cuda_param`
- `test_include_paths_with_device_type_param`
- `test_include_paths_default`
- `test_library_paths_with_cuda_param`
- `test_library_paths_with_device_type_param`
- `test_library_paths_default`
- `test_include_paths_patched_in_torch_module`
- `test_library_paths_patched_in_torch_module`
- `test_get_torch_include_paths_pattern` (exact user-reported pattern)

All 260 tests pass on both torch_musa 2.7.0 and 2.7.1 containers.