### PR TITLE
feat: add torch.cuda.random module for MUSA platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ See `src/torchada/_mapping.py` for the complete mapping table (380+ mappings).
 
 ```
 # pyproject.toml or requirements.txt
-torchada>=0.1.43
+torchada>=0.1.44
 ```
 
 ### Step 2: Conditional Import

--- a/README_CN.md
+++ b/README_CN.md
@@ -255,7 +255,7 @@ if torchada.is_gpu_device(device):  # 在 CUDA 和 MUSA 上都能工作
 
 ```
 # pyproject.toml 或 requirements.txt
-torchada>=0.1.43
+torchada>=0.1.44
 ```
 
 ### 步骤 2：条件导入

--- a/benchmarks/benchmark_history.json
+++ b/benchmarks/benchmark_history.json
@@ -3,7 +3,7 @@
   "description": "Historical benchmark results for torchada performance tracking",
   "results": [
     {
-      "version": "0.1.43",
+      "version": "0.1.44",
       "date": "2026-01-29",
       "platform": "MUSA",
       "pytorch_version": "2.7.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torchada"
-version = "0.1.43"
+version = "0.1.44"
 description = "Adapter package for torch_musa to act exactly like PyTorch CUDA"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/torchada/__init__.py
+++ b/src/torchada/__init__.py
@@ -24,7 +24,7 @@ Usage:
     from torch.utils.cpp_extension import CUDAExtension, BuildExtension, CUDA_HOME
 """
 
-__version__ = "0.1.43"
+__version__ = "0.1.44"
 
 from . import cuda, utils
 from ._patch import apply_patches, get_original_init_process_group, is_patched

--- a/src/torchada/_patch.py
+++ b/src/torchada/_patch.py
@@ -723,6 +723,16 @@ def _patch_torch_cuda_module():
         except ImportError:
             pass
 
+        # Patch torch.cuda.random - use torchada.cuda.random module
+        if not hasattr(torch.musa, "random"):
+            try:
+                from .cuda import random as random_stub
+
+                sys.modules["torch.cuda.random"] = random_stub
+                torch.musa.random = random_stub
+            except ImportError:
+                pass
+
         # Patch missing _lazy_call from torch_musa.core._lazy_init
         # torch_musa only maps _lazy_init but not _lazy_call
         # This is needed for code that does: from torch.cuda import _lazy_call

--- a/src/torchada/cuda/random.py
+++ b/src/torchada/cuda/random.py
@@ -1,0 +1,125 @@
+"""
+CUDA random stub module for MUSA platform.
+
+This module exposes CUDA-style random API entry points under
+`torch.cuda.random` and forwards them to `torch.musa` equivalents.
+On a MUSA platform, behavior is provided by `torch.musa`; on non-MUSA
+platforms, this module is only reachable when torchada patching is active.
+
+Usage:
+    import torchada  # Apply patches first
+    import torch.cuda.random as cuda_random
+
+    cuda_random.manual_seed(1234)
+    state = cuda_random.get_rng_state()
+"""
+
+from typing import Iterable, List, Union
+
+import torch
+from torch import Tensor
+
+__all__ = [
+    "get_rng_state",
+    "get_rng_state_all",
+    "set_rng_state",
+    "set_rng_state_all",
+    "manual_seed",
+    "manual_seed_all",
+    "seed",
+    "seed_all",
+    "initial_seed",
+]
+
+
+def get_rng_state(device: Union[int, str, torch.device] = "musa") -> Tensor:
+    r"""Return the random number generator state of the specified GPU as a ByteTensor.
+
+    Args:
+        device (torch.device or int, optional): The device to return the RNG state of.
+            Default: ``'musa'`` for the current device.
+
+    .. warning::
+        This function eagerly initializes the backend device.
+    """
+    return torch.musa.get_rng_state(device)
+
+
+def get_rng_state_all() -> List[Tensor]:
+    r"""Return a list of ByteTensor representing the random number states of all devices."""
+    return torch.musa.get_rng_state_all()
+
+
+def set_rng_state(new_state: Tensor, device: Union[int, str, torch.device] = "musa") -> None:
+    r"""Set the random number generator state of the specified GPU.
+
+    Args:
+        new_state (torch.ByteTensor): The desired state
+        device (torch.device or int, optional): The device to set the RNG state.
+            Default: ``'musa'`` for the current device.
+    """
+    return torch.musa.set_rng_state(new_state, device)
+
+
+def set_rng_state_all(new_states: Iterable[Tensor]) -> None:
+    r"""Set the random number generator state of all devices.
+
+    Args:
+        new_states (Iterable of torch.ByteTensor): The desired state for each device.
+    """
+    return torch.musa.set_rng_state_all(new_states)
+
+
+def manual_seed(seed: int) -> None:
+    r"""Set the seed for generating random numbers for the current device.
+
+    It's safe to call this function if the backend is unavailable; in that
+    case, behavior is backend-defined.
+
+    Args:
+        seed (int): The desired seed.
+
+    .. warning::
+        If you are working with a multi-GPU model, this function is insufficient
+        to get determinism.  To seed all GPUs, use :func:`manual_seed_all`.
+    """
+    return torch.musa.manual_seed(seed)
+
+
+def manual_seed_all(seed: int) -> None:
+    r"""Set the seed for generating random numbers on all GPUs.
+
+    It's safe to call this function if the backend is unavailable; in that
+    case, behavior is backend-defined.
+
+    Args:
+        seed (int): The desired seed.
+    """
+    return torch.musa.manual_seed_all(seed)
+
+
+def seed() -> None:
+    r"""Set the seed for generating random numbers to a random number for the current GPU.
+
+    It's safe to call this function if the backend is unavailable; in that
+    case, behavior is backend-defined.
+    """
+    return torch.musa.seed()
+
+
+def seed_all() -> None:
+    r"""Set the seed for generating random numbers to a random number on all GPUs.
+
+    It's safe to call this function if the backend is unavailable; in that
+    case, behavior is backend-defined.
+    """
+    return torch.musa.seed_all()
+
+
+def initial_seed() -> int:
+    r"""Return the current random seed of the current GPU.
+
+    .. warning::
+        This function eagerly initializes the backend device.
+    """
+    return torch.musa.initial_seed()

--- a/tests/test_cuda_patching.py
+++ b/tests/test_cuda_patching.py
@@ -497,6 +497,50 @@ class TestRNGFunctions:
             torch.cuda.manual_seed(42)
 
 
+class TestRandomFunctions:
+    """Test torch.cuda.random module and API proxy behavior."""
+
+    def test_cuda_random_module_available(self):
+        import torch
+
+        assert hasattr(torch.cuda, "random")
+        assert hasattr(torch.cuda.random, "get_rng_state")
+        assert hasattr(torch.cuda.random, "get_rng_state_all")
+        assert hasattr(torch.cuda.random, "set_rng_state")
+        assert hasattr(torch.cuda.random, "set_rng_state_all")
+        assert hasattr(torch.cuda.random, "manual_seed")
+        assert hasattr(torch.cuda.random, "manual_seed_all")
+        assert hasattr(torch.cuda.random, "seed")
+        assert hasattr(torch.cuda.random, "initial_seed")
+
+    def test_cuda_random_aliases_musa(self):
+        import torch
+
+        if hasattr(torch, "musa") and hasattr(torch.musa, "random"):
+            assert torch.cuda.random is torch.musa.random
+
+    def test_cuda_random_functionality(self):
+        import torch
+
+        # only execute on an actual GPU backend to avoid no-GPU failures
+        if not torch.cuda.is_available():
+            return
+
+        torch.cuda.random.manual_seed(42)
+        torch.cuda.random.manual_seed_all(42)
+
+        state = torch.cuda.random.get_rng_state()
+        assert state is not None
+
+        state_all = torch.cuda.random.get_rng_state_all()
+        assert state_all is not None
+
+        torch.cuda.random.set_rng_state(state)
+        torch.cuda.random.set_rng_state_all(state_all)
+
+        assert isinstance(torch.cuda.random.initial_seed(), int)
+
+
 class TestMemoryFunctions:
     """Test additional memory functions."""
 
@@ -1922,7 +1966,6 @@ class TestValidateDevice:
 
     def test_patch_when_attribute_missing(self, monkeypatch):
         """Verify the fallback implementation is installed when the attribute is absent."""
-        import torch
         import torch.nn.attention.flex_attention as flex_attention
 
         from torchada._patch import _patch_validate_device


### PR DESCRIPTION

## Summary
- Add `src/torchada/cuda/random.py` to implement `torch.cuda.random` shim.
- Patch in `src/torchada/_patch.py`:
  - `sys.modules["torch.cuda.random"] = torchada.cuda.random`
  - `torch.musa.random = torchada.cuda.random`
- Add tests in `tests/test_cuda_patching.py`:
  - verify `torch.cuda.random` exists and exposes expected APIs
  - verify alias behavior (`torch.cuda.random is torch.musa.random`) on MUSA
  - verify RNG methods work (manual_seed, get/set state, initial_seed)

## Behavior
- `torchada.cuda.random` forwards all calls to `torch.musa`:
  - `get_rng_state`, `get_rng_state_all`
  - `set_rng_state`, `set_rng_state_all`
  - `manual_seed`, `manual_seed_all`, `seed`, `seed_all`, `initial_seed`

## Motivation
- Provide compatibility for code that assumes `torch.cuda.random` while target platform is MUSA.
- Match existing `torch.cuda.*` stub patch style (`torch.cuda.nvtx` etc.).

## Testing

```
# pytest tests/test_cuda_patching.py::TestRandomFunctions
=================================================================================================== test session starts ===================================================================================================
platform linux -- Python 3.10.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/xuzhenxue/work/torchada
configfile: pyproject.toml
plugins: cov-7.0.0, anyio-4.12.0
collected 3 items                                                                                                                                                                                                         

tests/test_cuda_patching.py ...                                                                                                                                                                                     [100%]

==================================================================================================== 3 passed in 0.03s ====================================================================================================

```