### PR TITLE
Fix build vllm kernel for the first time may encounter failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ See `src/torchada/_mapping.py` for the complete mapping table (380+ mappings).
 
 ```
 # pyproject.toml or requirements.txt
-torchada>=0.1.48
+torchada>=0.1.49
 ```
 
 ### Step 2: Conditional Import

--- a/README_CN.md
+++ b/README_CN.md
@@ -255,7 +255,7 @@ if torchada.is_gpu_device(device):  # 在 CUDA 和 MUSA 上都能工作
 
 ```
 # pyproject.toml 或 requirements.txt
-torchada>=0.1.48
+torchada>=0.1.49
 ```
 
 ### 步骤 2：条件导入

--- a/benchmarks/benchmark_history.json
+++ b/benchmarks/benchmark_history.json
@@ -3,7 +3,7 @@
   "description": "Historical benchmark results for torchada performance tracking",
   "results": [
     {
-      "version": "0.1.48",
+      "version": "0.1.49",
       "date": "2026-01-29",
       "platform": "MUSA",
       "pytorch_version": "2.7.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torchada"
-version = "0.1.48"
+version = "0.1.49"
 description = "Adapter package for torch_musa to act exactly like PyTorch CUDA"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/torchada/__init__.py
+++ b/src/torchada/__init__.py
@@ -24,7 +24,7 @@ Usage:
     from torch.utils.cpp_extension import CUDAExtension, BuildExtension, CUDA_HOME
 """
 
-__version__ = "0.1.48"
+__version__ = "0.1.49"
 
 from . import cuda, utils
 from ._patch import apply_patches, get_original_init_process_group, is_patched

--- a/src/torchada/utils/cpp_extension.py
+++ b/src/torchada/utils/cpp_extension.py
@@ -624,7 +624,10 @@ def _get_build_extension_class():
                             if needs_porting:
                                 source_dir = os.path.dirname(os.path.abspath(source))
                                 dirs_to_port.add(source_dir)
-
+                        # Sort directories by depth (deepest first) to ensure proper porting order
+                        dirs_to_port = sorted(
+                            dirs_to_port, key=lambda p: p.count("/"), reverse=True
+                        )
                         # Port each unique directory
                         for cuda_dir in dirs_to_port:
                             self._port_directory(cuda_dir, mapping_rule)


### PR DESCRIPTION
The vLLM kernel uses header file references with relative paths that need to be modified from csrc/xxx to csrc/xxx_musa. If the default directory order is used, the operation that copies csrc to csrc_musa may execute before changing csrc/xxx to csrc/xxx_musa, causing header files to be missing during the initial installation. To avoid this, we sort directories by depth (deepest first).

All tests in tests/test_cpp_extension.py and tests/test_extension_build.py  have passed.