### PR TITLE
feat(triton): add patch for triton.extra.cuda on MUSA platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ That's it! All `torch.cuda.*` APIs are automatically redirected to `torch.musa.*
 | FlexAttention | `torch.nn.attention.flex_attention` works on MUSA |
 | ctypes Libraries | `ctypes.CDLL` with CUDA function names → MUSA equivalents |
 | Unified Accelerator API | `torch.accelerator.empty_cache()`, `memory_stats()`, `Stream`, `Event`, ... |
+| Triton CUDA Extra | `tl.extra.cuda` → `tl.extra.musa` compatibility on MUSA |
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ See `src/torchada/_mapping.py` for the complete mapping table (380+ mappings).
 
 ```
 # pyproject.toml or requirements.txt
-torchada>=0.1.56
+torchada>=0.1.57
 ```
 
 ### Step 2: Conditional Import

--- a/README_CN.md
+++ b/README_CN.md
@@ -64,6 +64,7 @@ torch.cuda.synchronize()
 | FlexAttention | `torch.nn.attention.flex_attention` 支持 MUSA 设备 |
 | ctypes 库加载 | `ctypes.CDLL` 使用 CUDA 函数名 → 自动转换为 MUSA |
 | 统一加速器 API | `torch.accelerator.empty_cache()`、`memory_stats()`、`Stream`、`Event` 等 |
+| Triton CUDA Extra | MUSA 上的 `tl.extra.cuda` → `tl.extra.musa` 兼容 |
 
 ## 示例
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -293,7 +293,7 @@ if torchada.is_gpu_device(device):  # 在 CUDA 和 MUSA 上都能工作
 
 ```
 # pyproject.toml 或 requirements.txt
-torchada>=0.1.56
+torchada>=0.1.57
 ```
 
 ### 步骤 2：条件导入

