### PR TITLE
fix(patch): remove duplicate @patch_function on _patch_graph_context_manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ See `src/torchada/_mapping.py` for the complete mapping table (380+ mappings).
 
 ```
 # pyproject.toml or requirements.txt
-torchada>=0.1.54
+torchada>=0.1.55
 ```
 
 ### Step 2: Conditional Import

--- a/README_CN.md
+++ b/README_CN.md
@@ -292,7 +292,7 @@ if torchada.is_gpu_device(device):  # 在 CUDA 和 MUSA 上都能工作
 
 ```
 # pyproject.toml 或 requirements.txt
-torchada>=0.1.54
+torchada>=0.1.55
 ```
 
 ### 步骤 2：条件导入

--- a/benchmarks/benchmark_history.json
+++ b/benchmarks/benchmark_history.json
@@ -3,7 +3,7 @@
   "description": "Historical benchmark results for torchada performance tracking",
   "results": [
     {
-      "version": "0.1.54",
+      "version": "0.1.55",
       "date": "2026-01-29",
       "platform": "MUSA",
       "pytorch_version": "2.7.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torchada"
-version = "0.1.54"
+version = "0.1.55"
 description = "Adapter package for torch_musa to act exactly like PyTorch CUDA"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/torchada/__init__.py
+++ b/src/torchada/__init__.py
@@ -24,7 +24,7 @@ Usage:
     from torch.utils.cpp_extension import CUDAExtension, BuildExtension, CUDA_HOME
 """
 
-__version__ = "0.1.54"
+__version__ = "0.1.55"
 
 from . import cuda, utils
 

--- a/src/torchada/_patch.py
+++ b/src/torchada/_patch.py
@@ -1602,6 +1602,26 @@ def _patch_torch_accelerator():
     if not hasattr(_original_torch_accelerator, "stream"):
         wrapper._set_override("stream", stream_cm)
 
+    # Memory APIs that exist on torch.accelerator (PyTorch 2.9+) but internally
+    # call torch._C._accelerator_* C++ functions which fail on MUSA because the
+    # MUSA allocator is not a CUDA DeviceAllocator.  Override them to delegate to
+    # torch.musa, following the same pattern as synchronize().
+    _ACCELERATOR_MEMORY_APIS = [
+        "empty_cache",
+        "empty_host_cache",
+        "memory_stats",
+        "memory_allocated",
+        "max_memory_allocated",
+        "memory_reserved",
+        "max_memory_reserved",
+        "reset_accumulated_memory_stats",
+        "reset_peak_memory_stats",
+        "get_memory_info",
+    ]
+    for api_name in _ACCELERATOR_MEMORY_APIS:
+        if hasattr(_original_torch_accelerator, api_name) and hasattr(torch.musa, api_name):
+            wrapper._set_override(api_name, getattr(torch.musa, api_name))
+
     sys.modules["torch.accelerator"] = wrapper
     torch.accelerator = wrapper
 

--- a/src/torchada/_patch.py
+++ b/src/torchada/_patch.py
@@ -1412,7 +1412,8 @@ class _AcceleratorModuleWrapper(ModuleType):
 
     Resolution order for attribute access:
         1. Explicit overrides installed by torchada (e.g. patched synchronize,
-           device_index / stream context managers)
+           device_index / stream context managers, and memory APIs that exist
+           upstream but are broken on MUSA)
         2. The original torch.accelerator module (so existing APIs keep their
            real implementations)
         3. torch.musa as a fallback for APIs that have not yet been added to
@@ -1442,11 +1443,38 @@ class _AcceleratorModuleWrapper(ModuleType):
         "StreamContext": "core.stream.StreamContext",
     }
 
+    # Memory APIs that exist on torch.accelerator (PyTorch 2.9+) but internally
+    # call torch._C._accelerator_* C++ functions which fail on MUSA because the
+    # MUSA allocator is not a CUDA DeviceAllocator. These are overridden to
+    # delegate to torch.musa, following the same pattern as synchronize().
+    # When an API in this list exists on the original torch.accelerator AND on
+    # torch.musa, we install an override that prefers torch.musa over the
+    # upstream implementation.
+    _MUSA_OVERRIDES = (
+        "empty_cache",
+        "empty_host_cache",
+        "memory_stats",
+        "memory_allocated",
+        "max_memory_allocated",
+        "memory_reserved",
+        "max_memory_reserved",
+        "reset_accumulated_memory_stats",
+        "reset_peak_memory_stats",
+        "get_memory_info",
+    )
+
     def __init__(self, original_accel, musa_module):
         super().__init__("torch.accelerator")
         self._original_accel = original_accel
         self._musa_module = musa_module
         self._overrides = {}
+
+        # Apply MUSA overrides for memory APIs that exist upstream but are
+        # broken on MUSA (they route through torch._C._accelerator_* which
+        # doesn't dispatch to the MUSA allocator).
+        for name in self._MUSA_OVERRIDES:
+            if hasattr(original_accel, name) and hasattr(musa_module, name):
+                self._set_override(name, getattr(musa_module, name))
 
     def _set_override(self, name, value):
         """Install an override that takes precedence over the wrapped modules."""
@@ -1577,14 +1605,26 @@ def _patch_torch_accelerator():
        implementation raises. The wrapper installs a patched synchronize that
        delegates to torch.musa.synchronize().
 
-    2. Forward compatibility for APIs that PyTorch is expected to add to
-       torch.accelerator in future releases (empty_cache, memory_stats,
-       memory_allocated, Stream, Event, manual_seed, get_device_name, ...).
-       Any attribute missing from the current torch.accelerator module is
-       looked up on torch.musa instead.
+    2. Overrides for memory APIs that exist on torch.accelerator (PyTorch 2.9+)
+       but are broken on MUSA because they route through torch._C._accelerator_*
+       C++ functions that don't dispatch to the MUSA allocator. These are
+       redirected to torch.musa implementations (see _AcceleratorModuleWrapper
+       ._MUSA_OVERRIDES).
 
-    3. device_index(idx) and stream(s) context managers, which are not yet
+    3. Forward compatibility for APIs that PyTorch is expected to add to
+       torch.accelerator in future releases but are not yet present (Stream,
+       Event, manual_seed, get_device_name, ...). Any attribute missing from
+       the current torch.accelerator module is looked up on torch.musa instead.
+
+    4. device_index(idx) and stream(s) context managers, which are not yet
        present on torch.accelerator in torch 2.7.
+
+    TODO(torchada): README.md / README_CN.md claim "the wrapper always prefers
+    the real torch.accelerator implementation and only falls back to torch.musa
+    when an attribute is missing". That is no longer accurate after adding the
+    memory API overrides (point 2 above). Update those documents to describe
+    the actual resolution order: (1) torchada overrides, (2) real torch.accelerator,
+    (3) fallback to torch.musa.
     """
     global _original_torch_accelerator
 
@@ -1601,26 +1641,6 @@ def _patch_torch_accelerator():
         wrapper._set_override("device_index", device_index_cm)
     if not hasattr(_original_torch_accelerator, "stream"):
         wrapper._set_override("stream", stream_cm)
-
-    # Memory APIs that exist on torch.accelerator (PyTorch 2.9+) but internally
-    # call torch._C._accelerator_* C++ functions which fail on MUSA because the
-    # MUSA allocator is not a CUDA DeviceAllocator.  Override them to delegate to
-    # torch.musa, following the same pattern as synchronize().
-    _ACCELERATOR_MEMORY_APIS = [
-        "empty_cache",
-        "empty_host_cache",
-        "memory_stats",
-        "memory_allocated",
-        "max_memory_allocated",
-        "memory_reserved",
-        "max_memory_reserved",
-        "reset_accumulated_memory_stats",
-        "reset_peak_memory_stats",
-        "get_memory_info",
-    ]
-    for api_name in _ACCELERATOR_MEMORY_APIS:
-        if hasattr(_original_torch_accelerator, api_name) and hasattr(torch.musa, api_name):
-            wrapper._set_override(api_name, getattr(torch.musa, api_name))
 
     sys.modules["torch.accelerator"] = wrapper
     torch.accelerator = wrapper

--- a/src/torchada/_patch.py
+++ b/src/torchada/_patch.py
@@ -389,7 +389,6 @@ def _patch_torch_generator():
 _original_graph_class = None
 
 
-@patch_function
 def _patch_graph_context_manager():
     """
     Patch torch.cuda.graph context manager to accept cuda_graph= keyword argument.

--- a/src/torchada/_patch.py
+++ b/src/torchada/_patch.py
@@ -1167,6 +1167,13 @@ def _patch_backends_cuda():
 
     torch.backends.cuda.is_built = patched_is_built
 
+    if (
+        is_musa_platform()
+        and hasattr(torch.backends, "musa")
+        and hasattr(torch.backends.musa, "matmul")
+    ):
+        torch.backends.cuda.matmul = torch.backends.musa.matmul
+
     # Patch cuBLASModule to support fp32_precision attribute
     # This attribute is in newer PyTorch but may be missing in torch_musa's version
     matmul = torch.backends.cuda.matmul

--- a/tests/test_cuda_patching.py
+++ b/tests/test_cuda_patching.py
@@ -2487,17 +2487,32 @@ class TestAcceleratorModuleWrapper:
         return _AcceleratorModuleWrapper(accel, musa), accel, musa
 
     def test_original_accelerator_takes_precedence_over_musa(self):
-        """Official torch.accelerator implementations must win over torch.musa.
+        """Official torch.accelerator implementations win over torch.musa for non-overridden APIs.
 
         This is the forward-compat guarantee: when PyTorch 2.9+ adds an
-        official implementation of an API (e.g. empty_cache), the wrapper
-        must return the official one, not the torch.musa fallback.
+        official implementation of an API (e.g. manual_seed) that is NOT in
+        _MUSA_OVERRIDES, the wrapper must return the official one, not the
+        torch.musa fallback.
+        """
+        wrapper, _, _ = self._make_wrapper(
+            accel_attrs={"manual_seed": "official_impl"},
+            musa_attrs={"manual_seed": "musa_fallback"},
+        )
+        assert wrapper.manual_seed == "official_impl"
+
+    def test_musa_overrides_take_precedence_when_both_exist(self):
+        """Memory APIs in _MUSA_OVERRIDES use torch.musa even when torch.accelerator has them.
+
+        Starting in PyTorch 2.9+, torch.accelerator.empty_cache() exists but
+        routes through torch._C._accelerator_* which doesn't work with the MUSA
+        allocator. The wrapper must override it to use torch.musa.empty_cache().
         """
         wrapper, _, _ = self._make_wrapper(
             accel_attrs={"empty_cache": "official_impl"},
             musa_attrs={"empty_cache": "musa_fallback"},
         )
-        assert wrapper.empty_cache == "official_impl"
+        # empty_cache is in _MUSA_OVERRIDES, so torch.musa wins
+        assert wrapper.empty_cache == "musa_fallback"
 
     def test_fallback_to_musa_when_accelerator_missing(self):
         """Attributes absent from torch.accelerator must fall back to torch.musa."""

--- a/tests/test_cuda_patching.py
+++ b/tests/test_cuda_patching.py
@@ -1258,7 +1258,10 @@ class TestIsCompiledAndBackends:
         except (AttributeError, AssertionError):
             pytest.skip("fp32_precision not available (torchada MUSA-specific attribute)")
 
-        if torch.__version__ >= torch.torch_version.TorchVersion("2.9.0"):
+        if (
+            not torchada.is_musa_platform()
+            and torch.__version__ >= torch.torch_version.TorchVersion("2.9.0")
+        ):
             # PyTorch 2.9+: Only use the new API. Do NOT call torch.get_float32_matmul_precision()
             valid_precisions = ("ieee", "tf32")
             test_values = ["ieee", "tf32"]


### PR DESCRIPTION
## Summary
- Remove `@patch_function` decorator from `_patch_graph_context_manager` to prevent it from being patched twice

## Test
### torch 2.7.1

```bash
========================================== 310 passed, 28 skipped in 1.09s ===========================================
```

### torch 2.9.1
test result: 323 passed, 15 skipped, 5 warnings in 2.67s
details: 

```bash
===================================================================================================================== test session starts ======================================================================================================================
platform linux -- Python 3.10.12, pytest-9.0.3, pluggy-1.6.0 -- /root/.virtualenvs/sglang-0.5.6/bin/python
cachedir: .pytest_cache
rootdir: /home/dist/zhenxue/github/torchada
configfile: pyproject.toml
plugins: anyio-4.13.0
collected 338 items                                                                                                                                                                                                                                            

tests/test_cpp_extension.py::TestCppExtensionImports::test_import_cuda_home PASSED                                                                                                                                                                       [  0%]
tests/test_cpp_extension.py::TestCppExtensionImports::test_import_cuda_extension PASSED                                                                                                                                                                  [  0%]
tests/test_cpp_extension.py::TestCppExtensionImports::test_import_build_extension PASSED                                                                                                                                                                 [  0%]
tests/test_cpp_extension.py::TestCppExtensionImports::test_cuda_home_on_musa PASSED                                                                                                                                                                      [  1%]
tests/test_cpp_extension.py::TestCppExtensionImports::test_torch_cpp_extension_is_patched PASSED                                                                                                                                                         [  1%]
tests/test_cpp_extension.py::TestCppExtensionImports::test_torch_cpp_extension_cuda_home_same_as_torchada PASSED                                                                                                                                         [  1%]
tests/test_cpp_extension.py::TestCUDAExtension::test_create_extension_basic PASSED                                                                                                                                                                       [  2%]
tests/test_cpp_extension.py::TestCUDAExtension::test_create_extension_with_include_dirs PASSED                                                                                                                                                           [  2%]
tests/test_cpp_extension.py::TestCUDAExtension::test_create_extension_with_extra_compile_args PASSED                                                                                                                                                     [  2%]
tests/test_cpp_extension.py::TestMusaPatches::test_is_musa_file_recognizes_cu PASSED                                                                                                                                                                     [  2%]
tests/test_cpp_extension.py::TestMusaPatches::test_is_musa_file_recognizes_cuh PASSED                                                                                                                                                                    [  3%]
tests/test_cpp_extension.py::TestMusaPatches::test_is_musa_file_recognizes_mu PASSED                                                                                                                                                                     [  3%]
tests/test_cpp_extension.py::TestMusaPatches::test_ext_replaced_mapping PASSED                                                                                                                                                                           [  3%]
tests/test_cpp_extension.py::TestMusaPatches::test_mapping_rule_exists PASSED                                                                                                                                                                            [  4%]
tests/test_cpp_extension.py::TestMusaPatches::test_mapping_rule_has_expected_entries PASSED                                                                                                                                                              [  4%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_is_patched_on_musa PASSED                                                                                                                                                              [  4%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_is_available PASSED                                                                                                                                                                    [  5%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_device_count PASSED                                                                                                                                                                    [  5%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_device_count_nvml PASSED                                                                                                                                                               [  5%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_current_device PASSED                                                                                                                                                                  [  5%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_get_device_name PASSED                                                                                                                                                                 [  6%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_synchronize PASSED                                                                                                                                                                     [  6%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_empty_cache PASSED                                                                                                                                                                     [  6%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_memory_allocated PASSED                                                                                                                                                                [  7%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_memory_reserved PASSED                                                                                                                                                                 [  7%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_set_device PASSED                                                                                                                                                                      [  7%]
tests/test_cuda_patching.py::TestTorchCudaLazyInit::test_import_lazy_call PASSED                                                                                                                                                                         [  7%]
tests/test_cuda_patching.py::TestTorchCudaLazyInit::test_lazy_call_functionality PASSED                                                                                                                                                                  [  8%]
tests/test_cuda_patching.py::TestTorchCudaAmp::test_import_autocast PASSED                                                                                                                                                                               [  8%]
tests/test_cuda_patching.py::TestTorchCudaAmp::test_import_grad_scaler PASSED                                                                                                                                                                            [  8%]
tests/test_cuda_patching.py::TestTorchCudaAmp::test_autocast_context_manager PASSED                                                                                                                                                                      [  9%]
tests/test_cuda_patching.py::TestTorchCudaAmp::test_grad_scaler_creation PASSED                                                                                                                                                                          [  9%]
tests/test_cuda_patching.py::TestCUDAGraph::test_cuda_graph_alias PASSED                                                                                                                                                                                 [  9%]
tests/test_cuda_patching.py::TestCUDAGraph::test_cuda_graph_is_musa_graph PASSED                                                                                                                                                                         [ 10%]
tests/test_cuda_patching.py::TestCUDAGraph::test_cuda_graph_creation PASSED                                                                                                                                                                              [ 10%]
tests/test_cuda_patching.py::TestCUDAGraph::test_graphs_module PASSED                                                                                                                                                                                    [ 10%]
tests/test_cuda_patching.py::TestCUDAGraph::test_make_graphed_callables PASSED                                                                                                                                                                           [ 10%]
tests/test_cuda_patching.py::TestCUDAGraph::test_graph_pool_handle PASSED                                                                                                                                                                                [ 11%]
tests/test_cuda_patching.py::TestCUDAGraph::test_graph_context_manager_cuda_graph_keyword PASSED                                                                                                                                                         [ 11%]
tests/test_cuda_patching.py::TestCUDAGraph::test_graph_context_manager_positional PASSED                                                                                                                                                                 [ 11%]
tests/test_cuda_patching.py::TestCUDAGraph::test_graph_context_manager_musa_graph_keyword PASSED                                                                                                                                                         [ 12%]
tests/test_cuda_patching.py::TestCUDAGraph::test_graph_context_manager_missing_arg_raises PASSED                                                                                                                                                         [ 12%]
tests/test_cuda_patching.py::TestCUDAGraph::test_graph_context_manager_with_pool_and_stream PASSED                                                                                                                                                       [ 12%]
tests/test_cuda_patching.py::TestDistributedBackend::test_original_init_available PASSED                                                                                                                                                                 [ 13%]
tests/test_cuda_patching.py::TestDistributedBackend::test_mccl_backend_available PASSED                                                                                                                                                                  [ 13%]
tests/test_cuda_patching.py::TestDistributedBackend::test_nccl_backend_available PASSED                                                                                                                                                                  [ 13%]
tests/test_cuda_patching.py::TestDistributedBackend::test_new_group_patched PASSED                                                                                                                                                                       [ 13%]
tests/test_cuda_patching.py::TestDistributedBackend::test_has_param_with_mock_functions PASSED                                                                                                                                                           [ 14%]
tests/test_cuda_patching.py::TestDistributedBackend::test_new_group_device_id_param_compatibility PASSED                                                                                                                                                 [ 14%]
tests/test_cuda_patching.py::TestNCCLModule::test_mccl_module_available PASSED                                                                                                                                                                           [ 14%]
tests/test_cuda_patching.py::TestRNGFunctions::test_get_rng_state PASSED                                                                                                                                                                                 [ 15%]
tests/test_cuda_patching.py::TestRNGFunctions::test_set_rng_state PASSED                                                                                                                                                                                 [ 15%]
tests/test_cuda_patching.py::TestRNGFunctions::test_manual_seed PASSED                                                                                                                                                                                   [ 15%]
tests/test_cuda_patching.py::TestRNGFunctions::test_manual_seed_all PASSED                                                                                                                                                                               [ 15%]
tests/test_cuda_patching.py::TestRNGFunctions::test_seed PASSED                                                                                                                                                                                          [ 16%]
tests/test_cuda_patching.py::TestRNGFunctions::test_initial_seed PASSED                                                                                                                                                                                  [ 16%]
tests/test_cuda_patching.py::TestRNGFunctions::test_manual_seed_works PASSED                                                                                                                                                                             [ 16%]
tests/test_cuda_patching.py::TestRandomFunctions::test_cuda_random_module_available PASSED                                                                                                                                                               [ 17%]
tests/test_cuda_patching.py::TestRandomFunctions::test_cuda_random_aliases_musa PASSED                                                                                                                                                                   [ 17%]
tests/test_cuda_patching.py::TestRandomFunctions::test_cuda_random_functionality PASSED                                                                                                                                                                  [ 17%]
tests/test_cuda_patching.py::TestMemoryFunctions::test_max_memory_allocated PASSED                                                                                                                                                                       [ 18%]
tests/test_cuda_patching.py::TestMemoryFunctions::test_max_memory_reserved PASSED                                                                                                                                                                        [ 18%]
tests/test_cuda_patching.py::TestMemoryFunctions::test_memory_stats PASSED                                                                                                                                                                               [ 18%]
tests/test_cuda_patching.py::TestMemoryFunctions::test_memory_summary PASSED                                                                                                                                                                             [ 18%]
tests/test_cuda_patching.py::TestMemoryFunctions::test_memory_snapshot PASSED                                                                                                                                                                            [ 19%]
tests/test_cuda_patching.py::TestMemoryFunctions::test_reset_peak_memory_stats PASSED                                                                                                                                                                    [ 19%]
tests/test_cuda_patching.py::TestMemoryFunctions::test_mem_get_info PASSED                                                                                                                                                                               [ 19%]
tests/test_cuda_patching.py::TestStreamAndEvent::test_stream_class PASSED                                                                                                                                                                                [ 20%]
tests/test_cuda_patching.py::TestStreamAndEvent::test_event_class PASSED                                                                                                                                                                                 [ 20%]
tests/test_cuda_patching.py::TestStreamAndEvent::test_external_stream_class PASSED                                                                                                                                                                       [ 20%]
tests/test_cuda_patching.py::TestStreamAndEvent::test_current_stream PASSED                                                                                                                                                                              [ 21%]
tests/test_cuda_patching.py::TestStreamAndEvent::test_default_stream PASSED                                                                                                                                                                              [ 21%]
tests/test_cuda_patching.py::TestStreamAndEvent::test_set_stream PASSED                                                                                                                                                                                  [ 21%]
tests/test_cuda_patching.py::TestStreamAndEvent::test_stream_context_manager PASSED                                                                                                                                                                      [ 21%]
tests/test_cuda_patching.py::TestStreamAndEvent::test_stream_context_class PASSED                                                                                                                                                                        [ 22%]
tests/test_cuda_patching.py::TestStreamAndEvent::test_stream_cuda_stream_property PASSED                                                                                                                                                                 [ 22%]
tests/test_cuda_patching.py::TestContextManagers::test_device_context_manager PASSED                                                                                                                                                                     [ 22%]
tests/test_cuda_patching.py::TestContextManagers::test_device_of_context_manager PASSED                                                                                                                                                                  [ 23%]
tests/test_cuda_patching.py::TestDeviceFunctions::test_get_device_properties PASSED                                                                                                                                                                      [ 23%]
tests/test_cuda_patching.py::TestDeviceFunctions::test_get_device_capability PASSED                                                                                                                                                                      [ 23%]
tests/test_cuda_patching.py::TestDeviceFunctions::test_is_initialized PASSED                                                                                                                                                                             [ 23%]
tests/test_cuda_patching.py::TestTorchCudaMemory::test_import_pluggable_allocator SKIPPED (torch.musa.memory.MUSAPluggableAllocator not available)                                                                                                       [ 24%]
tests/test_cuda_patching.py::TestTorchCudaMemory::test_memory_pool_functions_available_on_musa PASSED                                                                                                                                                    [ 24%]
tests/test_cuda_patching.py::TestTorchCudaMemory::test_memory_pool_functions_importable_from_cuda_memory PASSED                                                                                                                                          [ 24%]
tests/test_cuda_patching.py::TestTorchGenerator::test_generator_cuda_device PASSED                                                                                                                                                                       [ 25%]
tests/test_cuda_patching.py::TestTorchGenerator::test_generator_cuda_device_index PASSED                                                                                                                                                                 [ 25%]
tests/test_cuda_patching.py::TestTorchGenerator::test_generator_musa_device PASSED                                                                                                                                                                       [ 25%]
tests/test_cuda_patching.py::TestTorchGenerator::test_generator_no_device PASSED                                                                                                                                                                         [ 26%]
tests/test_cuda_patching.py::TestTorchGenerator::test_generator_manual_seed_chain PASSED                                                                                                                                                                 [ 26%]
tests/test_cuda_patching.py::TestTorchGenerator::test_generator_isinstance_check PASSED                                                                                                                                                                  [ 26%]
tests/test_cuda_patching.py::TestTorchGenerator::test_generator_isinstance_negative PASSED                                                                                                                                                               [ 26%]
tests/test_cuda_patching.py::TestTorchGenerator::test_generator_class_is_picklable PASSED                                                                                                                                                                [ 27%]
tests/test_cuda_patching.py::TestTorchGenerator::test_generator_instance_is_picklable PASSED                                                                                                                                                             [ 27%]
tests/test_cuda_patching.py::TestTorchGenerator::test_generator_picklable_in_container PASSED                                                                                                                                                            [ 27%]
tests/test_cuda_patching.py::TestTorchVersionCuda::test_torch_version_cuda_not_patched PASSED                                                                                                                                                            [ 28%]
tests/test_cuda_patching.py::TestTensorIsCuda::test_cpu_tensor_is_cuda_false PASSED                                                                                                                                                                      [ 28%]
tests/test_cuda_patching.py::TestTensorIsCuda::test_musa_tensor_is_cuda_true PASSED                                                                                                                                                                      [ 28%]
tests/test_cuda_patching.py::TestAutotuneProcess::test_cuda_visible_devices_patched PASSED                                                                                                                                                               [ 28%]
tests/test_cuda_patching.py::TestAutotuneProcess::test_cuda_visible_devices_is_string PASSED                                                                                                                                                             [ 29%]
tests/test_cuda_patching.py::TestAutotuneProcess::test_cuda_visible_devices_env_var_format PASSED                                                                                                                                                        [ 29%]
tests/test_cuda_patching.py::TestNvtxStub::test_nvtx_module_available PASSED                                                                                                                                                                             [ 29%]
tests/test_cuda_patching.py::TestNvtxStub::test_nvtx_mark PASSED                                                                                                                                                                                         [ 30%]
tests/test_cuda_patching.py::TestNvtxStub::test_nvtx_range_push_pop PASSED                                                                                                                                                                               [ 30%]
tests/test_cuda_patching.py::TestNvtxStub::test_nvtx_range_context_manager PASSED                                                                                                                                                                        [ 30%]
tests/test_cuda_patching.py::TestPatchDecorators::test_patch_registry_is_populated PASSED                                                                                                                                                                [ 31%]
tests/test_cuda_patching.py::TestPatchDecorators::test_patch_registry_contains_expected_functions PASSED                                                                                                                                                 [ 31%]
tests/test_cuda_patching.py::TestPatchDecorators::test_requires_import_decorator_guards_import PASSED                                                                                                                                                    [ 31%]
tests/test_cuda_patching.py::TestPatchDecorators::test_requires_import_decorator_allows_execution PASSED                                                                                                                                                 [ 31%]
tests/test_cuda_patching.py::TestPatchDecorators::test_requires_import_multiple_modules PASSED                                                                                                                                                           [ 32%]
tests/test_cuda_patching.py::TestIsCompiledAndBackends::test_torch_musa_is_compiled PASSED                                                                                                                                                               [ 32%]
tests/test_cuda_patching.py::TestIsCompiledAndBackends::test_torch_cuda_is_compiled_redirects PASSED                                                                                                                                                     [ 32%]
tests/test_cuda_patching.py::TestIsCompiledAndBackends::test_torch_backends_cuda_is_built PASSED                                                                                                                                                         [ 33%]
tests/test_cuda_patching.py::TestIsCompiledAndBackends::test_torch_backends_cuda_matmul_allow_tf32 PASSED                                                                                                                                                [ 33%]
tests/test_cuda_patching.py::TestIsCompiledAndBackends::test_torch_backends_cuda_matmul_fp32_precision PASSED                                                                                                                                            [ 33%]
tests/test_cuda_patching.py::TestIsCompiledAndBackends::test_torch_c_storage_use_count PASSED                                                                                                                                                            [ 34%]
tests/test_cuda_patching.py::TestProfilerActivity::test_profiler_activity_cuda_accessible PASSED                                                                                                                                                         [ 34%]
tests/test_cuda_patching.py::TestProfilerActivity::test_profiler_with_cuda_activity PASSED                                                                                                                                                               [ 34%]
tests/test_cuda_patching.py::TestProfilerActivity::test_profiler_context_manager PASSED                                                                                                                                                                  [ 34%]
tests/test_cuda_patching.py::TestProfilerActivity::test_profiler_methods_accessible PASSED                                                                                                                                                               [ 35%]
tests/test_cuda_patching.py::TestMusaWarnings::test_musa_warnings_patch_applied PASSED                                                                                                                                                                   [ 35%]
tests/test_cuda_patching.py::TestMusaWarnings::test_autocast_warning_suppressed PASSED                                                                                                                                                                   [ 35%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_cuda_translated PASSED                                                                                                                                                                   [ 36%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_with_keyset PASSED                                                                                                                                                                       [ 36%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_with_keyset_false_explicit PASSED                                                                                                                                                        [ 36%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_op_name_as_keyword PASSED                                                                                                                                                                [ 36%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_with_allow_override PASSED                                                                                                                                                               [ 37%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_allow_override_false_explicit PASSED                                                                                                                                                     [ 37%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_with_keyset_and_with_allow_override PASSED                                                                                                                                               [ 37%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_fn_as_keyword PASSED                                                                                                                                                                     [ 38%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_dispatch_key_as_keyword PASSED                                                                                                                                                           [ 38%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_cuda_with_keyset PASSED                                                                                                                                                                  [ 38%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_autograd_cuda_translation PASSED                                                                                                                                                         [ 39%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_opoverload_as_op_name PASSED                                                                                                                                                             [ 39%]
tests/test_cuda_patching.py::TestCudart::test_cudart_returns_wrapper PASSED                                                                                                                                                                              [ 39%]
tests/test_cuda_patching.py::TestCudart::test_cudart_host_register PASSED                                                                                                                                                                                [ 39%]
tests/test_cuda_patching.py::TestCudart::test_cudart_in_dir PASSED                                                                                                                                                                                       [ 40%]
tests/test_cuda_patching.py::TestCppExtensionPaths::test_include_paths_with_cuda_param PASSED                                                                                                                                                            [ 40%]
tests/test_cuda_patching.py::TestCppExtensionPaths::test_include_paths_with_device_type_param PASSED                                                                                                                                                     [ 40%]
tests/test_cuda_patching.py::TestCppExtensionPaths::test_include_paths_default PASSED                                                                                                                                                                    [ 41%]
tests/test_cuda_patching.py::TestCppExtensionPaths::test_library_paths_with_cuda_param PASSED                                                                                                                                                            [ 41%]
tests/test_cuda_patching.py::TestCppExtensionPaths::test_library_paths_with_device_type_param PASSED                                                                                                                                                     [ 41%]
tests/test_cuda_patching.py::TestCppExtensionPaths::test_library_paths_default PASSED                                                                                                                                                                    [ 42%]
tests/test_cuda_patching.py::TestCppExtensionPaths::test_include_paths_patched_in_torch_module PASSED                                                                                                                                                    [ 42%]
tests/test_cuda_patching.py::TestCppExtensionPaths::test_library_paths_patched_in_torch_module PASSED                                                                                                                                                    [ 42%]
tests/test_cuda_patching.py::TestCppExtensionPaths::test_get_torch_include_paths_pattern PASSED                                                                                                                                                          [ 42%]
tests/test_cuda_patching.py::TestTensorFactoryFunctions::test_asarray_with_cuda_device PASSED                                                                                                                                                            [ 43%]
tests/test_cuda_patching.py::TestTensorFactoryFunctions::test_asarray_with_cuda_index PASSED                                                                                                                                                             [ 43%]
tests/test_cuda_patching.py::TestTensorFactoryFunctions::test_asarray_without_device PASSED                                                                                                                                                              [ 43%]
tests/test_cuda_patching.py::TestTensorFactoryFunctions::test_tensor_with_cuda_device PASSED                                                                                                                                                             [ 44%]
tests/test_cuda_patching.py::TestTensorFactoryFunctions::test_zeros_with_cuda_device PASSED                                                                                                                                                              [ 44%]
tests/test_cuda_patching.py::TestTensorFactoryFunctions::test_ones_with_cuda_device PASSED                                                                                                                                                               [ 44%]
tests/test_cuda_patching.py::TestTensorFactoryFunctions::test_randn_with_cuda_device PASSED                                                                                                                                                              [ 44%]
tests/test_cuda_patching.py::TestTensorFactoryFunctions::test_empty_with_cuda_device PASSED                                                                                                                                                              [ 45%]
tests/test_cuda_patching.py::TestCppOpsInfrastructure::test_cpp_ops_module_exists PASSED                                                                                                                                                                 [ 45%]
tests/test_cuda_patching.py::TestCppOpsInfrastructure::test_cpp_ops_loaded_on_musa PASSED                                                                                                                                                                [ 45%]
tests/test_cuda_patching.py::TestCppOpsInfrastructure::test_cpp_ops_source_files_exist PASSED                                                                                                                                                            [ 46%]
tests/test_cuda_patching.py::TestCppOpsInfrastructure::test_cpp_ops_header_content PASSED                                                                                                                                                                [ 46%]
tests/test_cuda_patching.py::TestValidateDevice::test_musa_device_should_pass PASSED                                                                                                                                                                     [ 46%]
tests/test_cuda_patching.py::TestValidateDevice::test_patch_when_attribute_missing PASSED                                                                                                                                                                [ 47%]
tests/test_cuda_patching.py::TestFlashAttnPatching::test_sgl_kernel_flash_attn_import_when_flash_attn_interface_available PASSED                                                                                                                         [ 47%]
tests/test_cuda_patching.py::TestFlashAttnPatching::test_sgl_kernel_flash_attn_module_in_sys_modules PASSED                                                                                                                                              [ 47%]
tests/test_cuda_patching.py::TestFlashAttnPatching::test_sgl_kernel_stub_created_when_sgl_kernel_not_installed PASSED                                                                                                                                    [ 47%]
tests/test_cuda_patching.py::TestFlashAttnPatching::test_sgl_kernel_existing_module_preserved PASSED                                                                                                                                                     [ 48%]
tests/test_cuda_patching.py::TestFlashAttnPatching::test_real_sgl_kernel_not_replaced_by_stub PASSED                                                                                                                                                     [ 48%]
tests/test_cuda_patching.py::TestFlashAttnPatching::test_flash_attn_direct_import_still_works PASSED                                                                                                                                                     [ 48%]
tests/test_cuda_patching.py::TestFlashAttnPatching::test_flash_attn_interface_submodule_accessible PASSED                                                                                                                                                [ 49%]
tests/test_cuda_patching.py::TestFlashAttnPatching::test_patch_skipped_when_flash_attn_interface_not_available SKIPPED (flash_attn_interface is available - this test is for when it's NOT available)                                                    [ 49%]
tests/test_cuda_patching.py::TestFlashAttnPatching::test_multiple_flash_attn_functions_accessible PASSED                                                                                                                                                 [ 49%]
tests/test_cuda_patching.py::TestAcceleratorModuleWrapper::test_original_accelerator_takes_precedence_over_musa PASSED                                                                                                                                   [ 50%]
tests/test_cuda_patching.py::TestAcceleratorModuleWrapper::test_musa_overrides_take_precedence_when_both_exist PASSED                                                                                                                                    [ 50%]
tests/test_cuda_patching.py::TestAcceleratorModuleWrapper::test_fallback_to_musa_when_accelerator_missing PASSED                                                                                                                                         [ 50%]
tests/test_cuda_patching.py::TestAcceleratorModuleWrapper::test_override_takes_precedence_over_everything PASSED                                                                                                                                         [ 50%]
tests/test_cuda_patching.py::TestAcceleratorModuleWrapper::test_missing_everywhere_raises_attribute_error PASSED                                                                                                                                         [ 51%]
tests/test_cuda_patching.py::TestAcceleratorModuleWrapper::test_resolved_attribute_is_cached PASSED                                                                                                                                                      [ 51%]
tests/test_cuda_patching.py::TestAcceleratorModuleWrapper::test_dir_includes_attributes_from_both_modules PASSED                                                                                                                                         [ 51%]
tests/test_cuda_patching.py::TestAcceleratorModuleWrapper::test_remap_used_when_accel_and_musa_lack_index_suffix_name PASSED                                                                                                                             [ 52%]
tests/test_cuda_patching.py::TestAcceleratorModuleWrapper::test_remap_not_used_when_accelerator_has_official_impl PASSED                                                                                                                                 [ 52%]
tests/test_cuda_patching.py::TestAcceleratorModuleWrapper::test_remap_keys_listed_in_dir PASSED                                                                                                                                                          [ 52%]
tests/test_cuda_patching.py::TestAcceleratorModuleWrapper::test_special_attrs_for_nested_lookups PASSED                                                                                                                                                  [ 52%]
tests/test_cuda_patching.py::TestTorchAcceleratorPatching::test_accelerator_is_wrapped_on_musa PASSED                                                                                                                                                    [ 53%]
tests/test_cuda_patching.py::TestTorchAcceleratorPatching::test_existing_accelerator_apis_preserved PASSED                                                                                                                                               [ 53%]
tests/test_cuda_patching.py::TestTorchAcceleratorPatching::test_empty_cache_falls_back_to_musa PASSED                                                                                                                                                    [ 53%]
tests/test_cuda_patching.py::TestTorchAcceleratorPatching::test_memory_apis_fall_back_to_musa PASSED                                                                                                                                                     [ 54%]
tests/test_cuda_patching.py::TestTorchAcceleratorPatching::test_rng_apis_fall_back_to_musa PASSED                                                                                                                                                        [ 54%]
tests/test_cuda_patching.py::TestTorchAcceleratorPatching::test_stream_and_event_classes_fall_back_to_musa PASSED                                                                                                                                        [ 54%]
tests/test_cuda_patching.py::TestTorchAcceleratorPatching::test_synchronize_override_handles_multiple_device_types PASSED                                                                                                                                [ 55%]
tests/test_cuda_patching.py::TestTorchAcceleratorPatching::test_synchronize_override_rejects_invalid_types PASSED                                                                                                                                        [ 55%]
tests/test_cuda_patching.py::TestTorchAcceleratorPatching::test_set_device_index_works_when_missing_from_original PASSED                                                                                                                                 [ 55%]
tests/test_cuda_patching.py::TestTorchAcceleratorPatching::test_device_index_context_manager PASSED                                                                                                                                                      [ 55%]
tests/test_cuda_patching.py::TestTorchAcceleratorPatching::test_stream_context_manager PASSED                                                                                                                                                            [ 56%]
tests/test_cuda_patching.py::TestTorchAcceleratorPatching::test_from_import_resolves_through_wrapper PASSED                                                                                                                                              [ 56%]
tests/test_cuda_patching.py::TestTorchAcceleratorPatching::test_stream_context_falls_back_to_nested_musa_attr PASSED                                                                                                                                     [ 56%]
tests/test_device_strings.py::TestTensorDevicePatching::test_tensor_cuda_method PASSED                                                                                                                                                                   [ 57%]
tests/test_device_strings.py::TestTensorDevicePatching::test_tensor_to_cuda_string PASSED                                                                                                                                                                [ 57%]
tests/test_device_strings.py::TestTensorDevicePatching::test_tensor_to_cuda_device_index PASSED                                                                                                                                                          [ 57%]
tests/test_device_strings.py::TestTensorDevicePatching::test_tensor_to_torch_device PASSED                                                                                                                                                               [ 57%]
tests/test_device_strings.py::TestModuleDevicePatching::test_module_cuda_method PASSED                                                                                                                                                                   [ 58%]
tests/test_device_strings.py::TestModuleDevicePatching::test_module_to_cuda PASSED                                                                                                                                                                       [ 58%]
tests/test_device_strings.py::TestFactoryFunctions::test_torch_empty_device_cuda PASSED                                                                                                                                                                  [ 58%]
tests/test_device_strings.py::TestFactoryFunctions::test_torch_zeros_device_cuda PASSED                                                                                                                                                                  [ 59%]
tests/test_device_strings.py::TestFactoryFunctions::test_torch_ones_device_cuda PASSED                                                                                                                                                                   [ 59%]
tests/test_device_strings.py::TestFactoryFunctions::test_torch_randn_device_cuda PASSED                                                                                                                                                                  [ 59%]
tests/test_device_strings.py::TestFactoryFunctions::test_torch_rand_device_cuda PASSED                                                                                                                                                                   [ 60%]
tests/test_device_strings.py::TestFactoryFunctions::test_torch_full_device_cuda PASSED                                                                                                                                                                   [ 60%]
tests/test_device_strings.py::TestFactoryFunctions::test_torch_arange_device_cuda PASSED                                                                                                                                                                 [ 60%]
tests/test_device_strings.py::TestFactoryFunctions::test_torch_linspace_device_cuda PASSED                                                                                                                                                               [ 60%]
tests/test_device_strings.py::TestTranslateDeviceFunction::test_translate_device_none PASSED                                                                                                                                                             [ 61%]
tests/test_device_strings.py::TestTranslateDeviceFunction::test_translate_device_cuda_string PASSED                                                                                                                                                      [ 61%]
tests/test_device_strings.py::TestTranslateDeviceFunction::test_translate_device_cuda_with_index PASSED                                                                                                                                                  [ 61%]
tests/test_device_strings.py::TestTranslateDeviceFunction::test_translate_device_cpu_unchanged PASSED                                                                                                                                                    [ 62%]
tests/test_device_strings.py::TestTranslateDeviceFunction::test_translate_device_musa_unchanged PASSED                                                                                                                                                   [ 62%]
tests/test_device_strings.py::TestTranslateDeviceFunction::test_translate_device_integer_unchanged PASSED                                                                                                                                                [ 62%]
tests/test_device_strings.py::TestTranslateDeviceFunction::test_translate_device_torch_device_cuda PASSED                                                                                                                                                [ 63%]
tests/test_device_strings.py::TestTranslateDeviceFunction::test_translate_device_torch_device_cuda_with_index PASSED                                                                                                                                     [ 63%]
tests/test_device_strings.py::TestTranslateDeviceFunction::test_translate_device_torch_device_cpu_unchanged PASSED                                                                                                                                       [ 63%]
tests/test_device_strings.py::TestDeviceIndexVariants::test_cuda_colon_zero PASSED                                                                                                                                                                       [ 63%]
tests/test_device_strings.py::TestDeviceIndexVariants::test_factory_with_cuda_index PASSED                                                                                                                                                               [ 64%]
tests/test_device_strings.py::TestDeviceIndexVariants::test_torch_device_cuda_zero PASSED                                                                                                                                                                [ 64%]
tests/test_device_strings.py::TestDeviceIndexVariants::test_torch_device_with_index_arg PASSED                                                                                                                                                           [ 64%]
tests/test_device_strings.py::TestDeviceIndexVariants::test_torch_device_from_original_cuda_device PASSED                                                                                                                                                [ 65%]
tests/test_device_strings.py::TestDeviceIndexVariants::test_torch_device_type_keyword PASSED                                                                                                                                                             [ 65%]
tests/test_device_strings.py::TestDeviceContextManager::test_device_context_with_musa PASSED                                                                                                                                                             [ 65%]
tests/test_device_strings.py::TestDeviceContextManager::test_device_context_with_cuda_translated PASSED                                                                                                                                                  [ 65%]
tests/test_device_strings.py::TestDeviceContextManager::test_original_functions_in_device_constructors PASSED                                                                                                                                            [ 66%]
tests/test_extension_build.py::TestExtensionBuildSetup::test_vector_add_cu_exists PASSED                                                                                                                                                                 [ 66%]
tests/test_extension_build.py::TestExtensionBuildSetup::test_can_create_setup_py PASSED                                                                                                                                                                  [ 66%]
tests/test_extension_build.py::TestExtensionBuild::test_build_vector_add_extension SKIPPED (Extension build tests are slow; set TORCHADA_TEST_BUILD=1 to run)                                                                                            [ 67%]
tests/test_extension_build.py::TestExtensionBuild::test_run_vector_add_extension SKIPPED (Extension build tests are slow; set TORCHADA_TEST_BUILD=1 to run)                                                                                              [ 67%]
tests/test_extension_build.py::TestMixedSourcesBuild::test_mixed_sources_dir_exists SKIPPED (Extension build tests are slow; set TORCHADA_TEST_BUILD=1 to run)                                                                                           [ 67%]
tests/test_extension_build.py::TestMixedSourcesBuild::test_all_source_files_exist SKIPPED (Extension build tests are slow; set TORCHADA_TEST_BUILD=1 to run)                                                                                             [ 68%]
tests/test_extension_build.py::TestMixedSourcesBuild::test_build_mixed_sources_extension SKIPPED (Extension build tests are slow; set TORCHADA_TEST_BUILD=1 to run)                                                                                      [ 68%]
tests/test_extension_build.py::TestMixedSourcesBuild::test_run_mixed_sources_extension SKIPPED (Extension build tests are slow; set TORCHADA_TEST_BUILD=1 to run)                                                                                        [ 68%]
tests/test_extension_build.py::TestSameNameFilePrecedence::test_same_name_dir_exists SKIPPED (Extension build tests are slow; set TORCHADA_TEST_BUILD=1 to run)                                                                                          [ 68%]
tests/test_extension_build.py::TestSameNameFilePrecedence::test_both_cu_and_mu_exist SKIPPED (Extension build tests are slow; set TORCHADA_TEST_BUILD=1 to run)                                                                                          [ 69%]
tests/test_extension_build.py::TestSameNameFilePrecedence::test_mu_file_takes_precedence SKIPPED (Extension build tests are slow; set TORCHADA_TEST_BUILD=1 to run)                                                                                      [ 69%]
tests/test_mappings.py::TestMappingImports::test_import_mapping_rule PASSED                                                                                                                                                                              [ 69%]
tests/test_mappings.py::TestMappingImports::test_import_ext_replaced_mapping PASSED                                                                                                                                                                      [ 70%]
tests/test_mappings.py::TestATenMappings::test_aten_cuda_namespace PASSED                                                                                                                                                                                [ 70%]
tests/test_mappings.py::TestATenMappings::test_aten_cuda_includes PASSED                                                                                                                                                                                 [ 70%]
tests/test_mappings.py::TestC10Mappings::test_c10_cuda_namespace PASSED                                                                                                                                                                                  [ 71%]
tests/test_mappings.py::TestC10Mappings::test_c10_device_type PASSED                                                                                                                                                                                     [ 71%]
tests/test_mappings.py::TestTorchMappings::test_torch_cuda_namespace PASSED                                                                                                                                                                              [ 71%]
tests/test_mappings.py::TestTorchMappings::test_torch_device_type PASSED                                                                                                                                                                                 [ 71%]
tests/test_mappings.py::TestCuBLASMappings::test_cublas_basic PASSED                                                                                                                                                                                     [ 72%]
tests/test_mappings.py::TestCuBLASMappings::test_cublas_types PASSED                                                                                                                                                                                     [ 72%]
tests/test_mappings.py::TestCuBLASMappings::test_cublas_functions PASSED                                                                                                                                                                                 [ 72%]
tests/test_mappings.py::TestCuBLASMappings::test_cublas_gemm PASSED                                                                                                                                                                                      [ 73%]
tests/test_mappings.py::TestCuBLASMappings::test_cublas_batched PASSED                                                                                                                                                                                   [ 73%]
tests/test_mappings.py::TestCuBLASMappings::test_cublaslt PASSED                                                                                                                                                                                         [ 73%]
tests/test_mappings.py::TestCuRANDMappings::test_curand_basic PASSED                                                                                                                                                                                     [ 73%]
tests/test_mappings.py::TestCuRANDMappings::test_curand_types PASSED                                                                                                                                                                                     [ 74%]
tests/test_mappings.py::TestCuRANDMappings::test_curand_functions PASSED                                                                                                                                                                                 [ 74%]
tests/test_mappings.py::TestCuDNNMappings::test_cudnn_basic PASSED                                                                                                                                                                                       [ 74%]
tests/test_mappings.py::TestCuDNNMappings::test_cudnn_types PASSED                                                                                                                                                                                       [ 75%]
tests/test_mappings.py::TestCuDNNMappings::test_cudnn_functions PASSED                                                                                                                                                                                   [ 75%]
tests/test_mappings.py::TestCUDARuntimeMappings::test_memory_functions PASSED                                                                                                                                                                            [ 75%]
tests/test_mappings.py::TestCUDARuntimeMappings::test_host_memory_functions PASSED                                                                                                                                                                       [ 76%]
tests/test_mappings.py::TestCUDARuntimeMappings::test_async_memory_functions PASSED                                                                                                                                                                      [ 76%]
tests/test_mappings.py::TestCUDARuntimeMappings::test_device_functions PASSED                                                                                                                                                                            [ 76%]
tests/test_mappings.py::TestCUDARuntimeMappings::test_memcpy_kinds PASSED                                                                                                                                                                                [ 76%]
tests/test_mappings.py::TestCUDARuntimeMappings::test_memory_constants PASSED                                                                                                                                                                            [ 77%]
tests/test_mappings.py::TestStreamEventMappings::test_stream_types PASSED                                                                                                                                                                                [ 77%]
tests/test_mappings.py::TestStreamEventMappings::test_stream_functions PASSED                                                                                                                                                                            [ 77%]
tests/test_mappings.py::TestStreamEventMappings::test_stream_flags PASSED                                                                                                                                                                                [ 78%]
tests/test_mappings.py::TestStreamEventMappings::test_event_functions PASSED                                                                                                                                                                             [ 78%]
tests/test_mappings.py::TestStreamEventMappings::test_event_flags PASSED                                                                                                                                                                                 [ 78%]
tests/test_mappings.py::TestErrorHandlingMappings::test_error_types PASSED                                                                                                                                                                               [ 78%]
tests/test_mappings.py::TestErrorHandlingMappings::test_error_functions PASSED                                                                                                                                                                           [ 79%]
tests/test_mappings.py::TestErrorHandlingMappings::test_error_codes PASSED                                                                                                                                                                               [ 79%]
tests/test_mappings.py::TestNCCLMappings::test_nccl_basic PASSED                                                                                                                                                                                         [ 79%]
tests/test_mappings.py::TestNCCLMappings::test_nccl_types PASSED                                                                                                                                                                                         [ 80%]
tests/test_mappings.py::TestNCCLMappings::test_nccl_comm_functions PASSED                                                                                                                                                                                [ 80%]
tests/test_mappings.py::TestNCCLMappings::test_nccl_collective_functions PASSED                                                                                                                                                                          [ 80%]
tests/test_mappings.py::TestLibraryMappings::test_cusparse PASSED                                                                                                                                                                                        [ 81%]
tests/test_mappings.py::TestLibraryMappings::test_cusolver PASSED                                                                                                                                                                                        [ 81%]
tests/test_mappings.py::TestLibraryMappings::test_cufft PASSED                                                                                                                                                                                           [ 81%]
tests/test_mappings.py::TestLibraryMappings::test_cutlass PASSED                                                                                                                                                                                         [ 81%]
tests/test_mappings.py::TestLibraryMappings::test_cub PASSED                                                                                                                                                                                             [ 82%]
tests/test_mappings.py::TestLibraryMappings::test_thrust PASSED                                                                                                                                                                                          [ 82%]
tests/test_mappings.py::TestIntrinsicMappings::test_shuffle_intrinsics_not_mapped PASSED                                                                                                                                                                 [ 82%]
tests/test_mappings.py::TestIntrinsicMappings::test_vote_intrinsics_not_mapped PASSED                                                                                                                                                                    [ 83%]
tests/test_mappings.py::TestIntrinsicMappings::test_sync_intrinsics_not_mapped PASSED                                                                                                                                                                    [ 83%]
tests/test_mappings.py::TestIntrinsicMappings::test_atomic_operations_not_mapped PASSED                                                                                                                                                                  [ 83%]
tests/test_mappings.py::TestIntrinsicMappings::test_half_precision_not_mapped PASSED                                                                                                                                                                     [ 84%]
tests/test_mappings.py::TestIncludeMappings::test_cuda_headers PASSED                                                                                                                                                                                    [ 84%]
tests/test_mappings.py::TestPyTorchCppMappings::test_pytorch_stream_utils PASSED                                                                                                                                                                         [ 84%]
tests/test_mappings.py::TestPyTorchCppMappings::test_pytorch_guards PASSED                                                                                                                                                                               [ 84%]
tests/test_mappings.py::TestPyTorchCppMappings::test_pytorch_handle PASSED                                                                                                                                                                               [ 85%]
tests/test_mappings.py::TestPyTorchCppMappings::test_pytorch_torch_namespace PASSED                                                                                                                                                                      [ 85%]
tests/test_mappings.py::TestCUDADriverMappings::test_memory_constants PASSED                                                                                                                                                                             [ 85%]
tests/test_mappings.py::TestMappingCount::test_mapping_count PASSED                                                                                                                                                                                      [ 86%]
tests/test_mappings.py::TestMappingCount::test_ext_replaced_mapping PASSED                                                                                                                                                                               [ 86%]
tests/test_mappings.py::TestMappingRobustness::test_no_identity_mappings PASSED                                                                                                                                                                          [ 86%]
tests/test_mappings.py::TestMappingRobustness::test_no_empty_keys_or_values PASSED                                                                                                                                                                       [ 86%]
tests/test_mappings.py::TestMappingRobustness::test_all_keys_and_values_are_strings PASSED                                                                                                                                                               [ 87%]
tests/test_mappings.py::TestMappingRobustness::test_cuda_to_musa_consistency PASSED                                                                                                                                                                      [ 87%]
tests/test_mappings.py::TestMappingApplication::test_port_cuda_source_basic PASSED                                                                                                                                                                       [ 87%]
tests/test_mappings.py::TestMappingApplication::test_port_cuda_source_includes PASSED                                                                                                                                                                    [ 88%]
tests/test_mappings.py::TestMappingApplication::test_port_cuda_source_types PASSED                                                                                                                                                                       [ 88%]
tests/test_mappings.py::TestMappingApplication::test_port_cuda_source_functions PASSED                                                                                                                                                                   [ 88%]
tests/test_mappings.py::TestMappingApplication::test_port_cuda_source_preserves_non_cuda PASSED                                                                                                                                                          [ 89%]
tests/test_mappings.py::TestMappingApplication::test_port_cuda_source_longer_patterns_first PASSED                                                                                                                                                       [ 89%]
tests/test_mappings.py::TestMappingApplication::test_port_cuda_source_c10_macros PASSED                                                                                                                                                                  [ 89%]
tests/test_mappings.py::TestMappingApplication::test_port_cuda_source_nccl PASSED                                                                                                                                                                        [ 89%]
tests/test_mappings.py::TestMappingSubstringOrdering::test_specific_before_generic PASSED                                                                                                                                                                [ 90%]
tests/test_mappings.py::TestMappingSubstringOrdering::test_include_specific_paths PASSED                                                                                                                                                                 [ 90%]
tests/test_mappings.py::TestRuntimeNameConversion::test_cuda_to_musa_name PASSED                                                                                                                                                                         [ 90%]
tests/test_mappings.py::TestRuntimeNameConversion::test_nccl_to_mccl_name PASSED                                                                                                                                                                         [ 91%]
tests/test_mappings.py::TestRuntimeNameConversion::test_cublas_to_mublas_name PASSED                                                                                                                                                                     [ 91%]
tests/test_mappings.py::TestRuntimeNameConversion::test_curand_to_murand_name PASSED                                                                                                                                                                     [ 91%]
tests/test_mappings.py::TestCDLLWrapper::test_cdll_wrapper_class_exists PASSED                                                                                                                                                                           [ 92%]
tests/test_mappings.py::TestCDLLWrapper::test_libmusart_cuda_to_musa_translation PASSED                                                                                                                                                                  [ 92%]
tests/test_mappings.py::TestCDLLWrapper::test_libmccl_nccl_to_mccl_translation PASSED                                                                                                                                                                    [ 92%]
tests/test_mappings.py::TestCDLLWrapper::test_libmublas_cublas_to_mublas_translation PASSED                                                                                                                                                              [ 92%]
tests/test_mappings.py::TestCDLLWrapper::test_libmurand_curand_to_murand_translation PASSED                                                                                                                                                              [ 93%]
tests/test_mappings.py::TestCDLLWrapper::test_non_musa_lib_no_translation PASSED                                                                                                                                                                         [ 93%]
tests/test_mappings.py::TestCDLLWrapper::test_sglang_cuda_wrapper_pattern PASSED                                                                                                                                                                         [ 93%]
tests/test_mappings.py::TestDeviceTypeMappingCompilation::test_device_type_test_source_exists SKIPPED (Extension build tests are slow; set TORCHADA_TEST_BUILD=1 to run)                                                                                 [ 94%]
tests/test_mappings.py::TestDeviceTypeMappingCompilation::test_build_device_type_extension SKIPPED (Extension build tests are slow; set TORCHADA_TEST_BUILD=1 to run)                                                                                    [ 94%]
tests/test_mappings.py::TestDeviceTypeMappingCompilation::test_run_device_type_extension SKIPPED (Extension build tests are slow; set TORCHADA_TEST_BUILD=1 to run)                                                                                      [ 94%]
tests/test_mappings.py::TestDeviceTypeMappingCompilation::test_ported_source_contains_privateuse1 SKIPPED (Extension build tests are slow; set TORCHADA_TEST_BUILD=1 to run)                                                                             [ 94%]
tests/test_platform.py::TestPlatformDetection::test_import_torchada PASSED                                                                                                                                                                               [ 95%]
tests/test_platform.py::TestPlatformDetection::test_detect_platform PASSED                                                                                                                                                                               [ 95%]
tests/test_platform.py::TestPlatformDetection::test_platform_detection_functions PASSED                                                                                                                                                                  [ 95%]
tests/test_platform.py::TestPlatformDetection::test_patches_applied PASSED                                                                                                                                                                               [ 96%]
tests/test_platform.py::TestPlatformDetection::test_get_version PASSED                                                                                                                                                                                   [ 96%]
tests/test_platform.py::TestPlatformDetection::test_get_platform PASSED                                                                                                                                                                                  [ 96%]
tests/test_platform.py::TestPlatformDetection::test_get_backend PASSED                                                                                                                                                                                   [ 97%]
tests/test_platform.py::TestPlatformDetection::test_is_gpu_device PASSED                                                                                                                                                                                 [ 97%]
tests/test_platform.py::TestPlatformDetection::test_is_cuda_like_device_alias PASSED                                                                                                                                                                     [ 97%]
tests/test_python_compat.py::TestPython38Compatibility::test_all_files_parse PASSED                                                                                                                                                                      [ 97%]
tests/test_python_compat.py::TestPython38Compatibility::test_all_modules_importable PASSED                                                                                                                                                               [ 98%]
tests/test_python_compat.py::TestPython38Compatibility::test_no_builtin_generic_types PASSED                                                                                                                                                             [ 98%]
tests/test_python_compat.py::TestPython38Compatibility::test_no_union_type_operator PASSED                                                                                                                                                               [ 98%]
tests/test_python_compat.py::TestPython38Compatibility::test_no_match_statement PASSED                                                                                                                                                                   [ 99%]
tests/test_python_compat.py::TestPython38Compatibility::test_no_removeprefix_removesuffix PASSED                                                                                                                                                         [ 99%]
tests/test_python_compat.py::TestPython38Compatibility::test_typing_imports_used PASSED                                                                                                                                                                  [ 99%]
tests/test_python_compat.py::TestPython38Compatibility::test_python_version_requirement PASSED                                                                                                                                                           [100%]

======================================================================================================================= warnings summary =======================================================================================================================
tests/test_cpp_extension.py::TestCUDAExtension::test_create_extension_basic
tests/test_cpp_extension.py::TestCUDAExtension::test_create_extension_with_include_dirs
tests/test_cpp_extension.py::TestCUDAExtension::test_create_extension_with_extra_compile_args
  /usr/local/lib/python3.10/dist-packages/torch_musa/utils/musa_extension.py:803: UserWarning: TORCH_MUSA_ARCH_LIST is not set, all archs for visible cards are included for compilation. 
  If this is not desired, please set os.environ['TORCH_MUSA_ARCH_LIST'].
    warnings.warn(

tests/test_cuda_patching.py::TestIsCompiledAndBackends::test_torch_backends_cuda_matmul_fp32_precision
  /usr/local/lib/python3.10/dist-packages/torch/__init__.py:1551: UserWarning: Please use the new API settings to control TF32 behavior, such as torch.backends.cudnn.conv.fp32_precision = 'tf32' or torch.backends.cuda.matmul.fp32_precision = 'ieee'. Old settings, e.g, torch.backends.cuda.matmul.allow_tf32 = True, torch.backends.cudnn.allow_tf32 = True, allowTF32CuDNN() and allowTF32CuBLAS() will be deprecated after Pytorch 2.9. Please see https://pytorch.org/docs/main/notes/cuda.html#tensorfloat-32-tf32-on-ampere-and-later-devices (Triggered internally at /home/pytorch/aten/src/ATen/Context.cpp:80.)
    return _C._get_float32_matmul_precision()

tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_with_allow_override
  /usr/local/lib/python3.10/dist-packages/torch/library.py:364: UserWarning: Warning only once for all operators,  other operators may also be overridden.
    Overriding a previously registered kernel for the same operator and the same dispatch key
    operator: test_lib_9ef1bcb0::test_op(Tensor x) -> Tensor
      registered at /home/dist/zhenxue/github/torchada/tests/test_cuda_patching.py:1552
    dispatch key: CPU
    previous kernel: no debug info
         new kernel: registered at /home/dist/zhenxue/github/torchada/tests/test_cuda_patching.py:1552 (Triggered internally at /home/pytorch/aten/src/ATen/core/dispatch/OperatorEntry.cpp:218.)
    self.m.impl(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================================================= 323 passed, 15 skipped, 5 warnings in 2.67s ==========================================================================================================
```