### PR TITLE
fix(_patch): support additional kwargs in library.impl patching

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ See `src/torchada/_mapping.py` for the complete mapping table (380+ mappings).
 
 ```
 # pyproject.toml or requirements.txt
-torchada>=0.1.44
+torchada>=0.1.46
 ```
 
 ### Step 2: Conditional Import

--- a/README_CN.md
+++ b/README_CN.md
@@ -255,7 +255,7 @@ if torchada.is_gpu_device(device):  # 在 CUDA 和 MUSA 上都能工作
 
 ```
 # pyproject.toml 或 requirements.txt
-torchada>=0.1.44
+torchada>=0.1.46
 ```
 
 ### 步骤 2：条件导入

--- a/benchmarks/benchmark_history.json
+++ b/benchmarks/benchmark_history.json
@@ -3,7 +3,7 @@
   "description": "Historical benchmark results for torchada performance tracking",
   "results": [
     {
-      "version": "0.1.45",
+      "version": "0.1.46",
       "date": "2026-01-29",
       "platform": "MUSA",
       "pytorch_version": "2.7.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torchada"
-version = "0.1.44"
+version = "0.1.46"
 description = "Adapter package for torch_musa to act exactly like PyTorch CUDA"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/torchada/__init__.py
+++ b/src/torchada/__init__.py
@@ -24,7 +24,7 @@ Usage:
     from torch.utils.cpp_extension import CUDAExtension, BuildExtension, CUDA_HOME
 """
 
-__version__ = "0.1.44"
+__version__ = "0.1.46"
 
 from . import cuda, utils
 from ._patch import apply_patches, get_original_init_process_group, is_patched

--- a/src/torchada/_patch.py
+++ b/src/torchada/_patch.py
@@ -1029,6 +1029,7 @@ def _patch_library_impl():
     Example of code that needs this patch:
         my_lib.impl(op_name, op_func, "CUDA")  # Now works on MUSA!
         my_lib.impl(op_name, op_func, "Autograd", with_keyset=True)  # Also works!
+        my_lib.impl(op_name, op_func, "Autograd", with_keyset=True, allow_override=True)  # Also works!
     """
     if not hasattr(torch, "library") or not hasattr(torch.library, "Library"):
         return
@@ -1046,11 +1047,16 @@ def _patch_library_impl():
         "NestedTensorCUDA": "NestedTensorPrivateUse1",
     }
 
-    def patched_impl(self, op_name, fn, dispatch_key="", *, with_keyset=False):
+    def patched_impl(self, *args, **kwargs):
         # Translate CUDA dispatch keys to PrivateUse1 equivalents for MUSA compatibility
-        if dispatch_key in cuda_dispatch_key_map:
-            dispatch_key = cuda_dispatch_key_map[dispatch_key]
-        return original_impl(self, op_name, fn, dispatch_key, with_keyset=with_keyset)
+        sig = inspect.signature(original_impl)
+        bound = sig.bind(self, *args, **kwargs)
+        bound.apply_defaults()
+
+        if bound.arguments.get('dispatch_key') in cuda_dispatch_key_map:
+            bound.arguments['dispatch_key'] = cuda_dispatch_key_map[bound.arguments['dispatch_key']]
+
+        return original_impl(*bound.args, **bound.kwargs)
 
     torch.library.Library.impl = patched_impl
 

--- a/tests/test_cuda_patching.py
+++ b/tests/test_cuda_patching.py
@@ -1123,18 +1123,29 @@ class TestIsCompiledAndBackends:
         except (AttributeError, AssertionError):
             pytest.skip("fp32_precision not available (torchada MUSA-specific attribute)")
 
-        # Should be accessible
+        if torch.__version__ >= torch.torch_version.TorchVersion("2.9.0"):
+            # PyTorch 2.9+: Only use the new API. Do NOT call torch.get_float32_matmul_precision()
+            valid_precisions = ("ieee", "tf32")
+            test_values = ["ieee", "tf32"]
+            check_underlying_api = False  # Critical: avoid mixing APIs
+        else:
+            valid_precisions = ("highest", "high", "medium")
+            test_values = ["highest", "high"]
+            check_underlying_api = True
+
+        # Save original state
         original = torch.backends.cuda.matmul.fp32_precision
-        assert original in ("highest", "high", "medium")
+        assert original in valid_precisions, \
+            f"fp32_precision value '{original}' not in expected set {valid_precisions}"
 
-        # Test setting (use torch.get/set_float32_matmul_precision values)
-        torch.backends.cuda.matmul.fp32_precision = "highest"
-        assert torch.backends.cuda.matmul.fp32_precision == "highest"
-        assert torch.get_float32_matmul_precision() == "highest"
+        # Test setting values
+        for test_value in test_values:
+            torch.backends.cuda.matmul.fp32_precision = test_value
+            assert torch.backends.cuda.matmul.fp32_precision == test_value
 
-        torch.backends.cuda.matmul.fp32_precision = "high"
-        assert torch.backends.cuda.matmul.fp32_precision == "high"
-        assert torch.get_float32_matmul_precision() == "high"
+            # Only check the underlying old API for older PyTorch versions
+            if check_underlying_api:
+                assert torch.get_float32_matmul_precision() == test_value
 
         # Restore original
         torch.backends.cuda.matmul.fp32_precision = original
@@ -1394,6 +1405,10 @@ class TestLibraryImpl:
         if not torchada.is_musa_platform():
             pytest.skip("Only applicable on MUSA platform")
 
+        # Skip for PyTorch versions below 2.9 as allow_override may not be supported
+        if torch.__version__ < torch.torch_version.TorchVersion("2.9.0"):
+            pytest.skip("allow_override parameter requires PyTorch 2.9 or higher")
+
         lib_name = f"test_lib_{uuid.uuid4().hex[:8]}"
         test_lib = torch.library.Library(lib_name, "DEF")
 
@@ -1423,6 +1438,10 @@ class TestLibraryImpl:
         if not torchada.is_musa_platform():
             pytest.skip("Only applicable on MUSA platform")
 
+        # Skip for PyTorch versions below 2.9 as allow_override may not be supported
+        if torch.__version__ < torch.torch_version.TorchVersion("2.9.0"):
+            pytest.skip("allow_override parameter requires PyTorch 2.9 or higher")
+
         lib_name = f"test_lib_{uuid.uuid4().hex[:8]}"
         test_lib = torch.library.Library(lib_name, "DEF")
 
@@ -1448,6 +1467,10 @@ class TestLibraryImpl:
 
         if not torchada.is_musa_platform():
             pytest.skip("Only applicable on MUSA platform")
+
+        # Skip for PyTorch versions below 2.9 as allow_override may not be supported
+        if torch.__version__ < torch.torch_version.TorchVersion("2.9.0"):
+            pytest.skip("allow_override parameter requires PyTorch 2.9 or higher")
 
         lib_name = f"test_lib_{uuid.uuid4().hex[:8]}"
         test_lib = torch.library.Library(lib_name, "DEF")

--- a/tests/test_cuda_patching.py
+++ b/tests/test_cuda_patching.py
@@ -1382,6 +1382,90 @@ class TestLibraryImpl:
         result = op.identity_op(x)
         assert result is x
 
+    def test_library_impl_with_allow_override(self):
+        """Test that Library.impl with allow_override=True works."""
+        import uuid
+
+        import torch
+        import torch.library
+
+        import torchada
+
+        if not torchada.is_musa_platform():
+            pytest.skip("Only applicable on MUSA platform")
+
+        lib_name = f"test_lib_{uuid.uuid4().hex[:8]}"
+        test_lib = torch.library.Library(lib_name, "DEF")
+
+        def identity_allow_override_1(x: torch.Tensor) -> torch.Tensor:
+            return x
+        def doubled_allow_override_2(x: torch.Tensor) -> torch.Tensor:
+            return 2*x
+
+        test_lib.define("test_op(Tensor x) -> Tensor")
+        test_lib.impl("test_op", identity_allow_override_1, "CPU")
+        test_lib.impl("test_op", doubled_allow_override_2, "CPU", allow_override=True)
+
+        x = torch.randn(3)
+        op = getattr(torch.ops, lib_name)
+        result = op.test_op(x)
+        assert torch.equal(result, 2 * x)
+
+    def test_library_impl_allow_override_false_explicit(self):
+        """Test that Library.impl with allow_override=False explicitly works."""
+        import uuid
+
+        import torch
+        import torch.library
+
+        import torchada
+
+        if not torchada.is_musa_platform():
+            pytest.skip("Only applicable on MUSA platform")
+
+        lib_name = f"test_lib_{uuid.uuid4().hex[:8]}"
+        test_lib = torch.library.Library(lib_name, "DEF")
+
+        def identity(x: torch.Tensor) -> torch.Tensor:
+            return x
+
+        test_lib.define("identity_op(Tensor x) -> Tensor")
+        test_lib.impl("identity_op", identity, "CPU", allow_override=False)
+
+        x = torch.randn(3)
+        op = getattr(torch.ops, lib_name)
+        result = op.identity_op(x)
+        assert result is x
+
+    def test_library_impl_with_keyset_and_with_allow_override(self):
+        """Test that Library.impl with with_keyset=True and allow_override=True works."""
+        import uuid
+
+        import torch
+        import torch.library
+
+        import torchada
+
+        if not torchada.is_musa_platform():
+            pytest.skip("Only applicable on MUSA platform")
+
+        lib_name = f"test_lib_{uuid.uuid4().hex[:8]}"
+        test_lib = torch.library.Library(lib_name, "DEF")
+
+        def identity_allow_override_with_keyset_1(keyset, x: torch.Tensor) -> torch.Tensor:
+            return x
+        def doubled_allow_override_with_keyset_2(keyset, x: torch.Tensor) -> torch.Tensor:
+            return 2*x
+
+        test_lib.define("test_op(Tensor x) -> Tensor")
+        test_lib.impl("test_op", identity_allow_override_with_keyset_1, "CPU", with_keyset=True)
+        test_lib.impl("test_op", doubled_allow_override_with_keyset_2, "CPU", with_keyset=True, allow_override=True)
+
+        x = torch.randn(3)
+        op = getattr(torch.ops, lib_name)
+        result = op.test_op(x)
+        assert torch.equal(result, 2 * x)
+
     def test_library_impl_fn_as_keyword(self):
         """Test that Library.impl works with fn as keyword argument."""
         import uuid


### PR DESCRIPTION
### Description:

Refactor `_patch_library_impl()` to improve dispatch key translation and support additional parameters.

### Changes:

Replace the hardcoded parameter signature with a flexible `*args, **kwargs` approach

Dynamically map positional arguments to their corresponding parameter names based on the original function signature

Add support for the `allow_override` parameter that was previously not handled

Update CUDA dispatch key translation to work with `kwargs` instead of positional arguments

### Why:
This change ensures that all parameters (including newly added ones like `allow_override`) are properly passed through to the original `impl()` method while maintaining the MUSA/CUDA dispatch key translation functionality. The new implementation is more robust and forward-compatible with future changes to the `impl()` method signature.

### Example:
With this change, calls like:
```
python
my_lib.impl(op_name, op_func, "Autograd", with_keyset=True, allow_override=True)
```

### Test
#### torch2.9
<img width="2107" height="573" alt="image" src="https://github.com/user-attachments/assets/f01a996e-0d03-4a50-b2e3-1cac70cb4cf1" />

#### torch2.7.1
<img width="2535" height="172" alt="image" src="https://github.com/user-attachments/assets/230a9d5f-e140-4577-83ec-9299867f810e" />