--- a/benchmarks/benchmark_history.json
+++ b/benchmarks/benchmark_history.json
@@ -3,7 +3,7 @@
   "description": "Historical benchmark results for torchada performance tracking",
   "results": [
     {
-      "version": "0.1.56",
+      "version": "0.1.57",
       "date": "2026-01-29",
       "platform": "MUSA",
       "pytorch_version": "2.7.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torchada"
-version = "0.1.56"
+version = "0.1.57"
 description = "Adapter package for torch_musa to act exactly like PyTorch CUDA"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/torchada/__init__.py
+++ b/src/torchada/__init__.py
@@ -24,7 +24,7 @@ Usage:
     from torch.utils.cpp_extension import CUDAExtension, BuildExtension, CUDA_HOME
 """
 
-__version__ = "0.1.56"
+__version__ = "0.1.57"
 
 from . import cuda, utils
 

--- a/src/torchada/_patch.py
+++ b/src/torchada/_patch.py
@@ -25,7 +25,7 @@ import functools
 import inspect
 import sys
 import warnings
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 from typing import Any, Callable, List, Optional
 
 import torch
@@ -1202,7 +1202,6 @@ def _patch_backends_cuda():
     matmul_class.__setattr__ = patched_setattr
 
 
-
 @patch_function
 @requires_import("torchada.utils.cpp_extension", "torch.utils.cpp_extension")
 def _patch_cpp_extension():
@@ -1652,6 +1651,31 @@ def _patch_torch_accelerator():
 
 
 @patch_function
+@requires_import("torch_musa", "triton.language")
+def _patch_triton_extra():
+    if not is_musa_platform():
+        return
+
+    import triton.language as tl
+
+    if hasattr(tl.extra, "musa"):
+        tl.extra.cuda = tl.extra.musa
+    elif not hasattr(tl.extra, "cuda"):
+        tl.extra.cuda = SimpleNamespace()
+
+    def gdc_wait():
+        raise NotImplementedError("tl.extra.cuda.gdc_wait is not supported on MUSA")
+
+    def gdc_launch_dependents():
+        raise NotImplementedError("tl.extra.cuda.gdc_launch_dependents is not supported on MUSA")
+
+    if not hasattr(tl.extra.cuda, "gdc_wait"):
+        tl.extra.cuda.gdc_wait = gdc_wait
+    if not hasattr(tl.extra.cuda, "gdc_launch_dependents"):
+        tl.extra.cuda.gdc_launch_dependents = gdc_launch_dependents
+
+
+@patch_function
 def _patch_ctypes_cdll():
     """
     Patch ctypes.CDLL to automatically translate CUDA/NCCL function names to MUSA/MCCL.
@@ -1737,6 +1761,7 @@ def apply_patches():
     - torch._inductor.autotune_process.CUDA_VISIBLE_DEVICES -> MUSA_VISIBLE_DEVICES
     - torch.accelerator.synchronize() -> torch.musa.synchronize()
     - torch.accelerator context managers (device_index, stream) for forward compatibility
+    - Triton tl.extra.cuda.gdc_wait / gdc_launch_dependents unsupported shim
     - ctypes.CDLL function name translation for MUSA libraries:
         - cudaXxx -> musaXxx (for libmusart)
         - ncclXxx -> mcclXxx (for libmccl)

--- a/tests/test_triton_patching.py
+++ b/tests/test_triton_patching.py
@@ -1,0 +1,31 @@
+import pytest
+
+pytestmark = pytest.mark.musa
+
+
+def test_triton_extra_cuda_namespace_is_available_on_musa():
+    import torchada  # noqa: F401
+
+    tl = pytest.importorskip("triton.language")
+
+    assert hasattr(tl.extra, "cuda")
+    if hasattr(tl.extra, "musa") and hasattr(tl.extra.musa, "libdevice"):
+        assert hasattr(tl.extra.cuda, "libdevice")
+
+
+def test_triton_extra_cuda_gdc_functions_are_available_on_musa():
+    import torchada  # noqa: F401
+
+    tl = pytest.importorskip("triton.language")
+
+    assert hasattr(tl.extra, "cuda")
+    assert hasattr(tl.extra.cuda, "gdc_wait")
+    assert hasattr(tl.extra.cuda, "gdc_launch_dependents")
+
+    with pytest.raises(NotImplementedError, match="gdc_wait is not supported on MUSA"):
+        tl.extra.cuda.gdc_wait()
+    with pytest.raises(
+        NotImplementedError,
+        match="gdc_launch_dependents is not supported on MUSA",
+    ):
+        tl.extra.cuda.gdc_launch_dependents()


### PR DESCRIPTION
 ## Summary

  Add a torchada patch for Triton `tl.extra.cuda` compatibility on MUSA.

  On MUSA Triton, some downstream CUDA-oriented kernels may still reference
  `tl.extra.cuda`, for example `tl.extra.cuda.gdc_wait()` and
  `tl.extra.cuda.gdc_launch_dependents()`. Triton may resolve these attributes
  while building the JIT cache key, even when the corresponding constexpr branch
  is disabled, so missing `tl.extra.cuda` can fail before kernel compilation.

  This patch:
  - maps `tl.extra.cuda` to `tl.extra.musa` when `tl.extra.musa` exists
  - creates a minimal `tl.extra.cuda` namespace only when neither namespace exists
  - adds unsupported GDC stubs for `gdc_wait` and `gdc_launch_dependents`
  - preserves any existing `tl.extra.cuda` attributes and does not override existing GDC functions
  - adds a real-environment test for the Triton patch behavior

  ## Motivation

  This fixes MUSA failures in downstream Triton kernels that reference
  `tl.extra.cuda.gdc_*`, such as SGLang MLA KV buffer kernels, where Triton raises:

  ```text
  AttributeError: module 'triton.language.extra' has no attribute 'cuda'
```

  ## Validation

```
  PYTHONPATH=src \
  /root/.virtualenvs/triton-3.2.0/bin/python -m pytest tests/test_triton_patching.py -q
```
  Result:

  2 passed in 0.03s