### PR TITLE
Fix: handle missing _validate_device in flex_attention.

### DIFF
--- a/src/torchada/_patch.py
+++ b/src/torchada/_patch.py
@@ -1189,10 +1189,12 @@ def _patch_validate_device():
     """
     import torch.nn.attention.flex_attention
 
-    _orig_validate_device = torch.nn.attention.flex_attention._validate_device
+    _orig_validate_device = None
+    if hasattr(torch.nn.attention.flex_attention, "_validate_device"):
+        _orig_validate_device = torch.nn.attention.flex_attention._validate_device
 
     def _validate_device(query, key, value):
-        if query.device.type == "musa":
+        if query.device.type == "musa" or _orig_validate_device is None:
             return
         return _orig_validate_device(query, key, value)
 

--- a/tests/test_cuda_patching.py
+++ b/tests/test_cuda_patching.py
@@ -1871,3 +1871,18 @@ class TestValidateDevice:
 
         validator = self.get_validator()
         validator(q, k, v)
+
+    def test_patch_when_attribute_missing(self, monkeypatch):
+        """Verify the fallback implementation is installed when the attribute is absent."""
+        import torch
+        import torch.nn.attention.flex_attention as flex_attention
+
+        from torchada._patch import _patch_validate_device
+
+        # Simulate a PyTorch version that does not expose _validate_device.
+        monkeypatch.delattr(flex_attention, "_validate_device", raising=False)
+        assert not hasattr(flex_attention, "_validate_device")
+
+        # The patch must not raise even when the attribute is absent.
+        _patch_validate_device()
+        assert hasattr(flex_attention, "_validate_device")


### PR DESCRIPTION
Some PyTorch versions do not expose `_validate_device` on `torch.nn.attention.flex_attention`, causing an `AttributeError` at import time when torchada tries to wrap the function (torch 2.5.0).

Error Logs:

```sh
ImportError while loading conftest '/sgl-workspace/torchada/tests/conftest.py'.
tests/conftest.py:8: in <module>
    import torchada
/usr/local/lib/python3.10/dist-packages/torchada/__init__.py:51: in <module>
    apply_patches()
/usr/local/lib/python3.10/dist-packages/torchada/_patch.py:1403: in apply_patches
    patch_fn()
/usr/local/lib/python3.10/dist-packages/torchada/_patch.py:97: in wrapper
    return func(*args, **kwargs)
/usr/local/lib/python3.10/dist-packages/torchada/_patch.py:1192: in _patch_validate_device
    _orig_validate_device = torch.nn.attention.flex_attention._validate_device
E   AttributeError: module 'torch.nn.attention.flex_attention' has no attribute '_validate_device'
```


## Testing

```sh
root@worker3218:/sgl-workspace/torchada# pytest tests/test_cuda_patching.py::TestValidateDevice -v
============================================================================= test session starts =============================================================================
platform linux -- Python 3.10.12, pytest-9.0.1, pluggy-1.6.0 -- /usr/bin/python
cachedir: .pytest_cache
rootdir: /sgl-workspace/torchada
configfile: pyproject.toml
plugins: cov-7.0.0, anyio-4.11.0
collected 2 items                                                                                                                                                             

tests/test_cuda_patching.py::TestValidateDevice::test_musa_device_should_pass PASSED                                                                                    [ 50%]
tests/test_cuda_patching.py::TestValidateDevice::test_patch_when_attribute_missing PASSED                                                                               [100%]

============================================================================== warnings summary ===============================================================================
../../usr/local/lib/python3.10/dist-packages/torch/cuda/__init__.py:61
  /usr/local/lib/python3.10/dist-packages/torch/cuda/__init__.py:61: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
    import pynvml  # type: ignore[import]

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================================== 2 passed, 1 warning in 0.12s =========================================================================
```