### PR TITLE
Support 'from sgl_kernel.flash_attn import flash_attn_varlen_func'

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ See `src/torchada/_mapping.py` for the complete mapping table (380+ mappings).
 
 ```
 # pyproject.toml or requirements.txt
-torchada>=0.1.44
+torchada>=0.1.45
 ```
 
 ### Step 2: Conditional Import

--- a/README_CN.md
+++ b/README_CN.md
@@ -255,7 +255,7 @@ if torchada.is_gpu_device(device):  # 在 CUDA 和 MUSA 上都能工作
 
 ```
 # pyproject.toml 或 requirements.txt
-torchada>=0.1.44
+torchada>=0.1.45
 ```
 
 ### 步骤 2：条件导入

--- a/benchmarks/benchmark_history.json
+++ b/benchmarks/benchmark_history.json
@@ -3,7 +3,7 @@
   "description": "Historical benchmark results for torchada performance tracking",
   "results": [
     {
-      "version": "0.1.44",
+      "version": "0.1.45",
       "date": "2026-01-29",
       "platform": "MUSA",
       "pytorch_version": "2.7.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torchada"
-version = "0.1.44"
+version = "0.1.45"
 description = "Adapter package for torch_musa to act exactly like PyTorch CUDA"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/torchada/__init__.py
+++ b/src/torchada/__init__.py
@@ -24,7 +24,7 @@ Usage:
     from torch.utils.cpp_extension import CUDAExtension, BuildExtension, CUDA_HOME
 """
 
-__version__ = "0.1.44"
+__version__ = "0.1.45"
 
 from . import cuda, utils
 from ._patch import apply_patches, get_original_init_process_group, is_patched

--- a/src/torchada/_patch.py
+++ b/src/torchada/_patch.py
@@ -1251,12 +1251,16 @@ def _patch_flash_attn():
     """
     import flash_attn
 
-    # Ensure sgl_kernel package exists in sys.modules (create stub if needed)
+    # Ensure sgl_kernel package exists in sys.modules.
+    # First try to import the real package; only create a stub if it's truly not installed.
     if "sgl_kernel" not in sys.modules:
-        sgl_kernel_stub = ModuleType("sgl_kernel")
-        sgl_kernel_stub.__path__ = []  # Make it a package
-        sgl_kernel_stub.__package__ = "sgl_kernel"
-        sys.modules["sgl_kernel"] = sgl_kernel_stub
+        try:
+            import sgl_kernel  # noqa: F401
+        except ImportError:
+            sgl_kernel_stub = ModuleType("sgl_kernel")
+            sgl_kernel_stub.__path__ = []  # Make it a package
+            sgl_kernel_stub.__package__ = "sgl_kernel"
+            sys.modules["sgl_kernel"] = sgl_kernel_stub
 
     # Register flash_attn as sgl_kernel.flash_attn submodule
     sgl_kernel = sys.modules["sgl_kernel"]

--- a/src/torchada/_patch.py
+++ b/src/torchada/_patch.py
@@ -1233,6 +1233,37 @@ def _patch_validate_device():
     torch.nn.attention.flex_attention._validate_device = _validate_device
 
 
+@patch_function
+@requires_import("flash_attn")
+def _patch_flash_attn():
+    """
+    Redirect sgl_kernel.flash_attn imports to the MUSA flash_attn package.
+
+    On CUDA (NVIDIA), sgl_kernel provides its own flash_attn submodule:
+        from sgl_kernel.flash_attn import flash_attn_varlen_func
+
+    On MUSA, the mate package provides an equivalent flash_attn package.
+    This patch registers flash_attn as sgl_kernel.flash_attn in sys.modules
+    so that code using sgl_kernel.flash_attn works transparently on MUSA.
+
+    If sgl_kernel is not installed, a stub module is created so that
+    sgl_kernel.flash_attn imports still resolve correctly.
+    """
+    import flash_attn
+
+    # Ensure sgl_kernel package exists in sys.modules (create stub if needed)
+    if "sgl_kernel" not in sys.modules:
+        sgl_kernel_stub = ModuleType("sgl_kernel")
+        sgl_kernel_stub.__path__ = []  # Make it a package
+        sgl_kernel_stub.__package__ = "sgl_kernel"
+        sys.modules["sgl_kernel"] = sgl_kernel_stub
+
+    # Register flash_attn as sgl_kernel.flash_attn submodule
+    sgl_kernel = sys.modules["sgl_kernel"]
+    sgl_kernel.flash_attn = flash_attn
+    sys.modules["sgl_kernel.flash_attn"] = flash_attn
+
+
 class _CDLLWrapper:
     """
     Wrapper for ctypes.CDLL that automatically translates CUDA/NCCL function names

--- a/tests/test_cuda_patching.py
+++ b/tests/test_cuda_patching.py
@@ -2069,6 +2069,55 @@ class TestFlashAttnPatching:
         assert hasattr(sgl_kernel, "flash_attn")
         assert sgl_kernel.flash_attn is flash_attn
 
+    def test_real_sgl_kernel_not_replaced_by_stub(self):
+        """Test that a real sgl_kernel module already in sys.modules is preserved,
+        not replaced by a stub. The patch should only add flash_attn to it."""
+        import sys
+        from types import ModuleType
+
+        import torchada
+
+        if not torchada.is_musa_platform():
+            pytest.skip("Only applicable on MUSA platform")
+
+        try:
+            import flash_attn
+        except ImportError:
+            pytest.skip("flash_attn not installed")
+
+        from torchada._patch import _patch_flash_attn
+
+        # Save original state
+        orig_sgl_kernel = sys.modules.pop("sgl_kernel", None)
+        orig_sgl_kernel_fa = sys.modules.pop("sgl_kernel.flash_attn", None)
+
+        try:
+            # Simulate a real sgl_kernel package already imported with a custom attribute
+            fake_sgl_kernel = ModuleType("sgl_kernel")
+            fake_sgl_kernel.__path__ = ["/some/real/path"]
+            fake_sgl_kernel.__package__ = "sgl_kernel"
+            fake_sgl_kernel.some_other_api = lambda: "real"
+            sys.modules["sgl_kernel"] = fake_sgl_kernel
+
+            # Run the patch
+            _patch_flash_attn()
+
+            # The same module object should still be in sys.modules (not replaced)
+            assert sys.modules["sgl_kernel"] is fake_sgl_kernel
+            # The original attribute should still be there
+            assert fake_sgl_kernel.some_other_api() == "real"
+            # flash_attn should have been added
+            assert fake_sgl_kernel.flash_attn is flash_attn
+            assert sys.modules["sgl_kernel.flash_attn"] is flash_attn
+        finally:
+            # Restore original state
+            sys.modules.pop("sgl_kernel", None)
+            sys.modules.pop("sgl_kernel.flash_attn", None)
+            if orig_sgl_kernel is not None:
+                sys.modules["sgl_kernel"] = orig_sgl_kernel
+            if orig_sgl_kernel_fa is not None:
+                sys.modules["sgl_kernel.flash_attn"] = orig_sgl_kernel_fa
+
     def test_flash_attn_direct_import_still_works(self):
         """Test backward compatibility: 'from flash_attn import flash_attn_varlen_func'
         still works after patching."""

--- a/tests/test_cuda_patching.py
+++ b/tests/test_cuda_patching.py
@@ -1977,3 +1977,183 @@ class TestValidateDevice:
         # The patch must not raise even when the attribute is absent.
         _patch_validate_device()
         assert hasattr(flex_attention, "_validate_device")
+
+
+class TestFlashAttnPatching:
+    """Test flash_attn / sgl_kernel.flash_attn patching."""
+
+    def test_sgl_kernel_flash_attn_import_when_flash_attn_available(self):
+        """Test that 'from sgl_kernel.flash_attn import flash_attn_varlen_func' works
+        when flash_attn is available (MUSA platform with mate's flash_attn package).
+
+        This is the primary use case: unified code should always import from
+        sgl_kernel.flash_attn regardless of platform.
+        """
+
+        import torchada
+
+        if not torchada.is_musa_platform():
+            pytest.skip("Only applicable on MUSA platform")
+
+        try:
+            import flash_attn  # noqa: F401
+        except ImportError:
+            pytest.skip("flash_attn not installed")
+
+        from sgl_kernel.flash_attn import flash_attn_varlen_func
+
+        assert flash_attn_varlen_func is not None
+        assert callable(flash_attn_varlen_func)
+
+        # Verify it's the same function as in flash_attn directly
+        import flash_attn as fa
+
+        assert flash_attn_varlen_func is fa.flash_attn_varlen_func
+
+    def test_sgl_kernel_flash_attn_module_in_sys_modules(self):
+        """Test that sgl_kernel.flash_attn is registered in sys.modules."""
+        import sys
+
+        import torchada
+
+        if not torchada.is_musa_platform():
+            pytest.skip("Only applicable on MUSA platform")
+
+        try:
+            import flash_attn  # noqa: F401
+        except ImportError:
+            pytest.skip("flash_attn not installed")
+
+        assert "sgl_kernel" in sys.modules
+        assert "sgl_kernel.flash_attn" in sys.modules
+        assert sys.modules["sgl_kernel.flash_attn"] is flash_attn
+
+    def test_sgl_kernel_stub_created_when_sgl_kernel_not_installed(self):
+        """Test that a stub sgl_kernel module is created when sgl_kernel is not
+        installed but flash_attn is available."""
+        import sys
+
+        import torchada
+
+        if not torchada.is_musa_platform():
+            pytest.skip("Only applicable on MUSA platform")
+
+        try:
+            import flash_attn  # noqa: F401
+        except ImportError:
+            pytest.skip("flash_attn not installed")
+
+        sgl_kernel = sys.modules.get("sgl_kernel")
+        assert sgl_kernel is not None
+        # Stub should be a proper package (has __path__)
+        assert hasattr(sgl_kernel, "__path__")
+        assert hasattr(sgl_kernel, "flash_attn")
+
+    def test_sgl_kernel_existing_module_preserved(self):
+        """Test that if sgl_kernel is already in sys.modules, the existing module
+        is used (not replaced), but flash_attn submodule is still added."""
+        import sys
+
+        import torchada
+
+        if not torchada.is_musa_platform():
+            pytest.skip("Only applicable on MUSA platform")
+
+        try:
+            import flash_attn  # noqa: F401
+        except ImportError:
+            pytest.skip("flash_attn not installed")
+
+        # The patch has already run. Verify sgl_kernel.flash_attn is set.
+        sgl_kernel = sys.modules["sgl_kernel"]
+        assert hasattr(sgl_kernel, "flash_attn")
+        assert sgl_kernel.flash_attn is flash_attn
+
+    def test_flash_attn_direct_import_still_works(self):
+        """Test backward compatibility: 'from flash_attn import flash_attn_varlen_func'
+        still works after patching."""
+        import torchada
+
+        if not torchada.is_musa_platform():
+            pytest.skip("Only applicable on MUSA platform")
+
+        try:
+            from flash_attn import flash_attn_varlen_func
+
+            assert flash_attn_varlen_func is not None
+            assert callable(flash_attn_varlen_func)
+        except ImportError:
+            pytest.skip("flash_attn not installed")
+
+    def test_flash_attn_interface_submodule_accessible(self):
+        """Test that flash_attn.flash_attn_interface is accessible via
+        sgl_kernel.flash_attn.flash_attn_interface."""
+        import torchada
+
+        if not torchada.is_musa_platform():
+            pytest.skip("Only applicable on MUSA platform")
+
+        try:
+            import flash_attn  # noqa: F401
+        except ImportError:
+            pytest.skip("flash_attn not installed")
+
+        from sgl_kernel.flash_attn import flash_attn_interface
+
+        assert hasattr(flash_attn_interface, "flash_attn_varlen_func")
+
+    def test_patch_skipped_when_flash_attn_not_available(self):
+        """Test that the patch is gracefully skipped when flash_attn is not installed.
+
+        On platforms without flash_attn (e.g. yeahdongcn container), sgl_kernel.flash_attn
+        should NOT be available unless sgl_kernel was already installed.
+        """
+        import sys
+
+        import torchada
+
+        if not torchada.is_musa_platform():
+            pytest.skip("Only applicable on MUSA platform")
+
+        try:
+            import flash_attn  # noqa: F401
+
+            pytest.skip("flash_attn is available - this test is for when it's NOT available")
+        except ImportError:
+            pass
+
+        # Without flash_attn, the patch should not have created sgl_kernel.flash_attn
+        # (unless sgl_kernel was independently installed, which we don't expect in test containers)
+        if "sgl_kernel" in sys.modules:
+            # If sgl_kernel exists, it should NOT have flash_attn from our patch
+            sgl_kernel = sys.modules["sgl_kernel"]
+            if hasattr(sgl_kernel, "flash_attn"):
+                # This would mean something else installed sgl_kernel with flash_attn
+                pass
+        else:
+            # sgl_kernel should not exist at all
+            assert "sgl_kernel" not in sys.modules
+            assert "sgl_kernel.flash_attn" not in sys.modules
+
+    def test_multiple_flash_attn_functions_accessible(self):
+        """Test that multiple flash_attn functions are accessible via sgl_kernel.flash_attn."""
+        import torchada
+
+        if not torchada.is_musa_platform():
+            pytest.skip("Only applicable on MUSA platform")
+
+        try:
+            import flash_attn  # noqa: F401
+        except ImportError:
+            pytest.skip("flash_attn not installed")
+
+        from sgl_kernel import flash_attn as sgl_flash_attn
+
+        # These are the key functions that should be available
+        expected_funcs = [
+            "flash_attn_varlen_func",
+            "flash_attn_func",
+        ]
+        for func_name in expected_funcs:
+            assert hasattr(sgl_flash_attn, func_name), f"Missing {func_name}"
+            assert callable(getattr(sgl_flash_attn, func_name)), f"{func_name} not callable"


### PR DESCRIPTION
```bash
Python 3.10.12 (main, Nov  4 2025, 08:48:33) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import torchada
>>> from sgl_kernel.flash_attn import flash_attn_varlen_func
>>> flash_attn_varlen_func
<function flash_attn_varlen_func at 0x7fdeec8fd3f0>
>>> from flash_attn import flash_attn_varlen_func as x
>>> x
<function flash_attn_varlen_func at 0x7fdeec8fd3f0>
>>> 
```