### PR TITLE
fix(patch): preserve native matmul backend on torch 2.9

### DIFF
--- a/src/torchada/_patch.py
+++ b/src/torchada/_patch.py
@@ -1137,12 +1137,7 @@ def _patch_backends_cuda():
     This patches:
     - is_built() to return True when MUSA is available (since we're using
       torch.cuda APIs that are redirected to MUSA)
-    - torch.backends.cuda.matmul.fp32_precision to use torch.get/set_float32_matmul_precision
-      (this attribute is missing in some torch_musa versions)
-
-    Note: Other torch.backends.cuda.matmul properties (allow_tf32, etc.) work
-    as-is because they are settings that apply to the internal PyTorch
-    operations regardless of backend.
+    - torch.backends.cuda.matmul attribute access to MUSA matmul semantics
     """
     if not hasattr(torch, "backends") or not hasattr(torch.backends, "cuda"):
         return
@@ -1167,42 +1162,45 @@ def _patch_backends_cuda():
 
     torch.backends.cuda.is_built = patched_is_built
 
-    if (
+    if not (
         is_musa_platform()
         and hasattr(torch.backends, "musa")
         and hasattr(torch.backends.musa, "matmul")
+        and hasattr(torch.backends.cuda, "matmul")
     ):
-        torch.backends.cuda.matmul = torch.backends.musa.matmul
-
-    # Patch cuBLASModule to support fp32_precision attribute
-    # This attribute is in newer PyTorch but may be missing in torch_musa's version
-    matmul = torch.backends.cuda.matmul
-    matmul_class = matmul.__class__
-
-    # Check if fp32_precision is already supported
-    try:
-        _ = matmul.fp32_precision
-        # Already supported, no need to patch
         return
-    except AttributeError:
-        pass
 
-    # Store original methods
+    cuda_matmul = torch.backends.cuda.matmul
+    musa_matmul = torch.backends.musa.matmul
+    matmul_class = cuda_matmul.__class__
     original_getattr = matmul_class.__getattr__
     original_setattr = matmul_class.__setattr__
 
+    try:
+        _ = cuda_matmul.fp32_precision
+        has_native_fp32_precision = True
+    except AttributeError:
+        has_native_fp32_precision = False
+
     def patched_getattr(self, name):
-        if name == "fp32_precision":
+        if name == "fp32_precision" and not has_native_fp32_precision:
             return torch.get_float32_matmul_precision()
-        return original_getattr(self, name)
+        try:
+            return getattr(musa_matmul, name)
+        except (AttributeError, AssertionError):
+            return original_getattr(self, name)
 
     def patched_setattr(self, name, value):
-        if name == "fp32_precision":
+        if name == "fp32_precision" and not has_native_fp32_precision:
             return torch.set_float32_matmul_precision(value)
-        return original_setattr(self, name, value)
+        try:
+            return setattr(musa_matmul, name, value)
+        except (AttributeError, AssertionError):
+            return original_setattr(self, name, value)
 
     matmul_class.__getattr__ = patched_getattr
     matmul_class.__setattr__ = patched_setattr
+
 
 
 @patch_function

--- a/tests/test_cuda_patching.py
+++ b/tests/test_cuda_patching.py
@@ -1242,6 +1242,23 @@ class TestIsCompiledAndBackends:
         # Restore original
         torch.backends.cuda.matmul.allow_tf32 = original
 
+    def test_torch_backends_cuda_matmul_forwards_to_musa(self):
+        """Test torch.backends.cuda.matmul forwards settings to MUSA on MUSA."""
+        import torch
+
+        import torchada
+
+        if not torchada.is_musa_platform() or not hasattr(torch.backends, "musa"):
+            pytest.skip("MUSA matmul backend not available")
+
+        original = torch.backends.musa.matmul.allow_tf32
+        try:
+            torch.backends.cuda.matmul.allow_tf32 = not original
+            assert torch.backends.musa.matmul.allow_tf32 is (not original)
+            assert torch.backends.cuda.matmul.allow_tf32 is (not original)
+        finally:
+            torch.backends.cuda.matmul.allow_tf32 = original
+
     def test_torch_backends_cuda_matmul_fp32_precision(self):
         """Test torch.backends.cuda.matmul.fp32_precision is accessible."""
         import torch
@@ -1258,12 +1275,9 @@ class TestIsCompiledAndBackends:
         except (AttributeError, AssertionError):
             pytest.skip("fp32_precision not available (torchada MUSA-specific attribute)")
 
-        if (
-            not torchada.is_musa_platform()
-            and torch.__version__ >= torch.torch_version.TorchVersion("2.9.0")
-        ):
+        if torch.__version__ >= torch.torch_version.TorchVersion("2.9.0"):
             # PyTorch 2.9+: Only use the new API. Do NOT call torch.get_float32_matmul_precision()
-            valid_precisions = ("ieee", "tf32")
+            valid_precisions = ("none", "ieee", "tf32")
             test_values = ["ieee", "tf32"]
             check_underlying_api = False  # Critical: avoid mixing APIs
         else:


### PR DESCRIPTION
## Summary

Fix a PyTorch 2.9 + `torch.compile` compatibility issue on MUSA.

`torchada==0.1.55` replaces PyTorch's native CUDA matmul backend object with the MUSA matmul backend object:

```python
torch.backends.cuda.matmul = torch.backends.musa.matmul
```

That makes CUDA-style matmul settings point to MUSA, but it also changes the object seen by PyTorch internals.

In PyTorch 2.9, `torch.compile` / Inductor expects `torch.backends.cuda.matmul` to remain PyTorch's native backend object and reads native attributes from it. After the replacement, `torch.backends.cuda.matmul` becomes `torch_musa.core.musa.muBLASModule`, which does not expose all PyTorch 2.9 native matmul attributes.

This can break SGLang service startup when `torch.compile` / Inductor is enabled.

---

## Reproduced issue

With `torchada==0.1.55`:

```text
torch 2.9.0
torchada 0.1.55
is_musa_platform True
cuda.matmul class <class 'torch_musa.core.musa.muBLASModule'>
cuda.matmul is musa.matmul True
```

A minimal Inductor compile fails with:

```text
torch._dynamo.exc.BackendCompilerFailed: backend='inductor' raised:
AttributeError: Unknown attribute allow_fp16_reduced_precision_reduction
```

Relevant traceback:

```text
File "/usr/local/lib/python3.10/dist-packages/torch/_inductor/codecache.py", line 859, in __init__
    torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction,
AttributeError: Unknown attribute allow_fp16_reduced_precision_reduction
```

### Root cause

Inductor expects this attribute to exist on PyTorch's native `torch.backends.cuda.matmul` object:

```python
torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction
```

But after the replacement, `torch.backends.cuda.matmul` points to:

```python
torch.backends.musa.matmul
```

whose object type is:

```text
torch_musa.core.musa.muBLASModule
```

and that object does not provide the PyTorch 2.9 native matmul backend API.

---

## Fix

Keep the native PyTorch object:

```python
torch.backends.cuda.matmul
```

and patch attribute access on MUSA platforms so CUDA-style code still gets MUSA matmul semantics where appropriate.

After this change:

```python
torch.backends.cuda.matmul is not torch.backends.musa.matmul
```

but CUDA-style settings still forward to MUSA, for example:

```python
torch.backends.cuda.matmul.allow_tf32 = True
```

affects:

```python
torch.backends.musa.matmul.allow_tf32
```

on MUSA.

At the same time, PyTorch 2.9 / Inductor can still access native attributes such as:

```python
torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction
torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction
torch.backends.cuda.matmul.allow_fp16_accumulation
torch.backends.cuda.matmul.fp32_precision
```

---

## Validation

### Minimal `torch.compile` reproduction

After installing the fixed editable torchada:

```text
torch 2.9.0
torchada 0.1.56
cuda.matmul class <class 'torch.backends.cuda.cuBLASModule'>
cuda.matmul is musa.matmul False
allow_fp16_reduced_precision_reduction => True
allow_bf16_reduced_precision_reduction => True
allow_fp16_accumulation => False
allow_tf32 => False
fp32_precision => none
```

A minimal Inductor compile now succeeds:

```text
compile inductor ok torch.Size([4, 4]) cpu
```

### Targeted backend patch tests

```text
$ python3 -m pytest /home/dist/qzg/0506/gitlab/mcc/torchada/tests/test_cuda_patching.py::TestIsCompiledAndBackends

============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/dist/qzg/0506/gitlab/mcc/torchada
configfile: pyproject.toml
plugins: anyio-4.13.0
collected 7 items

torchada/tests/test_cuda_patching.py .......                             [100%]

============================== 7 passed in 0.02s ===============================
```

### Full torchada test suite

```text
$ python3 -m pytest /home/dist/qzg/0506/gitlab/mcc/torchada/tests

============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/dist/qzg/0506/gitlab/mcc/torchada
configfile: pyproject.toml
plugins: anyio-4.13.0
collected 340 items

torchada/tests/test_cpp_extension.py ...............                     [  4%]
torchada/tests/test_cuda_patching.py ................................... [ 14%]
...............................s........................................ [ 35%]
.............................................s.........................  [ 56%]
torchada/tests/test_device_strings.py ................................   [ 66%]
torchada/tests/test_extension_build.py ..sssssssss                       [ 69%]
torchada/tests/test_mappings.py ........................................ [ 81%]
...........................................ssss                          [ 95%]
torchada/tests/test_platform.py .........                                [ 97%]
torchada/tests/test_python_compat.py ........                            [100%]

================= 325 passed, 15 skipped, 4 warnings in 3.14s ==================
```

### SGLang startup validation

The SGLang service starts successfully after the fix:

```text
[2026-05-14 08:41:34] Capture cuda graph end. Time elapsed: 135.94 s. mem usage=1.08 GB. avail mem=7.39 GB.
[2026-05-14 08:42:12] Capture draft cuda graph end. Time elapsed: 30.44 s. mem usage=0.18 GB. avail mem=3.62 GB.
[2026-05-14 08:42:14] INFO:     Started server process [1181362]
[2026-05-14 08:42:14] INFO:     Waiting for application startup.
[2026-05-14 08:42:14] INFO:     Application startup complete.
[2026-05-14 08:42:14] INFO:     Uvicorn running on http://127.0.0.1:30000 (Press CTRL+C to quit)
[2026-05-14 08:42:15] INFO:     127.0.0.1:60398 - "GET /model_info HTTP/1.1" 200 OK
```
