### PR TITLE
Update mapping rules to support vllm v0.15.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ See `src/torchada/_mapping.py` for the complete mapping table (380+ mappings).
 
 ```
 # pyproject.toml or requirements.txt
-torchada>=0.1.32
+torchada>=0.1.33
 ```
 
 ### Step 2: Conditional Import

--- a/README_CN.md
+++ b/README_CN.md
@@ -254,7 +254,7 @@ if torchada.is_gpu_device(device):  # 在 CUDA 和 MUSA 上都能工作
 
 ```
 # pyproject.toml 或 requirements.txt
-torchada>=0.1.32
+torchada>=0.1.33
 ```
 
 ### 步骤 2：条件导入

--- a/benchmarks/benchmark_history.json
+++ b/benchmarks/benchmark_history.json
@@ -3,7 +3,7 @@
   "description": "Historical benchmark results for torchada performance tracking",
   "results": [
     {
-      "version": "0.1.32",
+      "version": "0.1.33",
       "date": "2026-01-29",
       "platform": "MUSA",
       "pytorch_version": "2.7.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torchada"
-version = "0.1.32"
+version = "0.1.33"
 description = "Adapter package for torch_musa to act exactly like PyTorch CUDA"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/torchada/__init__.py
+++ b/src/torchada/__init__.py
@@ -24,7 +24,7 @@ Usage:
     from torch.utils.cpp_extension import CUDAExtension, BuildExtension, CUDA_HOME
 """
 
-__version__ = "0.1.32"
+__version__ = "0.1.33"
 
 from . import cuda, utils
 from ._patch import apply_patches, get_original_init_process_group, is_patched

--- a/src/torchada/_mapping.py
+++ b/src/torchada/_mapping.py
@@ -188,6 +188,8 @@ _MAPPING_RULE = {
     "cudaMemcpyDeviceToHost": "musaMemcpyDeviceToHost",
     "cudaMemcpyDeviceToDevice": "musaMemcpyDeviceToDevice",
     "cudaMemcpyHostToHost": "musaMemcpyHostToHost",
+    # Constants - memory allocation
+    "cudaFuncAttributeMaxDynamicSharedMemorySize": "musaFuncAttributeMaxDynamicSharedMemorySize",
     # =========================================================================
     # Data types
     # =========================================================================
@@ -456,6 +458,7 @@ _MAPPING_RULE = {
     "torch::kCUDA": "torch::kPrivateUse1",
     "cudaDeviceIndex": "musaDeviceIndex",
     "CUDADeviceIndex": "MUSADeviceIndex",
+    "getCurrentCUDABlasHandle": "getCurrentMUSABlasHandle",
     # =========================================================================
     # CUDA driver API -> MUSA driver API
     # =========================================================================
@@ -495,6 +498,7 @@ _MAPPING_RULE = {
     "CU_MEM_ALLOCATION_COMP_NONE": "MU_MEM_ALLOCATION_COMP_NONE",
     "CU_MEM_ALLOCATION_TYPE_PINNED": "MU_MEM_ALLOCATION_TYPE_PINNED",
     "CU_MEM_LOCATION_TYPE_DEVICE": "MU_MEM_LOCATION_TYPE_DEVICE",
+    "CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_WITH_CUDA_VMM_SUPPORTED": "MU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_WITH_MUSA_VMM_SUPPORTED",
     # Constants - pointer attributes
     "CU_POINTER_ATTRIBUTE_CONTEXT": "MU_POINTER_ATTRIBUTE_CONTEXT",
     "CU_POINTER_ATTRIBUTE_DEVICE_POINTER": "MU_POINTER_ATTRIBUTE_DEVICE_POINTER",

--- a/tests/test_mappings.py
+++ b/tests/test_mappings.py
@@ -216,6 +216,11 @@ class TestCUDARuntimeMappings:
         assert _MAPPING_RULE["cudaMemcpyDeviceToHost"] == "musaMemcpyDeviceToHost"
         assert _MAPPING_RULE["cudaMemcpyDeviceToDevice"] == "musaMemcpyDeviceToDevice"
         assert _MAPPING_RULE["cudaMemcpyHostToHost"] == "musaMemcpyHostToHost"
+    
+    def test_memory_constants(self):
+        from torchada._mapping import _MAPPING_RULE
+        
+        assert _MAPPING_RULE["cudaFuncAttributeMaxDynamicSharedMemorySize"] == "musaFuncAttributeMaxDynamicSharedMemorySize"
 
 
 class TestStreamEventMappings:
@@ -457,6 +462,11 @@ class TestPyTorchCppMappings:
         assert _MAPPING_RULE["CUDAStreamGuard"] == "MUSAStreamGuard"
         assert _MAPPING_RULE["CUDAEvent"] == "MUSAEvent"
 
+    def test_pytorch_handle(self):
+        from torchada._mapping import _MAPPING_RULE
+
+        assert _MAPPING_RULE["getCurrentCUDABlasHandle"] == "getCurrentMUSABlasHandle"
+        
     def test_pytorch_torch_namespace(self):
         from torchada._mapping import _MAPPING_RULE
 
@@ -470,6 +480,13 @@ class TestPyTorchCppMappings:
         )
         assert _MAPPING_RULE["torch::cuda::getStreamFromPool"] == "torch::musa::getStreamFromPool"
 
+class TestCUDADriverMappings:
+    """Test CUDA driver API mappings."""
+
+    def test_memory_constants(self):
+        from torchada._mapping import _MAPPING_RULE
+
+        assert _MAPPING_RULE["CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_WITH_CUDA_VMM_SUPPORTED"] == "MU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_WITH_MUSA_VMM_SUPPORTED"
 
 class TestMappingCount:
     """Test total mapping count."""


### PR DESCRIPTION
### Changes

1. **Added new mappings**:
   - CUDA Runtime API: memory allocation constants (`cudaFuncAttributeMaxDynamicSharedMemorySize`, etc.)
   - CUDA driver API: memory allocation constants (`CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_WITH_CUDA_VMM_SUPPORTED`, etc.)
   - PyTorch C++ API: cuBLAS handle (`getCurrentCUDABlasHandle`, etc.)
2. **Added compilation tests**:
   - New test function ` TestPyTorchCppMappings.test_pytorch_handle `  in `tests/test_mappings.py` 
   - New test function `TestCUDARuntimeMappings.test_memory_constants` in `tests/test_mappings.py`
   - New test function `TestCUDADriverMappings.test_memory_constants` in `tests/test_mappings.py`

### Test Results

- **Regular tests**: new test passed
- **Compilation tests**: vllm/csrc build passed

