### PR TITLE
Fix/unsupported cuda api noops

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ See `src/torchada/_mapping.py` for the complete mapping table (380+ mappings).
 
 ```
 # pyproject.toml or requirements.txt
-torchada>=0.1.55
+torchada>=0.1.56
 ```
 
 ### Step 2: Conditional Import

--- a/README_CN.md
+++ b/README_CN.md
@@ -292,7 +292,7 @@ if torchada.is_gpu_device(device):  # 在 CUDA 和 MUSA 上都能工作
 
 ```
 # pyproject.toml 或 requirements.txt
-torchada>=0.1.55
+torchada>=0.1.56
 ```
 
 ### 步骤 2：条件导入

--- a/benchmarks/benchmark_history.json
+++ b/benchmarks/benchmark_history.json
@@ -3,7 +3,7 @@
   "description": "Historical benchmark results for torchada performance tracking",
   "results": [
     {
-      "version": "0.1.55",
+      "version": "0.1.56",
       "date": "2026-01-29",
       "platform": "MUSA",
       "pytorch_version": "2.7.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torchada"
-version = "0.1.55"
+version = "0.1.56"
 description = "Adapter package for torch_musa to act exactly like PyTorch CUDA"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/torchada/__init__.py
+++ b/src/torchada/__init__.py
@@ -24,7 +24,7 @@ Usage:
     from torch.utils.cpp_extension import CUDAExtension, BuildExtension, CUDA_HOME
 """
 
-__version__ = "0.1.55"
+__version__ = "0.1.56"
 
 from . import cuda, utils
 

--- a/src/torchada/_mapping.py
+++ b/src/torchada/_mapping.py
@@ -191,6 +191,9 @@ _MAPPING_RULE = {
     "cudaMemcpyHostToHost": "musaMemcpyHostToHost",
     # Constants - memory allocation
     "cudaFuncAttributeMaxDynamicSharedMemorySize": "musaFuncAttributeMaxDynamicSharedMemorySize",
+    # Unsupported APIs - map to no-ops or placeholders
+    "cudaGridDependencySynchronize()": "((void)0)",
+    "cudaTriggerProgrammaticLaunchCompletion()": "((void)0)",
     # =========================================================================
     # Data types
     # =========================================================================

--- a/tests/test_mappings.py
+++ b/tests/test_mappings.py
@@ -225,6 +225,12 @@ class TestCUDARuntimeMappings:
             == "musaFuncAttributeMaxDynamicSharedMemorySize"
         )
 
+    def test_unsupported_api_noops(self):
+        from torchada._mapping import _MAPPING_RULE
+
+        assert _MAPPING_RULE["cudaGridDependencySynchronize()"] == "((void)0)"
+        assert _MAPPING_RULE["cudaTriggerProgrammaticLaunchCompletion()"] == "((void)0)"
+
 
 class TestStreamEventMappings:
     """Test CUDA stream/event mappings."""
@@ -570,6 +576,8 @@ class TestMappingRobustness:
         exceptions = {
             "torch::kCUDA",  # Maps to PrivateUse1
             ".is_cuda()",  # Maps to .is_privateuseone()
+            "cudaGridDependencySynchronize()",
+            "cudaTriggerProgrammaticLaunchCompletion()",
         }
 
         for key, value in _MAPPING_RULE.items():


### PR DESCRIPTION
## Summary

- Add no-op mappings for unsupported CUDA runtime APIs:
  - `cudaGridDependencySynchronize()`
  - `cudaTriggerProgrammaticLaunchCompletion()`
- Add regression coverage for the new unsupported API mappings.
- Bump package/documented version references to `0.1.56`.

## Test plan

- [x] `PYTHONPATH=src pytest tests/test_mappings.py -q`

```text
........................................................................ [ 82%]
...........ssss                                                          [100%]
83 passed, 4 skipped in 0.13s
