### PR TITLE
fix: make GeneratorWrapper picklable for multiprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ See `src/torchada/_mapping.py` for the complete mapping table (380+ mappings).
 
 ```
 # pyproject.toml or requirements.txt
-torchada>=0.1.46
+torchada>=0.1.47
 ```
 
 ### Step 2: Conditional Import

--- a/README_CN.md
+++ b/README_CN.md
@@ -255,7 +255,7 @@ if torchada.is_gpu_device(device):  # 在 CUDA 和 MUSA 上都能工作
 
 ```
 # pyproject.toml 或 requirements.txt
-torchada>=0.1.46
+torchada>=0.1.47
 ```
 
 ### 步骤 2：条件导入

--- a/benchmarks/benchmark_history.json
+++ b/benchmarks/benchmark_history.json
@@ -3,7 +3,7 @@
   "description": "Historical benchmark results for torchada performance tracking",
   "results": [
     {
-      "version": "0.1.46",
+      "version": "0.1.47",
       "date": "2026-01-29",
       "platform": "MUSA",
       "pytorch_version": "2.7.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torchada"
-version = "0.1.46"
+version = "0.1.47"
 description = "Adapter package for torch_musa to act exactly like PyTorch CUDA"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/torchada/__init__.py
+++ b/src/torchada/__init__.py
@@ -24,7 +24,7 @@ Usage:
     from torch.utils.cpp_extension import CUDAExtension, BuildExtension, CUDA_HOME
 """
 
-__version__ = "0.1.46"
+__version__ = "0.1.47"
 
 from . import cuda, utils
 from ._patch import apply_patches, get_original_init_process_group, is_patched

--- a/src/torchada/_patch.py
+++ b/src/torchada/_patch.py
@@ -324,6 +324,36 @@ _original_torch_generator = None
 _original_c_generator = None
 
 
+class _GeneratorMeta(type):
+    """Metaclass that properly implements __instancecheck__ for isinstance() to work."""
+
+    def __instancecheck__(cls, instance):
+        if _original_c_generator is not None:
+            return isinstance(instance, _original_c_generator)
+        return False
+
+    def __subclasscheck__(cls, subclass):
+        if _original_c_generator is not None:
+            if subclass is _original_c_generator:
+                return True
+        return super().__subclasscheck__(subclass)
+
+
+class GeneratorWrapper(metaclass=_GeneratorMeta):
+    """Wrapper for torch.Generator that translates cuda -> musa."""
+
+    _original = None
+
+    def __new__(cls, device=None):
+        original = cls._original
+        if original is None:
+            raise RuntimeError("GeneratorWrapper not initialized")
+        # Translate device if needed
+        if device is not None:
+            device = _translate_device(device)
+        return original(device=device)
+
+
 @patch_function
 def _patch_torch_generator():
     """
@@ -346,31 +376,10 @@ def _patch_torch_generator():
     # of type torch._C.Generator
     _original_c_generator = torch._C.Generator
 
-    class GeneratorMeta(type):
-        """Metaclass that properly implements __instancecheck__ for isinstance() to work."""
+    GeneratorWrapper._original = _original_torch_generator
 
-        def __instancecheck__(cls, instance):
-            # Check if instance is a torch._C.Generator (the actual C class)
-            return isinstance(instance, _original_c_generator)
-
-        def __subclasscheck__(cls, subclass):
-            # Check if subclass is or inherits from torch._C.Generator
-            if subclass is _original_c_generator:
-                return True
-            return super().__subclasscheck__(subclass)
-
-    class GeneratorWrapper(metaclass=GeneratorMeta):
-        """Wrapper for torch.Generator that translates cuda -> musa."""
-
-        def __new__(cls, device=None):
-            # Translate device if needed
-            if device is not None:
-                device = _translate_device(device)
-            return _original_torch_generator(device=device)
-
-    # Copy over class attributes
+    # Copy over doc but keep __module__ as torchada._patch so pickle can find the class
     GeneratorWrapper.__doc__ = _original_torch_generator.__doc__
-    GeneratorWrapper.__module__ = _original_torch_generator.__module__
 
     torch.Generator = GeneratorWrapper
 
@@ -1053,8 +1062,8 @@ def _patch_library_impl():
         bound = sig.bind(self, *args, **kwargs)
         bound.apply_defaults()
 
-        if bound.arguments.get('dispatch_key') in cuda_dispatch_key_map:
-            bound.arguments['dispatch_key'] = cuda_dispatch_key_map[bound.arguments['dispatch_key']]
+        if bound.arguments.get("dispatch_key") in cuda_dispatch_key_map:
+            bound.arguments["dispatch_key"] = cuda_dispatch_key_map[bound.arguments["dispatch_key"]]
 
         return original_impl(*bound.args, **bound.kwargs)
 

--- a/tests/test_cuda_patching.py
+++ b/tests/test_cuda_patching.py
@@ -828,6 +828,61 @@ class TestTorchGenerator:
         assert not isinstance(None, torch.Generator)
         assert not isinstance(torch.tensor([1, 2, 3]), torch.Generator)
 
+    def test_generator_class_is_picklable(self):
+        """Test that torch.Generator class can be pickled.
+
+        This is a regression test for multiprocessing serialization.
+        When GeneratorWrapper was a local class inside _patch_torch_generator(),
+        pickle.dumps(torch.Generator) would fail with:
+            Can't pickle local object '_patch_torch_generator.<locals>.GeneratorWrapper'
+        """
+        import pickle
+
+        import torch
+
+        import torchada  # noqa: F401
+
+        # The class itself must be picklable for multiprocessing RPC
+        data = pickle.dumps(torch.Generator)
+        restored = pickle.loads(data)
+        assert restored is torch.Generator
+
+    @pytest.mark.gpu
+    def test_generator_instance_is_picklable(self):
+        """Test that torch.Generator instances can be pickled.
+
+        Generators created via torch.Generator(device='cuda') on MUSA must
+        survive pickle round-trips used by multiprocessing executors.
+        """
+        import pickle
+
+        import torch
+
+        import torchada  # noqa: F401
+
+        gen = torch.Generator(device="cuda").manual_seed(42)
+        data = pickle.dumps(gen)
+        restored = pickle.loads(data)
+        assert isinstance(restored, torch.Generator)
+
+    def test_generator_picklable_in_container(self):
+        """Test that a generator stored in a container can be pickled.
+
+        Simulates the real-world pattern where a generator is passed inside a
+        sampling params dict/tuple that gets serialized for multiprocessing RPC.
+        """
+        import pickle
+
+        import torch
+
+        import torchada  # noqa: F401
+
+        gen = torch.Generator().manual_seed(123)
+        params = {"generator": gen, "height": 512, "width": 512}
+        data = pickle.dumps(params)
+        restored = pickle.loads(data)
+        assert isinstance(restored["generator"], torch.Generator)
+
 
 class TestTorchVersionCuda:
     """Test torch.version.cuda is NOT patched.
@@ -1135,8 +1190,9 @@ class TestIsCompiledAndBackends:
 
         # Save original state
         original = torch.backends.cuda.matmul.fp32_precision
-        assert original in valid_precisions, \
-            f"fp32_precision value '{original}' not in expected set {valid_precisions}"
+        assert (
+            original in valid_precisions
+        ), f"fp32_precision value '{original}' not in expected set {valid_precisions}"
 
         # Test setting values
         for test_value in test_values:
@@ -1414,8 +1470,9 @@ class TestLibraryImpl:
 
         def identity_allow_override_1(x: torch.Tensor) -> torch.Tensor:
             return x
+
         def doubled_allow_override_2(x: torch.Tensor) -> torch.Tensor:
-            return 2*x
+            return 2 * x
 
         test_lib.define("test_op(Tensor x) -> Tensor")
         test_lib.impl("test_op", identity_allow_override_1, "CPU")
@@ -1477,12 +1534,19 @@ class TestLibraryImpl:
 
         def identity_allow_override_with_keyset_1(keyset, x: torch.Tensor) -> torch.Tensor:
             return x
+
         def doubled_allow_override_with_keyset_2(keyset, x: torch.Tensor) -> torch.Tensor:
-            return 2*x
+            return 2 * x
 
         test_lib.define("test_op(Tensor x) -> Tensor")
         test_lib.impl("test_op", identity_allow_override_with_keyset_1, "CPU", with_keyset=True)
-        test_lib.impl("test_op", doubled_allow_override_with_keyset_2, "CPU", with_keyset=True, allow_override=True)
+        test_lib.impl(
+            "test_op",
+            doubled_allow_override_with_keyset_2,
+            "CPU",
+            with_keyset=True,
+            allow_override=True,
+        )
 
         x = torch.randn(3)
         op = getattr(torch.ops, lib_name)


### PR DESCRIPTION
```bash
root@xiaodongye-s80:/ws# pytest -v ./tests/
================================================================ test session starts ================================================================
platform linux -- Python 3.10.12, pytest-7.2.2, pluggy-1.6.0 -- /usr/bin/python
cachedir: .pytest_cache
hypothesis profile 'default'
rootdir: /ws
plugins: hypothesis-6.150.0, anyio-4.12.0
collected 311 items                                                                                                                                 

tests/test_cpp_extension.py::TestCppExtensionImports::test_import_cuda_home PASSED                                                            [  0%]
tests/test_cpp_extension.py::TestCppExtensionImports::test_import_cuda_extension PASSED                                                       [  0%]
tests/test_cpp_extension.py::TestCppExtensionImports::test_import_build_extension PASSED                                                      [  0%]
tests/test_cpp_extension.py::TestCppExtensionImports::test_cuda_home_on_musa PASSED                                                           [  1%]
tests/test_cpp_extension.py::TestCppExtensionImports::test_torch_cpp_extension_is_patched PASSED                                              [  1%]
tests/test_cpp_extension.py::TestCppExtensionImports::test_torch_cpp_extension_cuda_home_same_as_torchada PASSED                              [  1%]
tests/test_cpp_extension.py::TestCUDAExtension::test_create_extension_basic PASSED                                                            [  2%]
tests/test_cpp_extension.py::TestCUDAExtension::test_create_extension_with_include_dirs PASSED                                                [  2%]
tests/test_cpp_extension.py::TestCUDAExtension::test_create_extension_with_extra_compile_args PASSED                                          [  2%]
tests/test_cpp_extension.py::TestMusaPatches::test_is_musa_file_recognizes_cu PASSED                                                          [  3%]
tests/test_cpp_extension.py::TestMusaPatches::test_is_musa_file_recognizes_cuh PASSED                                                         [  3%]
tests/test_cpp_extension.py::TestMusaPatches::test_is_musa_file_recognizes_mu PASSED                                                          [  3%]
tests/test_cpp_extension.py::TestMusaPatches::test_ext_replaced_mapping PASSED                                                                [  4%]
tests/test_cpp_extension.py::TestMusaPatches::test_mapping_rule_exists PASSED                                                                 [  4%]
tests/test_cpp_extension.py::TestMusaPatches::test_mapping_rule_has_expected_entries PASSED                                                   [  4%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_is_patched_on_musa PASSED                                                   [  5%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_is_available PASSED                                                         [  5%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_device_count PASSED                                                         [  5%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_device_count_nvml PASSED                                                    [  6%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_current_device PASSED                                                       [  6%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_get_device_name PASSED                                                      [  6%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_synchronize PASSED                                                          [  7%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_empty_cache PASSED                                                          [  7%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_memory_allocated PASSED                                                     [  7%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_memory_reserved PASSED                                                      [  8%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_set_device PASSED                                                           [  8%]
tests/test_cuda_patching.py::TestTorchCudaLazyInit::test_import_lazy_call PASSED                                                              [  8%]
tests/test_cuda_patching.py::TestTorchCudaLazyInit::test_lazy_call_functionality PASSED                                                       [  9%]
tests/test_cuda_patching.py::TestTorchCudaAmp::test_import_autocast PASSED                                                                    [  9%]
tests/test_cuda_patching.py::TestTorchCudaAmp::test_import_grad_scaler PASSED                                                                 [  9%]
tests/test_cuda_patching.py::TestTorchCudaAmp::test_autocast_context_manager PASSED                                                           [  9%]
tests/test_cuda_patching.py::TestTorchCudaAmp::test_grad_scaler_creation PASSED                                                               [ 10%]
tests/test_cuda_patching.py::TestCUDAGraph::test_cuda_graph_alias PASSED                                                                      [ 10%]
tests/test_cuda_patching.py::TestCUDAGraph::test_cuda_graph_is_musa_graph PASSED                                                              [ 10%]
tests/test_cuda_patching.py::TestCUDAGraph::test_cuda_graph_creation PASSED                                                                   [ 11%]
tests/test_cuda_patching.py::TestCUDAGraph::test_graphs_module PASSED                                                                         [ 11%]
tests/test_cuda_patching.py::TestCUDAGraph::test_make_graphed_callables PASSED                                                                [ 11%]
tests/test_cuda_patching.py::TestCUDAGraph::test_graph_pool_handle PASSED                                                                     [ 12%]
tests/test_cuda_patching.py::TestCUDAGraph::test_graph_context_manager_cuda_graph_keyword PASSED                                              [ 12%]
tests/test_cuda_patching.py::TestCUDAGraph::test_graph_context_manager_positional PASSED                                                      [ 12%]
tests/test_cuda_patching.py::TestCUDAGraph::test_graph_context_manager_musa_graph_keyword PASSED                                              [ 13%]
tests/test_cuda_patching.py::TestCUDAGraph::test_graph_context_manager_missing_arg_raises PASSED                                              [ 13%]
tests/test_cuda_patching.py::TestCUDAGraph::test_graph_context_manager_with_pool_and_stream PASSED                                            [ 13%]
tests/test_cuda_patching.py::TestDistributedBackend::test_original_init_available PASSED                                                      [ 14%]
tests/test_cuda_patching.py::TestDistributedBackend::test_mccl_backend_available PASSED                                                       [ 14%]
tests/test_cuda_patching.py::TestDistributedBackend::test_nccl_backend_available PASSED                                                       [ 14%]
tests/test_cuda_patching.py::TestDistributedBackend::test_new_group_patched PASSED                                                            [ 15%]
tests/test_cuda_patching.py::TestDistributedBackend::test_has_param_with_mock_functions PASSED                                                [ 15%]
tests/test_cuda_patching.py::TestDistributedBackend::test_new_group_device_id_param_compatibility PASSED                                      [ 15%]
tests/test_cuda_patching.py::TestNCCLModule::test_mccl_module_available PASSED                                                                [ 16%]
tests/test_cuda_patching.py::TestRNGFunctions::test_get_rng_state PASSED                                                                      [ 16%]
tests/test_cuda_patching.py::TestRNGFunctions::test_set_rng_state PASSED                                                                      [ 16%]
tests/test_cuda_patching.py::TestRNGFunctions::test_manual_seed PASSED                                                                        [ 17%]
tests/test_cuda_patching.py::TestRNGFunctions::test_manual_seed_all PASSED                                                                    [ 17%]
tests/test_cuda_patching.py::TestRNGFunctions::test_seed PASSED                                                                               [ 17%]
tests/test_cuda_patching.py::TestRNGFunctions::test_initial_seed PASSED                                                                       [ 18%]
tests/test_cuda_patching.py::TestRNGFunctions::test_manual_seed_works PASSED                                                                  [ 18%]
tests/test_cuda_patching.py::TestRandomFunctions::test_cuda_random_module_available PASSED                                                    [ 18%]
tests/test_cuda_patching.py::TestRandomFunctions::test_cuda_random_aliases_musa PASSED                                                        [ 18%]
tests/test_cuda_patching.py::TestRandomFunctions::test_cuda_random_functionality PASSED                                                       [ 19%]
tests/test_cuda_patching.py::TestMemoryFunctions::test_max_memory_allocated PASSED                                                            [ 19%]
tests/test_cuda_patching.py::TestMemoryFunctions::test_max_memory_reserved PASSED                                                             [ 19%]
tests/test_cuda_patching.py::TestMemoryFunctions::test_memory_stats PASSED                                                                    [ 20%]
tests/test_cuda_patching.py::TestMemoryFunctions::test_memory_summary PASSED                                                                  [ 20%]
tests/test_cuda_patching.py::TestMemoryFunctions::test_memory_snapshot PASSED                                                                 [ 20%]
tests/test_cuda_patching.py::TestMemoryFunctions::test_reset_peak_memory_stats PASSED                                                         [ 21%]
tests/test_cuda_patching.py::TestMemoryFunctions::test_mem_get_info PASSED                                                                    [ 21%]
tests/test_cuda_patching.py::TestStreamAndEvent::test_stream_class PASSED                                                                     [ 21%]
tests/test_cuda_patching.py::TestStreamAndEvent::test_event_class PASSED                                                                      [ 22%]
tests/test_cuda_patching.py::TestStreamAndEvent::test_external_stream_class PASSED                                                            [ 22%]
tests/test_cuda_patching.py::TestStreamAndEvent::test_current_stream PASSED                                                                   [ 22%]
tests/test_cuda_patching.py::TestStreamAndEvent::test_default_stream PASSED                                                                   [ 23%]
tests/test_cuda_patching.py::TestStreamAndEvent::test_set_stream PASSED                                                                       [ 23%]
tests/test_cuda_patching.py::TestStreamAndEvent::test_stream_context_manager PASSED                                                           [ 23%]
tests/test_cuda_patching.py::TestStreamAndEvent::test_stream_context_class PASSED                                                             [ 24%]
tests/test_cuda_patching.py::TestStreamAndEvent::test_stream_cuda_stream_property PASSED                                                      [ 24%]
tests/test_cuda_patching.py::TestContextManagers::test_device_context_manager PASSED                                                          [ 24%]
tests/test_cuda_patching.py::TestContextManagers::test_device_of_context_manager PASSED                                                       [ 25%]
tests/test_cuda_patching.py::TestDeviceFunctions::test_get_device_properties PASSED                                                           [ 25%]
tests/test_cuda_patching.py::TestDeviceFunctions::test_get_device_capability PASSED                                                           [ 25%]
tests/test_cuda_patching.py::TestDeviceFunctions::test_is_initialized PASSED                                                                  [ 26%]
tests/test_cuda_patching.py::TestTorchGenerator::test_generator_cuda_device PASSED                                                            [ 26%]
tests/test_cuda_patching.py::TestTorchGenerator::test_generator_cuda_device_index PASSED                                                      [ 26%]
tests/test_cuda_patching.py::TestTorchGenerator::test_generator_musa_device PASSED                                                            [ 27%]
tests/test_cuda_patching.py::TestTorchGenerator::test_generator_no_device PASSED                                                              [ 27%]
tests/test_cuda_patching.py::TestTorchGenerator::test_generator_manual_seed_chain PASSED                                                      [ 27%]
tests/test_cuda_patching.py::TestTorchGenerator::test_generator_isinstance_check PASSED                                                       [ 27%]
tests/test_cuda_patching.py::TestTorchGenerator::test_generator_isinstance_negative PASSED                                                    [ 28%]
tests/test_cuda_patching.py::TestTorchGenerator::test_generator_class_is_picklable PASSED                                                     [ 28%]
tests/test_cuda_patching.py::TestTorchGenerator::test_generator_instance_is_picklable PASSED                                                  [ 28%]
tests/test_cuda_patching.py::TestTorchGenerator::test_generator_picklable_in_container PASSED                                                 [ 29%]
tests/test_cuda_patching.py::TestTorchVersionCuda::test_torch_version_cuda_not_patched PASSED                                                 [ 29%]
tests/test_cuda_patching.py::TestTensorIsCuda::test_cpu_tensor_is_cuda_false PASSED                                                           [ 29%]
tests/test_cuda_patching.py::TestTensorIsCuda::test_musa_tensor_is_cuda_true PASSED                                                           [ 30%]
tests/test_cuda_patching.py::TestAutotuneProcess::test_cuda_visible_devices_patched PASSED                                                    [ 30%]
tests/test_cuda_patching.py::TestAutotuneProcess::test_cuda_visible_devices_is_string PASSED                                                  [ 30%]
tests/test_cuda_patching.py::TestAutotuneProcess::test_cuda_visible_devices_env_var_format PASSED                                             [ 31%]
tests/test_cuda_patching.py::TestNvtxStub::test_nvtx_module_available PASSED                                                                  [ 31%]
tests/test_cuda_patching.py::TestNvtxStub::test_nvtx_mark PASSED                                                                              [ 31%]
tests/test_cuda_patching.py::TestNvtxStub::test_nvtx_range_push_pop PASSED                                                                    [ 32%]
tests/test_cuda_patching.py::TestNvtxStub::test_nvtx_range_context_manager PASSED                                                             [ 32%]
tests/test_cuda_patching.py::TestPatchDecorators::test_patch_registry_is_populated PASSED                                                     [ 32%]
tests/test_cuda_patching.py::TestPatchDecorators::test_patch_registry_contains_expected_functions PASSED                                      [ 33%]
tests/test_cuda_patching.py::TestPatchDecorators::test_requires_import_decorator_guards_import PASSED                                         [ 33%]
tests/test_cuda_patching.py::TestPatchDecorators::test_requires_import_decorator_allows_execution PASSED                                      [ 33%]
tests/test_cuda_patching.py::TestPatchDecorators::test_requires_import_multiple_modules PASSED                                                [ 34%]
tests/test_cuda_patching.py::TestIsCompiledAndBackends::test_torch_musa_is_compiled PASSED                                                    [ 34%]
tests/test_cuda_patching.py::TestIsCompiledAndBackends::test_torch_cuda_is_compiled_redirects PASSED                                          [ 34%]
tests/test_cuda_patching.py::TestIsCompiledAndBackends::test_torch_backends_cuda_is_built PASSED                                              [ 35%]
tests/test_cuda_patching.py::TestIsCompiledAndBackends::test_torch_backends_cuda_matmul_allow_tf32 PASSED                                     [ 35%]
tests/test_cuda_patching.py::TestIsCompiledAndBackends::test_torch_backends_cuda_matmul_fp32_precision PASSED                                 [ 35%]
tests/test_cuda_patching.py::TestIsCompiledAndBackends::test_torch_c_storage_use_count PASSED                                                 [ 36%]
tests/test_cuda_patching.py::TestProfilerActivity::test_profiler_activity_cuda_accessible PASSED                                              [ 36%]
tests/test_cuda_patching.py::TestProfilerActivity::test_profiler_with_cuda_activity PASSED                                                    [ 36%]
tests/test_cuda_patching.py::TestProfilerActivity::test_profiler_context_manager PASSED                                                       [ 36%]
tests/test_cuda_patching.py::TestProfilerActivity::test_profiler_methods_accessible PASSED                                                    [ 37%]
tests/test_cuda_patching.py::TestMusaWarnings::test_musa_warnings_patch_applied PASSED                                                        [ 37%]
tests/test_cuda_patching.py::TestMusaWarnings::test_autocast_warning_suppressed PASSED                                                        [ 37%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_cuda_translated PASSED                                                        [ 38%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_with_keyset PASSED                                                            [ 38%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_with_keyset_false_explicit PASSED                                             [ 38%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_op_name_as_keyword PASSED                                                     [ 39%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_with_allow_override SKIPPED (allow_override parameter requires PyTorch 2....) [ 39%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_allow_override_false_explicit SKIPPED (allow_override parameter requires ...) [ 39%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_with_keyset_and_with_allow_override SKIPPED (allow_override parameter req...) [ 40%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_fn_as_keyword PASSED                                                          [ 40%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_dispatch_key_as_keyword PASSED                                                [ 40%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_cuda_with_keyset PASSED                                                       [ 41%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_autograd_cuda_translation PASSED                                              [ 41%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_opoverload_as_op_name PASSED                                                  [ 41%]
tests/test_cuda_patching.py::TestCudart::test_cudart_returns_wrapper PASSED                                                                   [ 42%]
tests/test_cuda_patching.py::TestCudart::test_cudart_host_register PASSED                                                                     [ 42%]
tests/test_cuda_patching.py::TestCudart::test_cudart_in_dir PASSED                                                                            [ 42%]
tests/test_cuda_patching.py::TestCppExtensionPaths::test_include_paths_with_cuda_param PASSED                                                 [ 43%]
tests/test_cuda_patching.py::TestCppExtensionPaths::test_include_paths_with_device_type_param PASSED                                          [ 43%]
tests/test_cuda_patching.py::TestCppExtensionPaths::test_include_paths_default PASSED                                                         [ 43%]
tests/test_cuda_patching.py::TestCppExtensionPaths::test_library_paths_with_cuda_param PASSED                                                 [ 44%]
tests/test_cuda_patching.py::TestCppExtensionPaths::test_library_paths_with_device_type_param PASSED                                          [ 44%]
tests/test_cuda_patching.py::TestCppExtensionPaths::test_library_paths_default PASSED                                                         [ 44%]
tests/test_cuda_patching.py::TestCppExtensionPaths::test_include_paths_patched_in_torch_module PASSED                                         [ 45%]
tests/test_cuda_patching.py::TestCppExtensionPaths::test_library_paths_patched_in_torch_module PASSED                                         [ 45%]
tests/test_cuda_patching.py::TestCppExtensionPaths::test_get_torch_include_paths_pattern PASSED                                               [ 45%]
tests/test_cuda_patching.py::TestTensorFactoryFunctions::test_asarray_with_cuda_device PASSED                                                 [ 45%]
tests/test_cuda_patching.py::TestTensorFactoryFunctions::test_asarray_with_cuda_index PASSED                                                  [ 46%]
tests/test_cuda_patching.py::TestTensorFactoryFunctions::test_asarray_without_device PASSED                                                   [ 46%]
tests/test_cuda_patching.py::TestTensorFactoryFunctions::test_tensor_with_cuda_device PASSED                                                  [ 46%]
tests/test_cuda_patching.py::TestTensorFactoryFunctions::test_zeros_with_cuda_device SKIPPED (MUDNN kernel execution failed (expected in ...) [ 47%]
tests/test_cuda_patching.py::TestTensorFactoryFunctions::test_ones_with_cuda_device SKIPPED (MUDNN kernel execution failed (expected in t...) [ 47%]
tests/test_cuda_patching.py::TestTensorFactoryFunctions::test_randn_with_cuda_device SKIPPED (MUDNN kernel execution failed (expected in ...) [ 47%]
tests/test_cuda_patching.py::TestTensorFactoryFunctions::test_empty_with_cuda_device PASSED                                                   [ 48%]
tests/test_cuda_patching.py::TestCppOpsInfrastructure::test_cpp_ops_module_exists PASSED                                                      [ 48%]
tests/test_cuda_patching.py::TestCppOpsInfrastructure::test_cpp_ops_not_loaded_by_default PASSED                                              [ 48%]
tests/test_cuda_patching.py::TestCppOpsInfrastructure::test_cpp_ops_source_files_exist PASSED                                                 [ 49%]
tests/test_cuda_patching.py::TestCppOpsInfrastructure::test_cpp_ops_header_content PASSED                                                     [ 49%]
tests/test_cuda_patching.py::TestValidateDevice::test_musa_device_should_pass SKIPPED (MUDNN kernel execution failed (expected in test co...) [ 49%]
tests/test_cuda_patching.py::TestValidateDevice::test_patch_when_attribute_missing PASSED                                                     [ 50%]
tests/test_cuda_patching.py::TestFlashAttnPatching::test_sgl_kernel_flash_attn_import_when_flash_attn_available PASSED                        [ 50%]
tests/test_cuda_patching.py::TestFlashAttnPatching::test_sgl_kernel_flash_attn_module_in_sys_modules PASSED                                   [ 50%]
tests/test_cuda_patching.py::TestFlashAttnPatching::test_sgl_kernel_stub_created_when_sgl_kernel_not_installed PASSED                         [ 51%]
tests/test_cuda_patching.py::TestFlashAttnPatching::test_sgl_kernel_existing_module_preserved PASSED                                          [ 51%]
tests/test_cuda_patching.py::TestFlashAttnPatching::test_real_sgl_kernel_not_replaced_by_stub PASSED                                          [ 51%]
tests/test_cuda_patching.py::TestFlashAttnPatching::test_flash_attn_direct_import_still_works PASSED                                          [ 52%]
tests/test_cuda_patching.py::TestFlashAttnPatching::test_flash_attn_interface_submodule_accessible PASSED                                     [ 52%]
tests/test_cuda_patching.py::TestFlashAttnPatching::test_patch_skipped_when_flash_attn_not_available SKIPPED (flash_attn is available - t...) [ 52%]
tests/test_cuda_patching.py::TestFlashAttnPatching::test_multiple_flash_attn_functions_accessible PASSED                                      [ 53%]
tests/test_device_strings.py::TestTensorDevicePatching::test_tensor_cuda_method PASSED                                                        [ 53%]
tests/test_device_strings.py::TestTensorDevicePatching::test_tensor_to_cuda_string PASSED                                                     [ 53%]
tests/test_device_strings.py::TestTensorDevicePatching::test_tensor_to_cuda_device_index PASSED                                               [ 54%]
tests/test_device_strings.py::TestTensorDevicePatching::test_tensor_to_torch_device PASSED                                                    [ 54%]
tests/test_device_strings.py::TestModuleDevicePatching::test_module_cuda_method PASSED                                                        [ 54%]
tests/test_device_strings.py::TestModuleDevicePatching::test_module_to_cuda PASSED                                                            [ 54%]
tests/test_device_strings.py::TestFactoryFunctions::test_torch_empty_device_cuda PASSED                                                       [ 55%]
tests/test_device_strings.py::TestFactoryFunctions::test_torch_zeros_device_cuda PASSED                                                       [ 55%]
tests/test_device_strings.py::TestFactoryFunctions::test_torch_ones_device_cuda PASSED                                                        [ 55%]
tests/test_device_strings.py::TestFactoryFunctions::test_torch_randn_device_cuda PASSED                                                       [ 56%]
tests/test_device_strings.py::TestFactoryFunctions::test_torch_rand_device_cuda PASSED                                                        [ 56%]
tests/test_device_strings.py::TestFactoryFunctions::test_torch_full_device_cuda PASSED                                                        [ 56%]
tests/test_device_strings.py::TestFactoryFunctions::test_torch_arange_device_cuda PASSED                                                      [ 57%]
tests/test_device_strings.py::TestFactoryFunctions::test_torch_linspace_device_cuda PASSED                                                    [ 57%]
tests/test_device_strings.py::TestTranslateDeviceFunction::test_translate_device_none PASSED                                                  [ 57%]
tests/test_device_strings.py::TestTranslateDeviceFunction::test_translate_device_cuda_string PASSED                                           [ 58%]
tests/test_device_strings.py::TestTranslateDeviceFunction::test_translate_device_cuda_with_index PASSED                                       [ 58%]
tests/test_device_strings.py::TestTranslateDeviceFunction::test_translate_device_cpu_unchanged PASSED                                         [ 58%]
tests/test_device_strings.py::TestTranslateDeviceFunction::test_translate_device_musa_unchanged PASSED                                        [ 59%]
tests/test_device_strings.py::TestTranslateDeviceFunction::test_translate_device_integer_unchanged PASSED                                     [ 59%]
tests/test_device_strings.py::TestTranslateDeviceFunction::test_translate_device_torch_device_cuda PASSED                                     [ 59%]
tests/test_device_strings.py::TestTranslateDeviceFunction::test_translate_device_torch_device_cuda_with_index PASSED                          [ 60%]
tests/test_device_strings.py::TestTranslateDeviceFunction::test_translate_device_torch_device_cpu_unchanged PASSED                            [ 60%]
tests/test_device_strings.py::TestDeviceIndexVariants::test_cuda_colon_zero PASSED                                                            [ 60%]
tests/test_device_strings.py::TestDeviceIndexVariants::test_factory_with_cuda_index PASSED                                                    [ 61%]
tests/test_device_strings.py::TestDeviceIndexVariants::test_torch_device_cuda_zero PASSED                                                     [ 61%]
tests/test_device_strings.py::TestDeviceIndexVariants::test_torch_device_with_index_arg PASSED                                                [ 61%]
tests/test_device_strings.py::TestDeviceIndexVariants::test_torch_device_from_original_cuda_device PASSED                                     [ 62%]
tests/test_device_strings.py::TestDeviceIndexVariants::test_torch_device_type_keyword PASSED                                                  [ 62%]
tests/test_device_strings.py::TestDeviceContextManager::test_device_context_with_musa PASSED                                                  [ 62%]
tests/test_device_strings.py::TestDeviceContextManager::test_device_context_with_cuda_translated PASSED                                       [ 63%]
tests/test_device_strings.py::TestDeviceContextManager::test_original_functions_in_device_constructors PASSED                                 [ 63%]
tests/test_extension_build.py::TestExtensionBuildSetup::test_vector_add_cu_exists PASSED                                                      [ 63%]
tests/test_extension_build.py::TestExtensionBuildSetup::test_can_create_setup_py PASSED                                                       [ 63%]
tests/test_extension_build.py::TestExtensionBuild::test_build_vector_add_extension SKIPPED (Extension build tests are slow; set TORCHADA_...) [ 64%]
tests/test_extension_build.py::TestExtensionBuild::test_run_vector_add_extension SKIPPED (Extension build tests are slow; set TORCHADA_TE...) [ 64%]
tests/test_extension_build.py::TestMixedSourcesBuild::test_mixed_sources_dir_exists SKIPPED (Extension build tests are slow; set TORCHADA...) [ 64%]
tests/test_extension_build.py::TestMixedSourcesBuild::test_all_source_files_exist SKIPPED (Extension build tests are slow; set TORCHADA_T...) [ 65%]
tests/test_extension_build.py::TestMixedSourcesBuild::test_build_mixed_sources_extension SKIPPED (Extension build tests are slow; set TOR...) [ 65%]
tests/test_extension_build.py::TestMixedSourcesBuild::test_run_mixed_sources_extension SKIPPED (Extension build tests are slow; set TORCH...) [ 65%]
tests/test_extension_build.py::TestSameNameFilePrecedence::test_same_name_dir_exists SKIPPED (Extension build tests are slow; set TORCHAD...) [ 66%]
tests/test_extension_build.py::TestSameNameFilePrecedence::test_both_cu_and_mu_exist SKIPPED (Extension build tests are slow; set TORCHAD...) [ 66%]
tests/test_extension_build.py::TestSameNameFilePrecedence::test_mu_file_takes_precedence SKIPPED (Extension build tests are slow; set TOR...) [ 66%]
tests/test_mappings.py::TestMappingImports::test_import_mapping_rule PASSED                                                                   [ 67%]
tests/test_mappings.py::TestMappingImports::test_import_ext_replaced_mapping PASSED                                                           [ 67%]
tests/test_mappings.py::TestATenMappings::test_aten_cuda_namespace PASSED                                                                     [ 67%]
tests/test_mappings.py::TestATenMappings::test_aten_cuda_includes PASSED                                                                      [ 68%]
tests/test_mappings.py::TestC10Mappings::test_c10_cuda_namespace PASSED                                                                       [ 68%]
tests/test_mappings.py::TestC10Mappings::test_c10_device_type PASSED                                                                          [ 68%]
tests/test_mappings.py::TestTorchMappings::test_torch_cuda_namespace PASSED                                                                   [ 69%]
tests/test_mappings.py::TestTorchMappings::test_torch_device_type PASSED                                                                      [ 69%]
tests/test_mappings.py::TestCuBLASMappings::test_cublas_basic PASSED                                                                          [ 69%]
tests/test_mappings.py::TestCuBLASMappings::test_cublas_types PASSED                                                                          [ 70%]
tests/test_mappings.py::TestCuBLASMappings::test_cublas_functions PASSED                                                                      [ 70%]
tests/test_mappings.py::TestCuBLASMappings::test_cublas_gemm PASSED                                                                           [ 70%]
tests/test_mappings.py::TestCuBLASMappings::test_cublas_batched PASSED                                                                        [ 71%]
tests/test_mappings.py::TestCuBLASMappings::test_cublaslt PASSED                                                                              [ 71%]
tests/test_mappings.py::TestCuRANDMappings::test_curand_basic PASSED                                                                          [ 71%]
tests/test_mappings.py::TestCuRANDMappings::test_curand_types PASSED                                                                          [ 72%]
tests/test_mappings.py::TestCuRANDMappings::test_curand_functions PASSED                                                                      [ 72%]
tests/test_mappings.py::TestCuDNNMappings::test_cudnn_basic PASSED                                                                            [ 72%]
tests/test_mappings.py::TestCuDNNMappings::test_cudnn_types PASSED                                                                            [ 72%]
tests/test_mappings.py::TestCuDNNMappings::test_cudnn_functions PASSED                                                                        [ 73%]
tests/test_mappings.py::TestCUDARuntimeMappings::test_memory_functions PASSED                                                                 [ 73%]
tests/test_mappings.py::TestCUDARuntimeMappings::test_host_memory_functions PASSED                                                            [ 73%]
tests/test_mappings.py::TestCUDARuntimeMappings::test_async_memory_functions PASSED                                                           [ 74%]
tests/test_mappings.py::TestCUDARuntimeMappings::test_device_functions PASSED                                                                 [ 74%]
tests/test_mappings.py::TestCUDARuntimeMappings::test_memcpy_kinds PASSED                                                                     [ 74%]
tests/test_mappings.py::TestCUDARuntimeMappings::test_memory_constants PASSED                                                                 [ 75%]
tests/test_mappings.py::TestStreamEventMappings::test_stream_types PASSED                                                                     [ 75%]
tests/test_mappings.py::TestStreamEventMappings::test_stream_functions PASSED                                                                 [ 75%]
tests/test_mappings.py::TestStreamEventMappings::test_stream_flags PASSED                                                                     [ 76%]
tests/test_mappings.py::TestStreamEventMappings::test_event_functions PASSED                                                                  [ 76%]
tests/test_mappings.py::TestStreamEventMappings::test_event_flags PASSED                                                                      [ 76%]
tests/test_mappings.py::TestErrorHandlingMappings::test_error_types PASSED                                                                    [ 77%]
tests/test_mappings.py::TestErrorHandlingMappings::test_error_functions PASSED                                                                [ 77%]
tests/test_mappings.py::TestErrorHandlingMappings::test_error_codes PASSED                                                                    [ 77%]
tests/test_mappings.py::TestNCCLMappings::test_nccl_basic PASSED                                                                              [ 78%]
tests/test_mappings.py::TestNCCLMappings::test_nccl_types PASSED                                                                              [ 78%]
tests/test_mappings.py::TestNCCLMappings::test_nccl_comm_functions PASSED                                                                     [ 78%]
tests/test_mappings.py::TestNCCLMappings::test_nccl_collective_functions PASSED                                                               [ 79%]
tests/test_mappings.py::TestLibraryMappings::test_cusparse PASSED                                                                             [ 79%]
tests/test_mappings.py::TestLibraryMappings::test_cusolver PASSED                                                                             [ 79%]
tests/test_mappings.py::TestLibraryMappings::test_cufft PASSED                                                                                [ 80%]
tests/test_mappings.py::TestLibraryMappings::test_cutlass PASSED                                                                              [ 80%]
tests/test_mappings.py::TestLibraryMappings::test_cub PASSED                                                                                  [ 80%]
tests/test_mappings.py::TestLibraryMappings::test_thrust PASSED                                                                               [ 81%]
tests/test_mappings.py::TestIntrinsicMappings::test_shuffle_intrinsics_not_mapped PASSED                                                      [ 81%]
tests/test_mappings.py::TestIntrinsicMappings::test_vote_intrinsics_not_mapped PASSED                                                         [ 81%]
tests/test_mappings.py::TestIntrinsicMappings::test_sync_intrinsics_not_mapped PASSED                                                         [ 81%]
tests/test_mappings.py::TestIntrinsicMappings::test_atomic_operations_not_mapped PASSED                                                       [ 82%]
tests/test_mappings.py::TestIntrinsicMappings::test_half_precision_not_mapped PASSED                                                          [ 82%]
tests/test_mappings.py::TestIncludeMappings::test_cuda_headers PASSED                                                                         [ 82%]
tests/test_mappings.py::TestPyTorchCppMappings::test_pytorch_stream_utils PASSED                                                              [ 83%]
tests/test_mappings.py::TestPyTorchCppMappings::test_pytorch_guards PASSED                                                                    [ 83%]
tests/test_mappings.py::TestPyTorchCppMappings::test_pytorch_handle PASSED                                                                    [ 83%]
tests/test_mappings.py::TestPyTorchCppMappings::test_pytorch_torch_namespace PASSED                                                           [ 84%]
tests/test_mappings.py::TestCUDADriverMappings::test_memory_constants PASSED                                                                  [ 84%]
tests/test_mappings.py::TestMappingCount::test_mapping_count PASSED                                                                           [ 84%]
tests/test_mappings.py::TestMappingCount::test_ext_replaced_mapping PASSED                                                                    [ 85%]
tests/test_mappings.py::TestMappingRobustness::test_no_identity_mappings PASSED                                                               [ 85%]
tests/test_mappings.py::TestMappingRobustness::test_no_empty_keys_or_values PASSED                                                            [ 85%]
tests/test_mappings.py::TestMappingRobustness::test_all_keys_and_values_are_strings PASSED                                                    [ 86%]
tests/test_mappings.py::TestMappingRobustness::test_cuda_to_musa_consistency PASSED                                                           [ 86%]
tests/test_mappings.py::TestMappingApplication::test_port_cuda_source_basic PASSED                                                            [ 86%]
tests/test_mappings.py::TestMappingApplication::test_port_cuda_source_includes PASSED                                                         [ 87%]
tests/test_mappings.py::TestMappingApplication::test_port_cuda_source_types PASSED                                                            [ 87%]
tests/test_mappings.py::TestMappingApplication::test_port_cuda_source_functions PASSED                                                        [ 87%]
tests/test_mappings.py::TestMappingApplication::test_port_cuda_source_preserves_non_cuda PASSED                                               [ 88%]
tests/test_mappings.py::TestMappingApplication::test_port_cuda_source_longer_patterns_first PASSED                                            [ 88%]
tests/test_mappings.py::TestMappingApplication::test_port_cuda_source_c10_macros PASSED                                                       [ 88%]
tests/test_mappings.py::TestMappingApplication::test_port_cuda_source_nccl PASSED                                                             [ 89%]
tests/test_mappings.py::TestMappingSubstringOrdering::test_specific_before_generic PASSED                                                     [ 89%]
tests/test_mappings.py::TestMappingSubstringOrdering::test_include_specific_paths PASSED                                                      [ 89%]
tests/test_mappings.py::TestRuntimeNameConversion::test_cuda_to_musa_name PASSED                                                              [ 90%]
tests/test_mappings.py::TestRuntimeNameConversion::test_nccl_to_mccl_name PASSED                                                              [ 90%]
tests/test_mappings.py::TestRuntimeNameConversion::test_cublas_to_mublas_name PASSED                                                          [ 90%]
tests/test_mappings.py::TestRuntimeNameConversion::test_curand_to_murand_name PASSED                                                          [ 90%]
tests/test_mappings.py::TestCDLLWrapper::test_cdll_wrapper_class_exists PASSED                                                                [ 91%]
tests/test_mappings.py::TestCDLLWrapper::test_libmusart_cuda_to_musa_translation PASSED                                                       [ 91%]
tests/test_mappings.py::TestCDLLWrapper::test_libmccl_nccl_to_mccl_translation PASSED                                                         [ 91%]
tests/test_mappings.py::TestCDLLWrapper::test_libmublas_cublas_to_mublas_translation PASSED                                                   [ 92%]
tests/test_mappings.py::TestCDLLWrapper::test_libmurand_curand_to_murand_translation PASSED                                                   [ 92%]
tests/test_mappings.py::TestCDLLWrapper::test_non_musa_lib_no_translation PASSED                                                              [ 92%]
tests/test_mappings.py::TestCDLLWrapper::test_sglang_cuda_wrapper_pattern PASSED                                                              [ 93%]
tests/test_mappings.py::TestDeviceTypeMappingCompilation::test_device_type_test_source_exists SKIPPED (Extension build tests are slow; se...) [ 93%]
tests/test_mappings.py::TestDeviceTypeMappingCompilation::test_build_device_type_extension SKIPPED (Extension build tests are slow; set T...) [ 93%]
tests/test_mappings.py::TestDeviceTypeMappingCompilation::test_run_device_type_extension SKIPPED (Extension build tests are slow; set TOR...) [ 94%]
tests/test_mappings.py::TestDeviceTypeMappingCompilation::test_ported_source_contains_privateuse1 SKIPPED (Extension build tests are slow...) [ 94%]
tests/test_platform.py::TestPlatformDetection::test_import_torchada PASSED                                                                    [ 94%]
tests/test_platform.py::TestPlatformDetection::test_detect_platform PASSED                                                                    [ 95%]
tests/test_platform.py::TestPlatformDetection::test_platform_detection_functions PASSED                                                       [ 95%]
tests/test_platform.py::TestPlatformDetection::test_patches_applied PASSED                                                                    [ 95%]
tests/test_platform.py::TestPlatformDetection::test_get_version PASSED                                                                        [ 96%]
tests/test_platform.py::TestPlatformDetection::test_get_platform PASSED                                                                       [ 96%]
tests/test_platform.py::TestPlatformDetection::test_get_backend PASSED                                                                        [ 96%]
tests/test_platform.py::TestPlatformDetection::test_is_gpu_device PASSED                                                                      [ 97%]
tests/test_platform.py::TestPlatformDetection::test_is_cuda_like_device_alias PASSED                                                          [ 97%]
tests/test_python_compat.py::TestPython38Compatibility::test_all_files_parse PASSED                                                           [ 97%]
tests/test_python_compat.py::TestPython38Compatibility::test_all_modules_importable PASSED                                                    [ 98%]
tests/test_python_compat.py::TestPython38Compatibility::test_no_builtin_generic_types PASSED                                                  [ 98%]
tests/test_python_compat.py::TestPython38Compatibility::test_no_union_type_operator PASSED                                                    [ 98%]
tests/test_python_compat.py::TestPython38Compatibility::test_no_match_statement PASSED                                                        [ 99%]
tests/test_python_compat.py::TestPython38Compatibility::test_no_removeprefix_removesuffix PASSED                                              [ 99%]
tests/test_python_compat.py::TestPython38Compatibility::test_typing_imports_used PASSED                                                       [ 99%]
tests/test_python_compat.py::TestPython38Compatibility::test_python_version_requirement PASSED                                                [100%]

========================================================== 290 passed, 21 skipped in 1.03s ==========================================================
```