### PR TITLE
feat(musa): patch torch.cuda.memory and add CUDAPluggableAllocator alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ See `src/torchada/_mapping.py` for the complete mapping table (380+ mappings).
 
 ```
 # pyproject.toml or requirements.txt
-torchada>=0.1.47
+torchada>=0.1.48
 ```
 
 ### Step 2: Conditional Import

--- a/README_CN.md
+++ b/README_CN.md
@@ -255,7 +255,7 @@ if torchada.is_gpu_device(device):  # 在 CUDA 和 MUSA 上都能工作
 
 ```
 # pyproject.toml 或 requirements.txt
-torchada>=0.1.47
+torchada>=0.1.48
 ```
 
 ### 步骤 2：条件导入

--- a/benchmarks/benchmark_history.json
+++ b/benchmarks/benchmark_history.json
@@ -3,7 +3,7 @@
   "description": "Historical benchmark results for torchada performance tracking",
   "results": [
     {
-      "version": "0.1.47",
+      "version": "0.1.48",
       "date": "2026-01-29",
       "platform": "MUSA",
       "pytorch_version": "2.7.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torchada"
-version = "0.1.47"
+version = "0.1.48"
 description = "Adapter package for torch_musa to act exactly like PyTorch CUDA"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/torchada/__init__.py
+++ b/src/torchada/__init__.py
@@ -24,7 +24,7 @@ Usage:
     from torch.utils.cpp_extension import CUDAExtension, BuildExtension, CUDA_HOME
 """
 
-__version__ = "0.1.47"
+__version__ = "0.1.48"
 
 from . import cuda, utils
 from ._patch import apply_patches, get_original_init_process_group, is_patched

--- a/src/torchada/_patch.py
+++ b/src/torchada/_patch.py
@@ -711,6 +711,16 @@ def _patch_torch_cuda_module():
         if hasattr(torch.musa, "MUSAGraph") and not hasattr(torch.musa, "CUDAGraph"):
             torch.musa.CUDAGraph = torch.musa.MUSAGraph
 
+        # Patch torch.cuda.memory
+        if hasattr(torch.musa, "memory"):
+            sys.modules["torch.cuda.memory"] = torch.musa.memory
+
+        # Add CUDAPluggableAllocator alias pointing to MUSAPluggableAllocator
+        if hasattr(torch.musa.memory, "MUSAPluggableAllocator") and not hasattr(
+            torch.musa.memory, "CUDAPluggableAllocator"
+        ):
+            torch.musa.memory.CUDAPluggableAllocator = torch.musa.memory.MUSAPluggableAllocator
+
         # Patch torch.cuda.graph context manager to accept cuda_graph= keyword
         # MUSA's graph class uses musa_graph= but CUDA code uses cuda_graph=
         _patch_graph_context_manager()

--- a/src/torchada/_patch.py
+++ b/src/torchada/_patch.py
@@ -713,13 +713,12 @@ def _patch_torch_cuda_module():
 
         # Patch torch.cuda.memory
         if hasattr(torch.musa, "memory"):
-            sys.modules["torch.cuda.memory"] = torch.musa.memory
-
-        # Add CUDAPluggableAllocator alias pointing to MUSAPluggableAllocator
-        if hasattr(torch.musa.memory, "MUSAPluggableAllocator") and not hasattr(
-            torch.musa.memory, "CUDAPluggableAllocator"
-        ):
-            torch.musa.memory.CUDAPluggableAllocator = torch.musa.memory.MUSAPluggableAllocator
+            musa_memory_module = torch.musa.memory
+            if musa_memory_module is not None:
+                sys.modules["torch.cuda.memory"] = musa_memory_module
+                # Add CUDAPluggableAllocator alias pointing to MUSAPluggableAllocator
+                if hasattr(musa_memory_module, "MUSAPluggableAllocator"):
+                    musa_memory_module.CUDAPluggableAllocator = musa_memory_module.MUSAPluggableAllocator
 
         # Patch torch.cuda.graph context manager to accept cuda_graph= keyword
         # MUSA's graph class uses musa_graph= but CUDA code uses cuda_graph=

--- a/tests/test_cuda_patching.py
+++ b/tests/test_cuda_patching.py
@@ -740,14 +740,13 @@ class TestTorchCudaMemory:
             pytest.skip("Only applicable on MUSA platform")
 
         try:
-            from torch.cuda.memory import CUDAPluggableAllocator
             from torch.musa.memory import MUSAPluggableAllocator
-
-            assert CUDAPluggableAllocator is MUSAPluggableAllocator
         except (ImportError, AttributeError):
-            # This is expected if torch_musa doesn't have memory.MUSAPluggableAllocator
-            # or if the environment doesn't have torch_musa
-            pytest.skip("torch.musa.memory or MUSAPluggableAllocator not available")
+            pytest.skip("torch.musa.memory.MUSAPluggableAllocator not available")
+
+        from torch.cuda.memory import CUDAPluggableAllocator
+
+        assert CUDAPluggableAllocator is MUSAPluggableAllocator
 
 
 class TestTorchGenerator:

--- a/tests/test_cuda_patching.py
+++ b/tests/test_cuda_patching.py
@@ -727,6 +727,29 @@ class TestDeviceFunctions:
         assert hasattr(torch.cuda, "is_initialized")
 
 
+class TestTorchCudaMemory:
+    """Test torch.cuda.memory module patching."""
+
+    def test_import_pluggable_allocator(self):
+        """Test that CUDAPluggableAllocator can be imported from torch.cuda.memory."""
+        import torch
+
+        import torchada
+
+        if not torchada.is_musa_platform():
+            pytest.skip("Only applicable on MUSA platform")
+
+        try:
+            from torch.cuda.memory import CUDAPluggableAllocator
+            from torch.musa.memory import MUSAPluggableAllocator
+
+            assert CUDAPluggableAllocator is MUSAPluggableAllocator
+        except (ImportError, AttributeError):
+            # This is expected if torch_musa doesn't have memory.MUSAPluggableAllocator
+            # or if the environment doesn't have torch_musa
+            pytest.skip("torch.musa.memory or MUSAPluggableAllocator not available")
+
+
 class TestTorchGenerator:
     """Test torch.Generator works with cuda device on MUSA platform."""
 


### PR DESCRIPTION
### Description
This PR introduces a patch to transparently redirect the torch.cuda.memory API to torch.musa.memory , enhancing torchada 's compatibility on the MUSA platform.

The primary goal is to allow code that uses torch.cuda.memory.CUDAPluggableAllocator to run on Moore Threads GPUs without modification.

### Key Changes
1. Module Redirection in _patch.py :
   
   - New logic has been added to the _patch_torch_cuda_module function to handle the torch.cuda.memory module.
   - When the MUSA platform is detected and a memory module exists within torch.musa , torchada now points sys.modules["torch.cuda.memory"] to torch.musa.memory .
2. Allocator Class Aliasing :
   
   - To ensure full API compatibility, the patch checks for the existence of MUSAPluggableAllocator within torch.musa.memory .
   - If found, it dynamically creates an alias named CUDAPluggableAllocator that points to MUSAPluggableAllocator . This allows statements like from torch.cuda.memory import CUDAPluggableAllocator to work seamlessly.
3. New Automated Tests :
   
   - A new test class, TestTorchCudaMemory , has been added to tests/test_cuda_patching.py .
   - It includes the test case test_import_pluggable_allocator , which specifically verifies that CUDAPluggableAllocator can be successfully imported on the MUSA platform and is indeed an alias for MUSAPluggableAllocator .
   - The test is automatically skipped if MUSAPluggableAllocator is not available in the torch_musa environment.
### How to Verify
In an environment with torch_musa integrated, run the following Pytest command to verify the new functionality:

```
pytest tests/test_cuda_patching.py -k "test_import_pluggable_allocator"
```
The test should pass on a MUSA platform or be skipped if the corresponding torch_musa components are not present.
<img width="2461" height="488" alt="image" src="https://github.com/user-attachments/assets/1da3b779-5b16-4f26-9f52-0df183d72f64" />
