### PR TITLE
Fix torch.distributed.new_group device_id not exists.

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ See `src/torchada/_mapping.py` for the complete mapping table (380+ mappings).
 
 ```
 # pyproject.toml or requirements.txt
-torchada>=0.1.36
+torchada>=0.1.37
 ```
 
 ### Step 2: Conditional Import

--- a/README_CN.md
+++ b/README_CN.md
@@ -255,7 +255,7 @@ if torchada.is_gpu_device(device):  # 在 CUDA 和 MUSA 上都能工作
 
 ```
 # pyproject.toml 或 requirements.txt
-torchada>=0.1.36
+torchada>=0.1.37
 ```
 
 ### 步骤 2：条件导入

--- a/benchmarks/benchmark_history.json
+++ b/benchmarks/benchmark_history.json
@@ -3,7 +3,7 @@
   "description": "Historical benchmark results for torchada performance tracking",
   "results": [
     {
-      "version": "0.1.36",
+      "version": "0.1.37",
       "date": "2026-01-29",
       "platform": "MUSA",
       "pytorch_version": "2.7.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torchada"
-version = "0.1.36"
+version = "0.1.37"
 description = "Adapter package for torch_musa to act exactly like PyTorch CUDA"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/torchada/__init__.py
+++ b/src/torchada/__init__.py
@@ -24,7 +24,7 @@ Usage:
     from torch.utils.cpp_extension import CUDAExtension, BuildExtension, CUDA_HOME
 """
 
-__version__ = "0.1.36"
+__version__ = "0.1.37"
 
 from . import cuda, utils
 from ._patch import apply_patches, get_original_init_process_group, is_patched

--- a/src/torchada/_patch.py
+++ b/src/torchada/_patch.py
@@ -22,6 +22,7 @@ Usage:
 """
 
 import functools
+import inspect
 import sys
 import warnings
 from types import ModuleType
@@ -106,6 +107,24 @@ _device_str_cache = {}
 
 # Cache for is_musa_platform result - computed once on first call
 _is_musa_platform_cached = None
+
+
+def _has_param(func: Callable, param_name: str) -> bool:
+    """
+    Check if a function has a specific parameter in its signature.
+
+    Args:
+        func: The function to check
+        param_name: The parameter name to look for
+
+    Returns:
+        True if the function has the parameter, False otherwise
+    """
+    try:
+        sig = inspect.signature(func)
+        return param_name in sig.parameters
+    except (ValueError, TypeError):
+        return False
 
 
 def _translate_device(device: Any) -> Any:
@@ -784,6 +803,9 @@ def _patch_distributed_backend():
     # Also patch new_group to translate 'nccl' to 'mccl'
     original_new_group = dist.new_group
 
+    # Cache the check for device_id support (added in torch 2.6)
+    _new_group_has_device_id = _has_param(original_new_group, "device_id")
+
     @functools.wraps(original_new_group)
     def patched_new_group(
         ranks=None,
@@ -799,10 +821,6 @@ def _patch_distributed_backend():
             if isinstance(backend, str) and backend.lower() == "nccl":
                 backend = "mccl"
 
-        # Translate device_id if it's a cuda device
-        if device_id is not None:
-            device_id = _translate_device(device_id)
-
         # Build kwargs for the original function
         kwargs = {
             "ranks": ranks,
@@ -810,8 +828,12 @@ def _patch_distributed_backend():
             "pg_options": pg_options,
             "use_local_synchronization": use_local_synchronization,
             "group_desc": group_desc,
-            "device_id": device_id,
         }
+
+        # Translate device_id if it's a cuda device (only if supported by torch version)
+        if device_id is not None and _new_group_has_device_id:
+            kwargs["device_id"] = _translate_device(device_id)
+
         if timeout is not None:
             kwargs["timeout"] = timeout
 

--- a/tests/test_cuda_patching.py
+++ b/tests/test_cuda_patching.py
@@ -388,6 +388,54 @@ class TestDistributedBackend:
             # Check new_group is wrapped
             assert hasattr(dist.new_group, "__wrapped__")
 
+    def test_has_param_with_mock_functions(self):
+        """Test _has_param with mocked functions simulating different torch versions."""
+        from torchada._patch import _has_param
+
+        # Simulate torch 2.7+ with device_id parameter
+        def new_group_v27(
+            ranks=None,
+            timeout=None,
+            backend=None,
+            pg_options=None,
+            use_local_synchronization=False,
+            group_desc=None,
+            device_id=None,
+        ):
+            pass
+
+        # Simulate torch 2.5 without device_id parameter
+        def new_group_v25(
+            ranks=None,
+            timeout=None,
+            backend=None,
+            pg_options=None,
+            use_local_synchronization=False,
+            group_desc=None,
+        ):
+            pass
+
+        # Test detection for torch 2.7+ (has device_id)
+        assert _has_param(new_group_v27, "device_id") is True
+
+        # Test detection for torch 2.5 (no device_id)
+        assert _has_param(new_group_v25, "device_id") is False
+
+        # Test that both have other common parameters
+        assert _has_param(new_group_v27, "backend") is True
+        assert _has_param(new_group_v25, "backend") is True
+
+    def test_new_group_device_id_param_compatibility(self):
+        """Test new_group handles device_id param based on torch version."""
+        import torch.distributed as dist
+
+        from torchada._patch import _has_param
+
+        has_device_id = _has_param(dist.new_group, "device_id")
+
+        # This test just verifies the detection works, not the specific version
+        assert isinstance(has_device_id, bool)
+
 
 class TestNCCLModule:
     """Test NCCL to MCCL module patching."""


### PR DESCRIPTION
## Summary
Fix torch.distributed.new_group compatibility across different PyTorch versions.

Error:
```sh
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/sgl-workspace/torchada/src/torchada/_patch.py", line 818, in patched_new_group
    return original_new_group(**kwargs)
  File "/usr/local/lib/python3.10/dist-packages/torch/distributed/c10d_logger.py", line 97, in wrapper
    func_return = func(*args, **kwargs)
TypeError: new_group() got an unexpected keyword argument 'device_id'
```

[torch2.5 new_group](https://docs.pytorch.org/docs/2.5/distributed.html#torch.distributed.new_group)
[torch2.7 new_group](https://docs.pytorch.org/docs/2.7/distributed.html#torch.distributed.new_group)

## Changes
- Add _has_param() utility function to check if a function supports a specific parameter
- Compatible with torch 2.5 (no device_id param) and torch 2.7+ (has device_id param)

## Testing
```sh
root@worker3218:/sgl-workspace/torchada# pytest tests/test_cuda_patching.py::TestDistributedBackend::test_has_param_with_mock_functions tests/test_cuda_patching.py::TestDistributedBackend::test_new_group_device_id_param_compatibility -v

===================================================== test session starts ======================================================
platform linux -- Python 3.10.12, pytest-9.0.1, pluggy-1.6.0 -- /usr/bin/python
cachedir: .pytest_cache
rootdir: /sgl-workspace/torchada
configfile: pyproject.toml
plugins: cov-7.0.0, anyio-4.11.0
collected 2 items                                                                                                              

tests/test_cuda_patching.py::TestDistributedBackend::test_has_param_with_mock_functions PASSED                           [ 50%]
tests/test_cuda_patching.py::TestDistributedBackend::test_new_group_device_id_param_compatibility PASSED                 [100%]

======================================================= warnings summary =======================================================
../../usr/local/lib/python3.10/dist-packages/torch/cuda/__init__.py:61
  /usr/local/lib/python3.10/dist-packages/torch/cuda/__init__.py:61: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
    import pynvml  # type: ignore[import]

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================= 2 passed, 1 warning in 0.01s =================================================
```