### PR TITLE
Use graph rotation to workaround PCG limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,14 +335,15 @@ if is_nvidia() or is_musa():
 
 | Project | Category | Status | Tracking |
 |---------|----------|--------|----------|
+| [SGLang](https://github.com/sgl-project/sglang) | Model Serving | ✅ Merged | - |
+| [vLLM-MUSA](https://github.com/MooreThreads/vllm-musa) | Model Serving | ✅ Merged | — |
+| [vLLM-Omni](https://github.com/vllm-project/vllm-omni) | Model Serving (Omni) | ✅ Merged | - |
 | [Xinference](https://github.com/xorbitsai/inference) | Model Serving | ✅ Merged | — |
 | [LightLLM](https://github.com/ModelTC/LightLLM) | Model Serving | ✅ Merged | — |
 | [LightX2V](https://github.com/ModelTC/LightX2V) | Image/Video Generation | ✅ Merged | — |
 | [Chitu](https://github.com/thu-pacman/chitu) | Model Serving | ✅ Merged | — |
-| [vLLM-MUSA](https://github.com/MooreThreads/vllm-musa) | Model Serving | ✅ Merged | — |
-| [SGLang](https://github.com/sgl-project/sglang) | Model Serving | 🚧 In Progress | [SGLang#16565](https://github.com/sgl-project/sglang/issues/16565) |
+| [Mooncake](https://github.com/kvcache-ai/Mooncake) | KVCache | ✅ Merged | - |
 | [ComfyUI](https://github.com/Comfy-Org/ComfyUI) | Image/Video Generation | 🚧 In Progress | [ComfyUI#11618](https://github.com/Comfy-Org/ComfyUI/pull/11618) |
-| [vLLM-Omni](https://github.com/vllm-project/vllm-omni) | Model Serving (Omni) | 🚧 In Progress | [vLLM-Omni#2347](https://github.com/vllm-project/vllm-omni/issues/2347) |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ See `src/torchada/_mapping.py` for the complete mapping table (380+ mappings).
 
 ```
 # pyproject.toml or requirements.txt
-torchada>=0.1.58
+torchada>=0.1.59
 ```
 
 ### Step 2: Conditional Import

--- a/README_CN.md
+++ b/README_CN.md
@@ -330,14 +330,17 @@ if is_nvidia() or is_musa():
 
 | 项目 | 类别 | 状态 | 跟踪 |
 |------|------|------|------|
+| [SGLang](https://github.com/sgl-project/sglang) | 模型服务 | ✅ 已合并 | — |
+| [vLLM-MUSA](https://github.com/MooreThreads/vllm-musa) | 模型服务 | ✅ 已合并 | — |
+| [vLLM-Omni](https://github.com/vllm-project/vllm-omni) | 模型服务 (Omni) | ✅ 已合并 | — |
 | [Xinference](https://github.com/xorbitsai/inference) | 模型服务 | ✅ 已合并 | — |
 | [LightLLM](https://github.com/ModelTC/LightLLM) | 模型服务 | ✅ 已合并 | — |
 | [LightX2V](https://github.com/ModelTC/LightX2V) | 图像/视频生成 | ✅ 已合并 | — |
 | [赤兔](https://github.com/thu-pacman/chitu) | 模型服务 | ✅ 已合并 | — |
-| [vLLM-MUSA](https://github.com/MooreThreads/vllm-musa) | 模型服务 | ✅ 已合并 | — |
-| [SGLang](https://github.com/sgl-project/sglang) | 模型服务 | 🚧 进行中 | [SGLang#16565](https://github.com/sgl-project/sglang/issues/16565) |
+| [赤兔](https://github.com/thu-pacman/chitu) | 模型服务 | ✅ 已合并 | — |
+| [Mooncake](https://github.com/kvcache-ai/Mooncake) | KV 缓存 | ✅ 已合并 | - |
 | [ComfyUI](https://github.com/Comfy-Org/ComfyUI) | 图像/视频生成 | 🚧 进行中 | [ComfyUI#11618](https://github.com/Comfy-Org/ComfyUI/pull/11618) |
-| [vLLM-Omni](https://github.com/vllm-project/vllm-omni) | 模型服务 (Omni) | 🚧 进行中 | [vLLM-Omni#2347](https://github.com/vllm-project/vllm-omni/issues/2347) |
+
 
 ## 许可证
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -293,7 +293,7 @@ if torchada.is_gpu_device(device):  # 在 CUDA 和 MUSA 上都能工作
 
 ```
 # pyproject.toml 或 requirements.txt
-torchada>=0.1.58
+torchada>=0.1.59
 ```
 
 ### 步骤 2：条件导入

--- a/benchmarks/benchmark_history.json
+++ b/benchmarks/benchmark_history.json
@@ -3,7 +3,7 @@
   "description": "Historical benchmark results for torchada performance tracking",
   "results": [
     {
-      "version": "0.1.58",
+      "version": "0.1.59",
       "date": "2026-01-29",
       "platform": "MUSA",
       "pytorch_version": "2.7.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ torchada = [
     "csrc/*.mu",
     "csrc/*.cuh",
     "csrc/*.muh",
+    "_graph_rotation_src/*.cpp",
     "triton/autotune/fused_moe/configs/**/*.json",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torchada"
-version = "0.1.58"
+version = "0.1.59"
 description = "Adapter package for torch_musa to act exactly like PyTorch CUDA"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/torchada/__init__.py
+++ b/src/torchada/__init__.py
@@ -24,7 +24,7 @@ Usage:
     from torch.utils.cpp_extension import CUDAExtension, BuildExtension, CUDA_HOME
 """
 
-__version__ = "0.1.58"
+__version__ = "0.1.59"
 
 from . import cuda, utils
 

--- a/src/torchada/_cpp_ops.py
+++ b/src/torchada/_cpp_ops.py
@@ -21,6 +21,7 @@ import subprocess
 from typing import Optional
 
 _cpp_ops_module: Optional[object] = None
+_graph_rotation_module: Optional[object] = None
 _musa_arch_cached: Optional[str] = None
 
 
@@ -155,6 +156,65 @@ def load_cpp_ops(force_reload: bool = False) -> Optional[object]:
         import warnings
 
         warnings.warn(f"Failed to load torchada C++ ops: {e}")
+        return None
+
+
+def load_graph_rotation_ops(force_reload: bool = False) -> Optional[object]:
+    """Build/load the MUSA CUDA-graph executable-rotation ops.
+
+    This is a *separate* extension from the ATen op overrides built by
+    ``load_cpp_ops``: it needs torch_musa's internal headers (``MUSAGraph.h``) and
+    links ``libmusa_python``, and a build failure here must not break the core op
+    overrides. It is host-only (no device kernels), so torch's plain loader is used.
+    Built lazily by the graph-rotation module the first time rotation engages.
+
+    Returns the extension module exposing ``free_exec``/``inst_exec``/``has_exec``,
+    or ``None`` on a non-MUSA platform or build failure.
+    """
+    global _graph_rotation_module
+
+    if _graph_rotation_module is not None and not force_reload:
+        return _graph_rotation_module
+
+    from ._platform import is_musa_platform
+
+    if not is_musa_platform():
+        return None
+
+    try:
+        import os.path as osp
+
+        import torch_musa
+        from torch.utils.cpp_extension import load
+
+        src = osp.join(osp.dirname(__file__), "_graph_rotation_src", "graph_exec_aux.cpp")
+        tm = osp.dirname(torch_musa.__file__)
+        musa_home = os.environ.get("MUSA_HOME", "/usr/local/musa")
+        include_dirs = [
+            osp.join(tm, "csrc"),
+            osp.join(tm, "share", "generated_cuda_compatible", "include"),
+            osp.join(musa_home, "include"),
+        ]
+        libdir = osp.join(tm, "lib")
+        verbose = os.environ.get("TORCHADA_CPP_OPS_VERBOSE") == "1"
+
+        _graph_rotation_module = load(
+            name="torchada_graph_rotation_ops",
+            sources=[src],
+            extra_include_paths=include_dirs,
+            extra_cflags=["-O2"],
+            extra_ldflags=[
+                "-L" + osp.join(musa_home, "lib"), "-lmusart",
+                "-L" + libdir, "-lmusa_python", "-Wl,-rpath," + libdir,
+            ],
+            verbose=verbose,
+        )
+        return _graph_rotation_module
+
+    except Exception as e:
+        import warnings
+
+        warnings.warn(f"Failed to load torchada graph-rotation ops: {e}")
         return None
 
 

--- a/src/torchada/_graph_rotation.py
+++ b/src/torchada/_graph_rotation.py
@@ -1,0 +1,281 @@
+"""Transparent MUSA CUDA-graph executable rotation.
+
+The MUSA driver caps the number of *live* ``musaGraphExec_t`` (instantiated CUDA
+graphs) at ~2048 per process; the next ``musaGraphInstantiate`` then throws an
+illegal-memory-access at ``capture_end``. vLLM/SGLang piecewise CUDA graphs
+instantiate ``capture_sizes * num_layers`` executables, so models deeper than
+~40 layers blow past the cap and cannot use piecewise CUDA graphs at all.
+
+This works around it transparently. Graph *templates* (``musaGraph_t``) do **not**
+count toward the cap and re-instantiating an executable from an existing template is
+cheap (~0.3 ms) and needs no forward re-run. So we keep every template alive,
+LRU-cap the live *executables* (default cap 1900, just under the ~2043 driver
+limit), and re-instantiate an evicted graph's executable from its template on the
+next replay.
+
+It is **zero-cost until the cap is exceeded**: shallow models never evict, never
+build the aux extension, and pay only a dict insert per capture plus a single bool
+check per replay. Backed by a small aux ``.so`` JIT-built against torch_musa's
+*installed* headers -- it does not rebuild torch_musa.
+
+Environment variables:
+  * ``TORCHADA_GRAPH_ROTATION=0`` -- disable rotation entirely.
+  * ``TORCHADA_GRAPH_EXEC_CAP=<n>`` -- set the live-executable cap explicitly.
+  * ``TORCHADA_GRAPH_AUTOPROBE=1`` -- measure the real per-process limit at startup
+    and use ``limit - margin`` (adaptive across drivers; adds a one-time probe).
+  * ``TORCHADA_GRAPH_EXEC_MARGIN=<n>`` -- margin under the probed limit (default 128).
+"""
+
+from __future__ import annotations
+
+import collections
+import logging
+import os
+import threading
+import weakref
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# Safe-max default, just under the observed MUSA-driver per-process live-executable
+# limit (~2043 on MTT S5000 / driver 3.3.5). Bigger cap → larger working set fits →
+# fewer re-instantiations. Override with TORCHADA_GRAPH_EXEC_CAP, or set
+# TORCHADA_GRAPH_AUTOPROBE=1 to measure the real limit at startup and use limit−margin.
+_DEFAULT_CAP = 1900
+_DEFAULT_MARGIN = 128
+
+
+def _read_cap() -> int:
+    raw = os.environ.get("TORCHADA_GRAPH_EXEC_CAP", str(_DEFAULT_CAP))
+    try:
+        cap = int(raw)
+    except ValueError:
+        logger.warning("invalid TORCHADA_GRAPH_EXEC_CAP=%r; using %d", raw, _DEFAULT_CAP)
+        return _DEFAULT_CAP
+    return cap if cap > 0 else _DEFAULT_CAP
+
+
+_PROBE_SCRIPT = """
+import torch, torch_musa
+pool = torch.musa.graph_pool_handle()
+inp = torch.zeros(8, device="musa", dtype=torch.float32)
+_ = inp + 1.0
+torch.musa.synchronize()
+n = 0
+keep = []
+for i in range({max_probe}):
+    g = torch.musa.MUSAGraph()
+    try:
+        with torch.musa.graph(g, pool=pool):
+            y = inp + 1.0
+        keep.append(g)
+        n = i + 1
+    except Exception:
+        break
+print("TORCHADA_PROBE_LIMIT=%d" % n)
+"""
+
+
+def _probe_live_exec_limit(max_probe: int = 4096) -> Optional[int]:
+    """Measure the MUSA driver's per-process live-executable limit, in an ISOLATED
+    subprocess.
+
+    Capturing CUDA graphs to the failure point corrupts the process's RNG-generator
+    capture state ("Offset increment outside graph capture"), which would break the
+    serving process's later RNG. So the probe runs in a throwaway subprocess: it
+    captures trivial graphs until the ``capture_end`` illegal-memory-access, prints
+    the count that succeeded (= the limit), and exits — any corruption dies with it.
+    Returns the limit, or ``None`` if the probe could not run.
+    """
+    import subprocess
+    import sys
+
+    code = _PROBE_SCRIPT.format(max_probe=max_probe)
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True, text=True, timeout=300,
+        )
+        for line in proc.stdout.splitlines():
+            if line.startswith("TORCHADA_PROBE_LIMIT="):
+                return int(line.split("=", 1)[1])
+        logger.warning(
+            "graph-exec probe subprocess produced no limit; stderr tail: %s",
+            (proc.stderr or "")[-200:])
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("graph-exec probe subprocess failed: %r", exc)
+    return None
+
+
+def _resolve_cap() -> int:
+    """Pick the live-executable cap. Priority: explicit env > auto-probe > default."""
+    if "TORCHADA_GRAPH_EXEC_CAP" in os.environ:
+        return _read_cap()
+    if os.environ.get("TORCHADA_GRAPH_AUTOPROBE", "0") == "1":
+        limit = _probe_live_exec_limit()
+        if limit and limit > 0:
+            margin = _DEFAULT_MARGIN
+            try:
+                margin = int(os.environ.get("TORCHADA_GRAPH_EXEC_MARGIN", str(_DEFAULT_MARGIN)))
+            except ValueError:
+                pass
+            cap = max(64, limit - margin)
+            logger.warning(
+                "torchada graph-exec auto-probe: driver live-exec limit ≈ %d, "
+                "cap set to %d (margin %d).", limit, cap, margin)
+            return cap
+        logger.warning("torchada graph-exec auto-probe failed; using default cap %d", _DEFAULT_CAP)
+    return _DEFAULT_CAP
+
+
+class _Rotation:
+    """LRU rotation of live CUDA-graph executables, keyed by ``id(graph)``.
+
+    ``_live`` maps ``id(graph) -> weakref(graph)`` in LRU order and holds only the
+    graphs whose executable is currently instantiated. Weak references are used so
+    the rotation never keeps a user's graph alive beyond its own ownership.
+    """
+
+    def __init__(self, cap: int) -> None:
+        self.cap = cap
+        self._lock = threading.RLock()
+        self._live: "collections.OrderedDict[int, weakref.ReferenceType]" = (
+            collections.OrderedDict()
+        )
+        self._aux: Optional[Any] = None
+        self._aux_failed = False
+        self._evicting = False
+        self.stats: Dict[str, int] = {
+            "register": 0, "evict": 0, "reinstantiate": 0, "build_failed": 0
+        }
+
+    def _ensure_aux(self) -> Optional[Any]:
+        if self._aux is not None:
+            return self._aux
+        if self._aux_failed:
+            return None
+        from ._cpp_ops import load_graph_rotation_ops
+
+        aux = load_graph_rotation_ops()
+        if aux is None:
+            self._aux_failed = True
+            self.stats["build_failed"] += 1
+            logger.warning(
+                "torchada graph-exec rotation unavailable (aux ops failed to build); "
+                "deep models may hit the MUSA ~2048 CUDA-graph cap.")
+            return None
+        self._aux = aux
+        logger.warning(
+            "torchada graph-exec rotation engaged (cap=%d): live CUDA-graph "
+            "executables exceeded the cap; rotating via re-instantiation.", self.cap)
+        return self._aux
+
+    def _evict_locked(self, keep_id: int) -> None:
+        aux: Optional[Any] = None
+        while len(self._live) > self.cap:
+            key, wref = next(iter(self._live.items()))
+            if key == keep_id:                      # never evict the graph we just touched
+                self._live.move_to_end(key)
+                break
+            self._live.pop(key, None)
+            graph = wref()
+            if graph is None:                       # already GC'd -> exec freed by its destructor
+                continue
+            if aux is None:
+                aux = self._ensure_aux()
+                if aux is None:                     # aux unavailable -> cannot rotate; stop
+                    return
+            try:
+                aux.free_exec(graph)                # destroy exec, keep template
+                self._evicting = True
+                self.stats["evict"] += 1
+            except Exception as exc:                # noqa: BLE001
+                logger.warning("torchada rotation free_exec failed: %r", exc)
+
+    def register(self, graph: Any) -> None:
+        with self._lock:
+            key = id(graph)
+            self._live[key] = weakref.ref(graph)
+            self._live.move_to_end(key)
+            self.stats["register"] += 1
+            if len(self._live) > self.cap:
+                self._evict_locked(key)
+
+    def on_replay(self, graph: Any) -> None:
+        if not self._evicting:                      # fast path: nothing evicted -> exec is live
+            return
+        with self._lock:
+            aux = self._aux
+            if aux is None:
+                return
+            key = id(graph)
+            if key not in self._live or not aux.has_exec(graph):
+                aux.inst_exec(graph)                # re-instantiate from the kept template
+                self._live[key] = weakref.ref(graph)
+                self.stats["reinstantiate"] += 1
+            self._live.move_to_end(key)
+            self._evict_locked(key)
+
+    def snapshot(self) -> Dict[str, Any]:
+        with self._lock:
+            return dict(self.stats, live=len(self._live), cap=self.cap,
+                        evicting=self._evicting, aux_failed=self._aux_failed)
+
+
+_rotation: Optional[_Rotation] = None
+_installed = False
+_lock = threading.Lock()
+
+
+def is_enabled() -> bool:
+    return os.environ.get("TORCHADA_GRAPH_ROTATION", "1") != "0"
+
+
+def stats() -> Optional[Dict[str, Any]]:
+    """Diagnostics snapshot, or ``None`` if rotation is not installed."""
+    return _rotation.snapshot() if _rotation is not None else None
+
+
+def install() -> bool:
+    """Patch ``torch.musa.MUSAGraph.{capture_end,replay}`` to rotate executables.
+
+    Idempotent and safe to call from ``torchada.apply_patches()``. Returns True if
+    the patches were installed. No-op if disabled, if torch.musa is unavailable, or
+    if already installed.
+    """
+    global _installed, _rotation
+    with _lock:
+        if _installed:
+            return True
+        if not is_enabled():
+            return False
+        import torch
+
+        graph_cls = getattr(getattr(torch, "musa", None), "MUSAGraph", None)
+        if graph_cls is None:
+            return False
+
+        rot = _Rotation(_resolve_cap())
+        orig_capture_end = graph_cls.capture_end
+        orig_replay = graph_cls.replay
+
+        def capture_end(self: Any, *args: Any, **kwargs: Any) -> Any:
+            result = orig_capture_end(self, *args, **kwargs)
+            try:
+                rot.register(self)
+            except Exception as exc:                # noqa: BLE001
+                logger.warning("torchada rotation register failed: %r", exc)
+            return result
+
+        def replay(self: Any, *args: Any, **kwargs: Any) -> Any:
+            try:
+                rot.on_replay(self)
+            except Exception as exc:                # noqa: BLE001
+                logger.warning("torchada rotation on_replay failed: %r", exc)
+            return orig_replay(self, *args, **kwargs)
+
+        graph_cls.capture_end = capture_end
+        graph_cls.replay = replay
+        _rotation = rot
+        _installed = True
+        return True

--- a/src/torchada/_graph_rotation.py
+++ b/src/torchada/_graph_rotation.py
@@ -177,20 +177,24 @@ class _Rotation:
             if key == keep_id:                      # never evict the graph we just touched
                 self._live.move_to_end(key)
                 break
-            self._live.pop(key, None)
             graph = wref()
             if graph is None:                       # already GC'd -> exec freed by its destructor
+                self._live.pop(key, None)
                 continue
             if aux is None:
                 aux = self._ensure_aux()
                 if aux is None:                     # aux unavailable -> cannot rotate; stop
                     return
             try:
-                aux.free_exec(graph)                # destroy exec, keep template
-                self._evicting = True
-                self.stats["evict"] += 1
+                aux.free_exec(graph)                # destroy exec (keep template) FIRST
             except Exception as exc:                # noqa: BLE001
+                # free failed -> the exec is still live; keep it tracked and stop, so
+                # _live stays an honest count of live executables (no false eviction).
                 logger.warning("torchada rotation free_exec failed: %r", exc)
+                return
+            self._live.pop(key, None)               # untrack only after the exec is freed
+            self._evicting = True
+            self.stats["evict"] += 1
 
     def register(self, graph: Any) -> None:
         with self._lock:

--- a/src/torchada/_graph_rotation_src/graph_exec_aux.cpp
+++ b/src/torchada/_graph_rotation_src/graph_exec_aux.cpp
@@ -9,46 +9,54 @@
 // Compiled against torch_musa's INSTALLED headers at runtime via
 // torch.utils.cpp_extension.load -- it does NOT rebuild torch_musa.
 //
-// graph_/graph_exec_ are `protected` in at::musa::MUSAGraph; we reach them with a
-// derived accessor that adds no data members (identical object layout), which is a
-// standard, well-defined way to access protected base members.
+// graph_/graph_exec_/has_graph_exec_ are `protected` in at::musa::MUSAGraph. We
+// reach them through pointers-to-members formed inside a derived class, where
+// protected access is permitted. Because the members are declared in MUSAGraph,
+// the pointer type is pointer-to-member-of-MUSAGraph and applies directly to a
+// real MUSAGraph object -- no base->derived downcast, no undefined behavior.
 #include <torch/extension.h>
 #include "aten/musa/MUSAGraph.h"
 #include <musa_runtime_api.h>
 
 namespace {
-struct Accessor : public at::musa::MUSAGraph {
-  musaGraphExec_t& exec() { return graph_exec_; }
-  musaGraph_t&     tmpl() { return graph_; }
-  bool&            has_exec() { return has_graph_exec_; }
-  bool&            has_tmpl() { return has_graph_; }
+using Graph = at::musa::MUSAGraph;
+
+// Pointers to torch_musa's protected members, formed where access is allowed.
+struct Members : public Graph {
+  static musaGraphExec_t Graph::* exec() { return &Members::graph_exec_; }
+  static musaGraph_t     Graph::* tmpl() { return &Members::graph_; }
+  static bool            Graph::* has_exec_flag() { return &Members::has_graph_exec_; }
 };
+
+inline musaGraphExec_t& exec_of(Graph& g) { return g.*Members::exec(); }
+inline musaGraph_t&     tmpl_of(Graph& g) { return g.*Members::tmpl(); }
+inline bool&            has_exec_flag_of(Graph& g) { return g.*Members::has_exec_flag(); }
+
+// Ground truth for "is the executable live" is the pointer itself, not the flag.
+inline bool exec_live(Graph& g) { return exec_of(g) != nullptr; }
 }  // namespace
 
-static void free_exec(at::musa::MUSAGraph& g) {
-  auto& a = static_cast<Accessor&>(g);
-  if (a.has_exec() && a.exec() != nullptr) {
-    musaError_t e = musaGraphExecDestroy(a.exec());
+// Destroy graph_exec_, keep the graph_ template. Keyed on the pointer (not just the
+// flag) so it stays correct even if torch_musa's flag and pointer ever desync.
+static void free_exec(Graph& g) {
+  if (exec_live(g)) {
+    musaError_t e = musaGraphExecDestroy(exec_of(g));
     TORCH_CHECK(e == musaSuccess, "musaGraphExecDestroy failed: ", static_cast<int>(e));
-    a.exec() = nullptr;
-    a.has_exec() = false;
+    exec_of(g) = nullptr;
   }
+  has_exec_flag_of(g) = false;  // keep torch_musa's reset()/dtor bookkeeping in sync
 }
 
-static void inst_exec(at::musa::MUSAGraph& g) {
-  auto& a = static_cast<Accessor&>(g);
-  if (!a.has_exec()) {
-    TORCH_CHECK(a.has_tmpl() && a.tmpl() != nullptr,
-                "inst_exec: no graph template to instantiate from");
-    musaError_t e = musaGraphInstantiate(&a.exec(), a.tmpl(), nullptr, nullptr, 0);
-    TORCH_CHECK(e == musaSuccess, "musaGraphInstantiate failed: ", static_cast<int>(e));
-    a.has_exec() = true;
-  }
+// Re-instantiate graph_exec_ from the kept template. No-op if already live.
+static void inst_exec(Graph& g) {
+  if (exec_live(g)) return;
+  TORCH_CHECK(tmpl_of(g) != nullptr, "inst_exec: no graph template to instantiate from");
+  musaError_t e = musaGraphInstantiate(&exec_of(g), tmpl_of(g), nullptr, nullptr, 0);
+  TORCH_CHECK(e == musaSuccess, "musaGraphInstantiate failed: ", static_cast<int>(e));
+  has_exec_flag_of(g) = true;  // keep torch_musa's reset()/dtor bookkeeping in sync
 }
 
-static bool has_exec(at::musa::MUSAGraph& g) {
-  return static_cast<Accessor&>(g).has_exec();
-}
+static bool has_exec(Graph& g) { return exec_live(g); }
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("free_exec", &free_exec, "destroy graph_exec_, keep graph_ template");

--- a/src/torchada/_graph_rotation_src/graph_exec_aux.cpp
+++ b/src/torchada/_graph_rotation_src/graph_exec_aux.cpp
@@ -1,0 +1,57 @@
+// torchada CUDA-graph executable-rotation aux extension.
+//
+// Frees a MUSAGraph's executable while KEEPING its template, and re-instantiates
+// the executable from the kept template on demand. This lets torchada cap the
+// number of LIVE musaGraphExec_t (the MUSA driver throws an illegal-memory-access
+// at ~2048 live executables per process) while still being able to replay any
+// captured graph by re-instantiating it from its (cheap, uncapped) template.
+//
+// Compiled against torch_musa's INSTALLED headers at runtime via
+// torch.utils.cpp_extension.load -- it does NOT rebuild torch_musa.
+//
+// graph_/graph_exec_ are `protected` in at::musa::MUSAGraph; we reach them with a
+// derived accessor that adds no data members (identical object layout), which is a
+// standard, well-defined way to access protected base members.
+#include <torch/extension.h>
+#include "aten/musa/MUSAGraph.h"
+#include <musa_runtime_api.h>
+
+namespace {
+struct Accessor : public at::musa::MUSAGraph {
+  musaGraphExec_t& exec() { return graph_exec_; }
+  musaGraph_t&     tmpl() { return graph_; }
+  bool&            has_exec() { return has_graph_exec_; }
+  bool&            has_tmpl() { return has_graph_; }
+};
+}  // namespace
+
+static void free_exec(at::musa::MUSAGraph& g) {
+  auto& a = static_cast<Accessor&>(g);
+  if (a.has_exec() && a.exec() != nullptr) {
+    musaError_t e = musaGraphExecDestroy(a.exec());
+    TORCH_CHECK(e == musaSuccess, "musaGraphExecDestroy failed: ", static_cast<int>(e));
+    a.exec() = nullptr;
+    a.has_exec() = false;
+  }
+}
+
+static void inst_exec(at::musa::MUSAGraph& g) {
+  auto& a = static_cast<Accessor&>(g);
+  if (!a.has_exec()) {
+    TORCH_CHECK(a.has_tmpl() && a.tmpl() != nullptr,
+                "inst_exec: no graph template to instantiate from");
+    musaError_t e = musaGraphInstantiate(&a.exec(), a.tmpl(), nullptr, nullptr, 0);
+    TORCH_CHECK(e == musaSuccess, "musaGraphInstantiate failed: ", static_cast<int>(e));
+    a.has_exec() = true;
+  }
+}
+
+static bool has_exec(at::musa::MUSAGraph& g) {
+  return static_cast<Accessor&>(g).has_exec();
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("free_exec", &free_exec, "destroy graph_exec_, keep graph_ template");
+  m.def("inst_exec", &inst_exec, "re-instantiate graph_exec_ from the kept template");
+  m.def("has_exec", &has_exec, "whether graph_exec_ is currently live");
+}

--- a/src/torchada/_patch.py
+++ b/src/torchada/_patch.py
@@ -741,6 +741,17 @@ def _patch_torch_cuda_module():
         # MUSA's graph class uses musa_graph= but CUDA code uses cuda_graph=
         _patch_graph_context_manager()
 
+        # Install transparent CUDA-graph executable rotation so deep models can
+        # use piecewise CUDA graphs despite the MUSA driver's ~2048 live-executable
+        # per-process cap. Zero-cost until the cap is exceeded; disable with
+        # TORCHADA_GRAPH_ROTATION=0.
+        try:
+            from ._graph_rotation import install as _install_graph_rotation
+
+            _install_graph_rotation()
+        except Exception as _rot_exc:  # noqa: BLE001
+            warnings.warn(f"torchada graph-exec rotation install failed: {_rot_exc!r}")
+
         # Patch torch.cuda.nccl -> torch.musa.mccl
         if hasattr(torch.musa, "mccl"):
             sys.modules["torch.cuda.nccl"] = torch.musa.mccl

--- a/tests/test_graph_rotation.py
+++ b/tests/test_graph_rotation.py
@@ -1,0 +1,190 @@
+"""Tests for transparent CUDA-graph executable rotation.
+
+The MUSA driver caps live ``musaGraphExec_t`` at ~2048 per process. torchada's
+rotation keeps graph templates alive, LRU-caps live executables, and
+re-instantiates an evicted graph's executable from its template on replay. The
+capture/replay tests run on MUSA hardware only; the env-gating test is pure Python.
+"""
+
+import pytest
+import torch
+
+
+def _musa_ready() -> bool:
+    return hasattr(torch, "musa") and torch.musa.is_available()
+
+
+def test_is_enabled_respects_env(monkeypatch):
+    """Pure-Python: the master switch honors TORCHADA_GRAPH_ROTATION."""
+    from torchada import _graph_rotation as rot
+
+    monkeypatch.setenv("TORCHADA_GRAPH_ROTATION", "0")
+    assert rot.is_enabled() is False
+    monkeypatch.setenv("TORCHADA_GRAPH_ROTATION", "1")
+    assert rot.is_enabled() is True
+
+
+def test_cap_env_parsing(monkeypatch):
+    """Pure-Python: cap parsing falls back on bad input and rejects non-positive."""
+    from torchada import _graph_rotation as rot
+
+    monkeypatch.setenv("TORCHADA_GRAPH_EXEC_CAP", "1234")
+    assert rot._read_cap() == 1234
+    monkeypatch.setenv("TORCHADA_GRAPH_EXEC_CAP", "garbage")
+    assert rot._read_cap() == rot._DEFAULT_CAP
+    monkeypatch.setenv("TORCHADA_GRAPH_EXEC_CAP", "0")
+    assert rot._read_cap() == rot._DEFAULT_CAP
+
+
+def test_resolve_cap_priority(monkeypatch):
+    """Pure-Python: explicit cap wins; otherwise default (no probe unless opted in)."""
+    from torchada import _graph_rotation as rot
+
+    monkeypatch.setenv("TORCHADA_GRAPH_EXEC_CAP", "1500")
+    monkeypatch.delenv("TORCHADA_GRAPH_AUTOPROBE", raising=False)
+    assert rot._resolve_cap() == 1500
+
+    monkeypatch.delenv("TORCHADA_GRAPH_EXEC_CAP", raising=False)
+    monkeypatch.delenv("TORCHADA_GRAPH_AUTOPROBE", raising=False)
+    assert rot._resolve_cap() == rot._DEFAULT_CAP
+
+
+@pytest.mark.musa
+def test_rotation_installed_on_import():
+    import torchada  # noqa: F401  (apply_patches installs the rotation)
+
+    if not _musa_ready():
+        pytest.skip("MUSA-only test")
+    from torchada import _graph_rotation as rot
+
+    assert rot._installed, "rotation should install during torchada.apply_patches()"
+    assert rot._rotation is not None
+
+
+@pytest.mark.musa
+def test_rotation_captures_past_cap_and_replays_correctly():
+    """Capturing past the cap evicts executables (keeping templates); an evicted
+    graph must re-instantiate from its template and replay correctly."""
+    import torchada  # noqa: F401
+
+    if not _musa_ready():
+        pytest.skip("MUSA-only test")
+    from torchada import _graph_rotation as rot
+
+    if not rot._installed or rot._rotation is None:
+        pytest.skip("rotation not installed (TORCHADA_GRAPH_ROTATION=0?)")
+    r = rot._rotation
+
+    old_cap, old_evicting = r.cap, r._evicting
+    r._live.clear()
+    r._evicting = False
+    for key in r.stats:
+        r.stats[key] = 0
+    r.cap = 40
+    try:
+        dev = "musa"
+        pool = torch.musa.graph_pool_handle()
+
+        # a correctness graph captured first -> guaranteed evicted by the burst below
+        sout = torch.zeros(4, device=dev, dtype=torch.float32)
+        const = torch.full((4,), 7.0, device=dev, dtype=torch.float32)
+        g0 = torch.musa.MUSAGraph()
+        with torch.musa.graph(g0, pool=pool):
+            sout.copy_(const)
+
+        # capture well past the cap (40) to force eviction of g0's executable
+        inp = torch.randn(64, 64, device=dev, dtype=torch.bfloat16)
+        _ = inp + 1.0
+        torch.musa.synchronize()
+        held = []
+        for _ in range(200):
+            g = torch.musa.MUSAGraph()
+            with torch.musa.graph(g, pool=pool):
+                _y = inp + 1.0
+            held.append(g)
+
+        snap = r.snapshot()
+        assert snap["evict"] > 0, "expected evictions once past the cap"
+        assert snap["live"] <= r.cap, "live executables must stay within the cap"
+
+        # g0 was evicted long ago; replay must auto-reinstantiate from its template
+        sout.zero_()
+        g0.replay()
+        torch.musa.synchronize()
+        assert sout.tolist() == [7.0, 7.0, 7.0, 7.0], "evicted graph replayed incorrectly"
+        assert r.snapshot()["reinstantiate"] > 0, "expected a re-instantiation on replay"
+    finally:
+        r.cap, r._evicting = old_cap, old_evicting
+        r._live.clear()
+
+
+@pytest.mark.musa
+def test_probe_live_exec_limit_isolated():
+    """The auto-probe measures a positive driver limit in a throwaway subprocess
+    and leaves the caller's RNG generator uncorrupted (the in-process probe would
+    raise 'Offset increment outside graph capture' on later RNG)."""
+    import torchada  # noqa: F401
+
+    if not _musa_ready():
+        pytest.skip("MUSA-only test")
+    from torchada import _graph_rotation as rot
+
+    limit = rot._probe_live_exec_limit(max_probe=256)
+    assert limit is None or (isinstance(limit, int) and limit > 0)
+
+    # RNG inside a captured graph, then RNG outside -> raises if the probe corrupted
+    # this process's generator. Subprocess isolation must prevent that.
+    pool = torch.musa.graph_pool_handle()
+    out = torch.empty(8, device="musa", dtype=torch.float32)
+    g = torch.musa.MUSAGraph()
+    with torch.musa.graph(g, pool=pool):
+        out.copy_(torch.randn(8, device="musa", dtype=torch.float32))
+    g.replay()
+    torch.musa.synchronize()
+    _ = torch.randn(8, device="musa", dtype=torch.float32)
+    torch.musa.synchronize()
+
+
+@pytest.mark.musa
+def test_shallow_workload_never_evicts():
+    """Under-cap capture must not evict (and the replay fast path stays correct)."""
+    import torchada  # noqa: F401
+
+    if not _musa_ready():
+        pytest.skip("MUSA-only test")
+    from torchada import _graph_rotation as rot
+
+    if not rot._installed or rot._rotation is None:
+        pytest.skip("rotation not installed")
+    r = rot._rotation
+
+    old_cap = r.cap
+    r._live.clear()
+    evict0 = r.stats["evict"]
+    r.cap = 100_000  # effectively unbounded -> never evict
+    try:
+        dev = "musa"
+        pool = torch.musa.graph_pool_handle()
+        sout = torch.zeros(4, device=dev, dtype=torch.float32)
+        const = torch.full((4,), 3.0, device=dev, dtype=torch.float32)
+        g = torch.musa.MUSAGraph()
+        with torch.musa.graph(g, pool=pool):
+            sout.copy_(const)
+        held = [g]
+        inp = torch.randn(16, 16, device=dev, dtype=torch.bfloat16)
+        _ = inp + 1.0
+        torch.musa.synchronize()
+        for _ in range(50):
+            gx = torch.musa.MUSAGraph()
+            with torch.musa.graph(gx, pool=pool):
+                _y = inp + 1.0
+            held.append(gx)
+
+        assert r.stats["evict"] == evict0, "no eviction expected under the cap"
+        sout.zero_()
+        g.replay()
+        torch.musa.synchronize()
+        assert sout.tolist() == [3.0, 3.0, 3.0, 3.0]
+    finally:
+        r.cap = old_cap
+        r._live.clear()


### PR DESCRIPTION
Verified with vLLM-MUSA, PCG works as expected (qwen3_30b_moe_bf16/qwen3_8b_bf16/qwen3_30b_moe_fp8/qwen3_8b_fp8).

```bash
root@xiaodongye-s80:/ws# pytest -v ./tests/
========================================== test session starts ==========================================
platform linux -- Python 3.10.12, pytest-7.2.2, pluggy-1.6.0 -- /usr/bin/python
cachedir: .pytest_cache
hypothesis profile 'default'
rootdir: /ws
plugins: hypothesis-6.150.0, anyio-4.12.0
collected 342 items                                                                                     

tests/test_cpp_extension.py::TestCppExtensionImports::test_import_cuda_home PASSED                [  0%]
tests/test_cpp_extension.py::TestCppExtensionImports::test_import_cuda_extension PASSED           [  0%]
tests/test_cpp_extension.py::TestCppExtensionImports::test_import_build_extension PASSED          [  0%]
tests/test_cpp_extension.py::TestCppExtensionImports::test_cuda_home_on_musa PASSED               [  1%]
tests/test_cpp_extension.py::TestCppExtensionImports::test_torch_cpp_extension_is_patched PASSED  [  1%]
tests/test_cpp_extension.py::TestCppExtensionImports::test_torch_cpp_extension_cuda_home_same_as_torchada PASSED [  1%]
tests/test_cpp_extension.py::TestCUDAExtension::test_create_extension_basic PASSED                [  2%]
tests/test_cpp_extension.py::TestCUDAExtension::test_create_extension_with_include_dirs PASSED    [  2%]
tests/test_cpp_extension.py::TestCUDAExtension::test_create_extension_with_extra_compile_args PASSED [  2%]
tests/test_cpp_extension.py::TestMusaPatches::test_is_musa_file_recognizes_cu PASSED              [  2%]
tests/test_cpp_extension.py::TestMusaPatches::test_is_musa_file_recognizes_cuh PASSED             [  3%]
tests/test_cpp_extension.py::TestMusaPatches::test_is_musa_file_recognizes_mu PASSED              [  3%]
tests/test_cpp_extension.py::TestMusaPatches::test_ext_replaced_mapping PASSED                    [  3%]
tests/test_cpp_extension.py::TestMusaPatches::test_mapping_rule_exists PASSED                     [  4%]
tests/test_cpp_extension.py::TestMusaPatches::test_mapping_rule_has_expected_entries PASSED       [  4%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_is_patched_on_musa PASSED       [  4%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_is_available PASSED             [  4%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_device_count PASSED             [  5%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_device_count_nvml PASSED        [  5%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_current_device PASSED           [  5%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_get_device_name PASSED          [  6%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_synchronize PASSED              [  6%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_empty_cache PASSED              [  6%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_memory_allocated PASSED         [  7%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_memory_reserved PASSED          [  7%]
tests/test_cuda_patching.py::TestTorchCudaModule::test_torch_cuda_set_device PASSED               [  7%]
tests/test_cuda_patching.py::TestTorchCudaLazyInit::test_import_lazy_call PASSED                  [  7%]
tests/test_cuda_patching.py::TestTorchCudaLazyInit::test_lazy_call_functionality PASSED           [  8%]
tests/test_cuda_patching.py::TestTorchCudaAmp::test_import_autocast PASSED                        [  8%]
tests/test_cuda_patching.py::TestTorchCudaAmp::test_import_grad_scaler PASSED                     [  8%]
tests/test_cuda_patching.py::TestTorchCudaAmp::test_autocast_context_manager PASSED               [  9%]
tests/test_cuda_patching.py::TestTorchCudaAmp::test_grad_scaler_creation PASSED                   [  9%]
tests/test_cuda_patching.py::TestCUDAGraph::test_cuda_graph_alias PASSED                          [  9%]
tests/test_cuda_patching.py::TestCUDAGraph::test_cuda_graph_is_musa_graph PASSED                  [  9%]
tests/test_cuda_patching.py::TestCUDAGraph::test_cuda_graph_creation PASSED                       [ 10%]
tests/test_cuda_patching.py::TestCUDAGraph::test_graphs_module PASSED                             [ 10%]
tests/test_cuda_patching.py::TestCUDAGraph::test_make_graphed_callables PASSED                    [ 10%]
tests/test_cuda_patching.py::TestCUDAGraph::test_graph_pool_handle PASSED                         [ 11%]
tests/test_cuda_patching.py::TestCUDAGraph::test_graph_context_manager_cuda_graph_keyword PASSED  [ 11%]
tests/test_cuda_patching.py::TestCUDAGraph::test_graph_context_manager_positional PASSED          [ 11%]
tests/test_cuda_patching.py::TestCUDAGraph::test_graph_context_manager_musa_graph_keyword PASSED  [ 11%]
tests/test_cuda_patching.py::TestCUDAGraph::test_graph_context_manager_missing_arg_raises PASSED  [ 12%]
tests/test_cuda_patching.py::TestCUDAGraph::test_graph_context_manager_with_pool_and_stream PASSED [ 12%]
tests/test_cuda_patching.py::TestDistributedBackend::test_original_init_available PASSED          [ 12%]
tests/test_cuda_patching.py::TestDistributedBackend::test_mccl_backend_available PASSED           [ 13%]
tests/test_cuda_patching.py::TestDistributedBackend::test_nccl_backend_available PASSED           [ 13%]
tests/test_cuda_patching.py::TestDistributedBackend::test_new_group_patched PASSED                [ 13%]
tests/test_cuda_patching.py::TestDistributedBackend::test_has_param_with_mock_functions PASSED    [ 14%]
tests/test_cuda_patching.py::TestDistributedBackend::test_new_group_device_id_param_compatibility PASSED [ 14%]
tests/test_cuda_patching.py::TestNCCLModule::test_mccl_module_available PASSED                    [ 14%]
tests/test_cuda_patching.py::TestRNGFunctions::test_get_rng_state PASSED                          [ 14%]
tests/test_cuda_patching.py::TestRNGFunctions::test_set_rng_state PASSED                          [ 15%]
tests/test_cuda_patching.py::TestRNGFunctions::test_manual_seed PASSED                            [ 15%]
tests/test_cuda_patching.py::TestRNGFunctions::test_manual_seed_all PASSED                        [ 15%]
tests/test_cuda_patching.py::TestRNGFunctions::test_seed PASSED                                   [ 16%]
tests/test_cuda_patching.py::TestRNGFunctions::test_initial_seed PASSED                           [ 16%]
tests/test_cuda_patching.py::TestRNGFunctions::test_manual_seed_works PASSED                      [ 16%]
tests/test_cuda_patching.py::TestRandomFunctions::test_cuda_random_module_available PASSED        [ 16%]
tests/test_cuda_patching.py::TestRandomFunctions::test_cuda_random_aliases_musa PASSED            [ 17%]
tests/test_cuda_patching.py::TestRandomFunctions::test_cuda_random_functionality PASSED           [ 17%]
tests/test_cuda_patching.py::TestMemoryFunctions::test_max_memory_allocated PASSED                [ 17%]
tests/test_cuda_patching.py::TestMemoryFunctions::test_max_memory_reserved PASSED                 [ 18%]
tests/test_cuda_patching.py::TestMemoryFunctions::test_memory_stats PASSED                        [ 18%]
tests/test_cuda_patching.py::TestMemoryFunctions::test_memory_summary PASSED                      [ 18%]
tests/test_cuda_patching.py::TestMemoryFunctions::test_memory_snapshot PASSED                     [ 19%]
tests/test_cuda_patching.py::TestMemoryFunctions::test_reset_peak_memory_stats PASSED             [ 19%]
tests/test_cuda_patching.py::TestMemoryFunctions::test_mem_get_info PASSED                        [ 19%]
tests/test_cuda_patching.py::TestStreamAndEvent::test_stream_class PASSED                         [ 19%]
tests/test_cuda_patching.py::TestStreamAndEvent::test_event_class PASSED                          [ 20%]
tests/test_cuda_patching.py::TestStreamAndEvent::test_external_stream_class PASSED                [ 20%]
tests/test_cuda_patching.py::TestStreamAndEvent::test_current_stream PASSED                       [ 20%]
tests/test_cuda_patching.py::TestStreamAndEvent::test_default_stream PASSED                       [ 21%]
tests/test_cuda_patching.py::TestStreamAndEvent::test_set_stream PASSED                           [ 21%]
tests/test_cuda_patching.py::TestStreamAndEvent::test_stream_context_manager PASSED               [ 21%]
tests/test_cuda_patching.py::TestStreamAndEvent::test_stream_context_class PASSED                 [ 21%]
tests/test_cuda_patching.py::TestStreamAndEvent::test_stream_cuda_stream_property PASSED          [ 22%]
tests/test_cuda_patching.py::TestContextManagers::test_device_context_manager PASSED              [ 22%]
tests/test_cuda_patching.py::TestContextManagers::test_device_of_context_manager PASSED           [ 22%]
tests/test_cuda_patching.py::TestDeviceFunctions::test_get_device_properties PASSED               [ 23%]
tests/test_cuda_patching.py::TestDeviceFunctions::test_get_device_capability PASSED               [ 23%]
tests/test_cuda_patching.py::TestDeviceFunctions::test_is_initialized PASSED                      [ 23%]
tests/test_cuda_patching.py::TestTorchCudaMemory::test_import_pluggable_allocator SKIPPED (to...) [ 23%]
tests/test_cuda_patching.py::TestTorchCudaMemory::test_memory_pool_functions_available_on_musa PASSED [ 24%]
tests/test_cuda_patching.py::TestTorchCudaMemory::test_memory_pool_functions_importable_from_cuda_memory PASSED [ 24%]
tests/test_cuda_patching.py::TestTorchGenerator::test_generator_cuda_device PASSED                [ 24%]
tests/test_cuda_patching.py::TestTorchGenerator::test_generator_cuda_device_index PASSED          [ 25%]
tests/test_cuda_patching.py::TestTorchGenerator::test_generator_musa_device PASSED                [ 25%]
tests/test_cuda_patching.py::TestTorchGenerator::test_generator_no_device PASSED                  [ 25%]
tests/test_cuda_patching.py::TestTorchGenerator::test_generator_manual_seed_chain PASSED          [ 26%]
tests/test_cuda_patching.py::TestTorchGenerator::test_generator_isinstance_check PASSED           [ 26%]
tests/test_cuda_patching.py::TestTorchGenerator::test_generator_isinstance_negative PASSED        [ 26%]
tests/test_cuda_patching.py::TestTorchGenerator::test_generator_class_is_picklable PASSED         [ 26%]
tests/test_cuda_patching.py::TestTorchGenerator::test_generator_instance_is_picklable PASSED      [ 27%]
tests/test_cuda_patching.py::TestTorchGenerator::test_generator_picklable_in_container PASSED     [ 27%]
tests/test_cuda_patching.py::TestTorchVersionCuda::test_torch_version_cuda_not_patched PASSED     [ 27%]
tests/test_cuda_patching.py::TestTensorIsCuda::test_cpu_tensor_is_cuda_false PASSED               [ 28%]
tests/test_cuda_patching.py::TestTensorIsCuda::test_musa_tensor_is_cuda_true PASSED               [ 28%]
tests/test_cuda_patching.py::TestAutotuneProcess::test_cuda_visible_devices_patched PASSED        [ 28%]
tests/test_cuda_patching.py::TestAutotuneProcess::test_cuda_visible_devices_is_string PASSED      [ 28%]
tests/test_cuda_patching.py::TestAutotuneProcess::test_cuda_visible_devices_env_var_format PASSED [ 29%]
tests/test_cuda_patching.py::TestNvtxStub::test_nvtx_module_available PASSED                      [ 29%]
tests/test_cuda_patching.py::TestNvtxStub::test_nvtx_mark PASSED                                  [ 29%]
tests/test_cuda_patching.py::TestNvtxStub::test_nvtx_range_push_pop PASSED                        [ 30%]
tests/test_cuda_patching.py::TestNvtxStub::test_nvtx_range_context_manager PASSED                 [ 30%]
tests/test_cuda_patching.py::TestPatchDecorators::test_patch_registry_is_populated PASSED         [ 30%]
tests/test_cuda_patching.py::TestPatchDecorators::test_patch_registry_contains_expected_functions PASSED [ 30%]
tests/test_cuda_patching.py::TestPatchDecorators::test_requires_import_decorator_guards_import PASSED [ 31%]
tests/test_cuda_patching.py::TestPatchDecorators::test_requires_import_decorator_allows_execution PASSED [ 31%]
tests/test_cuda_patching.py::TestPatchDecorators::test_requires_import_multiple_modules PASSED    [ 31%]
tests/test_cuda_patching.py::TestIsCompiledAndBackends::test_torch_musa_is_compiled PASSED        [ 32%]
tests/test_cuda_patching.py::TestIsCompiledAndBackends::test_torch_cuda_is_compiled_redirects PASSED [ 32%]
tests/test_cuda_patching.py::TestIsCompiledAndBackends::test_torch_backends_cuda_is_built PASSED  [ 32%]
tests/test_cuda_patching.py::TestIsCompiledAndBackends::test_torch_backends_cuda_matmul_allow_tf32 PASSED [ 33%]
tests/test_cuda_patching.py::TestIsCompiledAndBackends::test_torch_backends_cuda_matmul_forwards_to_musa SKIPPED [ 33%]
tests/test_cuda_patching.py::TestIsCompiledAndBackends::test_torch_backends_cuda_matmul_fp32_precision SKIPPED [ 33%]
tests/test_cuda_patching.py::TestIsCompiledAndBackends::test_torch_c_storage_use_count PASSED     [ 33%]
tests/test_cuda_patching.py::TestProfilerActivity::test_profiler_activity_cuda_accessible PASSED  [ 34%]
tests/test_cuda_patching.py::TestProfilerActivity::test_profiler_with_cuda_activity PASSED        [ 34%]
tests/test_cuda_patching.py::TestProfilerActivity::test_profiler_context_manager PASSED           [ 34%]
tests/test_cuda_patching.py::TestProfilerActivity::test_profiler_methods_accessible PASSED        [ 35%]
tests/test_cuda_patching.py::TestMusaWarnings::test_musa_warnings_patch_applied PASSED            [ 35%]
tests/test_cuda_patching.py::TestMusaWarnings::test_autocast_warning_suppressed PASSED            [ 35%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_cuda_translated PASSED            [ 35%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_with_keyset PASSED                [ 36%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_with_keyset_false_explicit PASSED [ 36%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_op_name_as_keyword PASSED         [ 36%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_with_allow_override SKIPPED (...) [ 37%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_allow_override_false_explicit SKIPPED [ 37%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_with_keyset_and_with_allow_override SKIPPED [ 37%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_fn_as_keyword PASSED              [ 38%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_dispatch_key_as_keyword PASSED    [ 38%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_cuda_with_keyset PASSED           [ 38%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_autograd_cuda_translation PASSED  [ 38%]
tests/test_cuda_patching.py::TestLibraryImpl::test_library_impl_opoverload_as_op_name PASSED      [ 39%]
tests/test_cuda_patching.py::TestCudart::test_cudart_returns_wrapper PASSED                       [ 39%]
tests/test_cuda_patching.py::TestCudart::test_cudart_host_register PASSED                         [ 39%]
tests/test_cuda_patching.py::TestCudart::test_cudart_in_dir PASSED                                [ 40%]
tests/test_cuda_patching.py::TestCppExtensionPaths::test_include_paths_with_cuda_param PASSED     [ 40%]
tests/test_cuda_patching.py::TestCppExtensionPaths::test_include_paths_with_device_type_param PASSED [ 40%]
tests/test_cuda_patching.py::TestCppExtensionPaths::test_include_paths_default PASSED             [ 40%]
tests/test_cuda_patching.py::TestCppExtensionPaths::test_library_paths_with_cuda_param PASSED     [ 41%]
tests/test_cuda_patching.py::TestCppExtensionPaths::test_library_paths_with_device_type_param PASSED [ 41%]
tests/test_cuda_patching.py::TestCppExtensionPaths::test_library_paths_default PASSED             [ 41%]
tests/test_cuda_patching.py::TestCppExtensionPaths::test_include_paths_patched_in_torch_module PASSED [ 42%]
tests/test_cuda_patching.py::TestCppExtensionPaths::test_library_paths_patched_in_torch_module PASSED [ 42%]
tests/test_cuda_patching.py::TestCppExtensionPaths::test_get_torch_include_paths_pattern PASSED   [ 42%]
tests/test_cuda_patching.py::TestTensorFactoryFunctions::test_asarray_with_cuda_device PASSED     [ 42%]
tests/test_cuda_patching.py::TestTensorFactoryFunctions::test_asarray_with_cuda_index PASSED      [ 43%]
tests/test_cuda_patching.py::TestTensorFactoryFunctions::test_asarray_without_device PASSED       [ 43%]
tests/test_cuda_patching.py::TestTensorFactoryFunctions::test_tensor_with_cuda_device PASSED      [ 43%]
tests/test_cuda_patching.py::TestTensorFactoryFunctions::test_zeros_with_cuda_device SKIPPED      [ 44%]
tests/test_cuda_patching.py::TestTensorFactoryFunctions::test_ones_with_cuda_device SKIPPED (...) [ 44%]
tests/test_cuda_patching.py::TestTensorFactoryFunctions::test_randn_with_cuda_device SKIPPED      [ 44%]
tests/test_cuda_patching.py::TestTensorFactoryFunctions::test_empty_with_cuda_device PASSED       [ 45%]
tests/test_cuda_patching.py::TestCppOpsInfrastructure::test_cpp_ops_module_exists PASSED          [ 45%]
tests/test_cuda_patching.py::TestCppOpsInfrastructure::test_cpp_ops_loaded_on_musa PASSED         [ 45%]
tests/test_cuda_patching.py::TestCppOpsInfrastructure::test_cpp_ops_source_files_exist PASSED     [ 45%]
tests/test_cuda_patching.py::TestCppOpsInfrastructure::test_cpp_ops_header_content PASSED         [ 46%]
tests/test_cuda_patching.py::TestValidateDevice::test_musa_device_should_pass SKIPPED (MUDNN ...) [ 46%]
tests/test_cuda_patching.py::TestValidateDevice::test_patch_when_attribute_missing PASSED         [ 46%]
tests/test_cuda_patching.py::TestFlashAttnPatching::test_sgl_kernel_flash_attn_import_when_flash_attn_interface_available SKIPPED [ 47%]
tests/test_cuda_patching.py::TestFlashAttnPatching::test_sgl_kernel_flash_attn_module_in_sys_modules SKIPPED [ 47%]
tests/test_cuda_patching.py::TestFlashAttnPatching::test_sgl_kernel_stub_created_when_sgl_kernel_not_installed SKIPPED [ 47%]
tests/test_cuda_patching.py::TestFlashAttnPatching::test_sgl_kernel_existing_module_preserved SKIPPED [ 47%]
tests/test_cuda_patching.py::TestFlashAttnPatching::test_real_sgl_kernel_not_replaced_by_stub SKIPPED [ 48%]
tests/test_cuda_patching.py::TestFlashAttnPatching::test_flash_attn_direct_import_still_works PASSED [ 48%]
tests/test_cuda_patching.py::TestFlashAttnPatching::test_flash_attn_interface_submodule_accessible SKIPPED [ 48%]
tests/test_cuda_patching.py::TestFlashAttnPatching::test_patch_skipped_when_flash_attn_interface_not_available PASSED [ 49%]
tests/test_cuda_patching.py::TestFlashAttnPatching::test_multiple_flash_attn_functions_accessible SKIPPED [ 49%]
tests/test_cuda_patching.py::TestAcceleratorModuleWrapper::test_original_accelerator_takes_precedence_over_musa PASSED [ 49%]
tests/test_cuda_patching.py::TestAcceleratorModuleWrapper::test_musa_overrides_take_precedence_when_both_exist PASSED [ 50%]
tests/test_cuda_patching.py::TestAcceleratorModuleWrapper::test_fallback_to_musa_when_accelerator_missing PASSED [ 50%]
tests/test_cuda_patching.py::TestAcceleratorModuleWrapper::test_override_takes_precedence_over_everything PASSED [ 50%]
tests/test_cuda_patching.py::TestAcceleratorModuleWrapper::test_missing_everywhere_raises_attribute_error PASSED [ 50%]
tests/test_cuda_patching.py::TestAcceleratorModuleWrapper::test_resolved_attribute_is_cached PASSED [ 51%]
tests/test_cuda_patching.py::TestAcceleratorModuleWrapper::test_dir_includes_attributes_from_both_modules PASSED [ 51%]
tests/test_cuda_patching.py::TestAcceleratorModuleWrapper::test_remap_used_when_accel_and_musa_lack_index_suffix_name PASSED [ 51%]
tests/test_cuda_patching.py::TestAcceleratorModuleWrapper::test_remap_not_used_when_accelerator_has_official_impl PASSED [ 52%]
tests/test_cuda_patching.py::TestAcceleratorModuleWrapper::test_remap_keys_listed_in_dir PASSED   [ 52%]
tests/test_cuda_patching.py::TestAcceleratorModuleWrapper::test_special_attrs_for_nested_lookups PASSED [ 52%]
tests/test_cuda_patching.py::TestTorchAcceleratorPatching::test_accelerator_is_wrapped_on_musa PASSED [ 52%]
tests/test_cuda_patching.py::TestTorchAcceleratorPatching::test_existing_accelerator_apis_preserved PASSED [ 53%]
tests/test_cuda_patching.py::TestTorchAcceleratorPatching::test_empty_cache_falls_back_to_musa PASSED [ 53%]
tests/test_cuda_patching.py::TestTorchAcceleratorPatching::test_memory_apis_fall_back_to_musa PASSED [ 53%]
tests/test_cuda_patching.py::TestTorchAcceleratorPatching::test_rng_apis_fall_back_to_musa PASSED [ 54%]
tests/test_cuda_patching.py::TestTorchAcceleratorPatching::test_stream_and_event_classes_fall_back_to_musa PASSED [ 54%]
tests/test_cuda_patching.py::TestTorchAcceleratorPatching::test_synchronize_override_handles_multiple_device_types PASSED [ 54%]
tests/test_cuda_patching.py::TestTorchAcceleratorPatching::test_synchronize_override_rejects_invalid_types PASSED [ 54%]
tests/test_cuda_patching.py::TestTorchAcceleratorPatching::test_set_device_index_works_when_missing_from_original PASSED [ 55%]
tests/test_cuda_patching.py::TestTorchAcceleratorPatching::test_device_index_context_manager PASSED [ 55%]
tests/test_cuda_patching.py::TestTorchAcceleratorPatching::test_stream_context_manager PASSED     [ 55%]
tests/test_cuda_patching.py::TestTorchAcceleratorPatching::test_from_import_resolves_through_wrapper PASSED [ 56%]
tests/test_cuda_patching.py::TestTorchAcceleratorPatching::test_stream_context_falls_back_to_nested_musa_attr PASSED [ 56%]
tests/test_device_strings.py::TestTensorDevicePatching::test_tensor_cuda_method PASSED            [ 56%]
tests/test_device_strings.py::TestTensorDevicePatching::test_tensor_to_cuda_string PASSED         [ 57%]
tests/test_device_strings.py::TestTensorDevicePatching::test_tensor_to_cuda_device_index PASSED   [ 57%]
tests/test_device_strings.py::TestTensorDevicePatching::test_tensor_to_torch_device PASSED        [ 57%]
tests/test_device_strings.py::TestModuleDevicePatching::test_module_cuda_method PASSED            [ 57%]
tests/test_device_strings.py::TestModuleDevicePatching::test_module_to_cuda PASSED                [ 58%]
tests/test_device_strings.py::TestFactoryFunctions::test_torch_empty_device_cuda PASSED           [ 58%]
tests/test_device_strings.py::TestFactoryFunctions::test_torch_zeros_device_cuda PASSED           [ 58%]
tests/test_device_strings.py::TestFactoryFunctions::test_torch_ones_device_cuda PASSED            [ 59%]
tests/test_device_strings.py::TestFactoryFunctions::test_torch_randn_device_cuda PASSED           [ 59%]
tests/test_device_strings.py::TestFactoryFunctions::test_torch_rand_device_cuda PASSED            [ 59%]
tests/test_device_strings.py::TestFactoryFunctions::test_torch_full_device_cuda PASSED            [ 59%]
tests/test_device_strings.py::TestFactoryFunctions::test_torch_arange_device_cuda PASSED          [ 60%]
tests/test_device_strings.py::TestFactoryFunctions::test_torch_linspace_device_cuda PASSED        [ 60%]
tests/test_device_strings.py::TestTranslateDeviceFunction::test_translate_device_none PASSED      [ 60%]
tests/test_device_strings.py::TestTranslateDeviceFunction::test_translate_device_cuda_string PASSED [ 61%]
tests/test_device_strings.py::TestTranslateDeviceFunction::test_translate_device_cuda_with_index PASSED [ 61%]
tests/test_device_strings.py::TestTranslateDeviceFunction::test_translate_device_cpu_unchanged PASSED [ 61%]
tests/test_device_strings.py::TestTranslateDeviceFunction::test_translate_device_musa_unchanged PASSED [ 61%]
tests/test_device_strings.py::TestTranslateDeviceFunction::test_translate_device_integer_unchanged PASSED [ 62%]
tests/test_device_strings.py::TestTranslateDeviceFunction::test_translate_device_torch_device_cuda PASSED [ 62%]
tests/test_device_strings.py::TestTranslateDeviceFunction::test_translate_device_torch_device_cuda_with_index PASSED [ 62%]
tests/test_device_strings.py::TestTranslateDeviceFunction::test_translate_device_torch_device_cpu_unchanged PASSED [ 63%]
tests/test_device_strings.py::TestDeviceIndexVariants::test_cuda_colon_zero PASSED                [ 63%]
tests/test_device_strings.py::TestDeviceIndexVariants::test_factory_with_cuda_index PASSED        [ 63%]
tests/test_device_strings.py::TestDeviceIndexVariants::test_torch_device_cuda_zero PASSED         [ 64%]
tests/test_device_strings.py::TestDeviceIndexVariants::test_torch_device_with_index_arg PASSED    [ 64%]
tests/test_device_strings.py::TestDeviceIndexVariants::test_torch_device_from_original_cuda_device PASSED [ 64%]
tests/test_device_strings.py::TestDeviceIndexVariants::test_torch_device_type_keyword PASSED      [ 64%]
tests/test_device_strings.py::TestDeviceContextManager::test_device_context_with_musa PASSED      [ 65%]
tests/test_device_strings.py::TestDeviceContextManager::test_device_context_with_cuda_translated PASSED [ 65%]
tests/test_device_strings.py::TestDeviceContextManager::test_original_functions_in_device_constructors PASSED [ 65%]
tests/test_extension_build.py::TestExtensionBuildSetup::test_vector_add_cu_exists PASSED          [ 66%]
tests/test_extension_build.py::TestExtensionBuildSetup::test_can_create_setup_py PASSED           [ 66%]
tests/test_extension_build.py::TestExtensionBuild::test_build_vector_add_extension SKIPPED (E...) [ 66%]
tests/test_extension_build.py::TestExtensionBuild::test_run_vector_add_extension SKIPPED (Ext...) [ 66%]
tests/test_extension_build.py::TestMixedSourcesBuild::test_mixed_sources_dir_exists SKIPPED (...) [ 67%]
tests/test_extension_build.py::TestMixedSourcesBuild::test_all_source_files_exist SKIPPED (Ex...) [ 67%]
tests/test_extension_build.py::TestMixedSourcesBuild::test_build_mixed_sources_extension SKIPPED  [ 67%]
tests/test_extension_build.py::TestMixedSourcesBuild::test_run_mixed_sources_extension SKIPPED    [ 68%]
tests/test_extension_build.py::TestSameNameFilePrecedence::test_same_name_dir_exists SKIPPED      [ 68%]
tests/test_extension_build.py::TestSameNameFilePrecedence::test_both_cu_and_mu_exist SKIPPED      [ 68%]
tests/test_extension_build.py::TestSameNameFilePrecedence::test_mu_file_takes_precedence SKIPPED  [ 69%]
tests/test_mappings.py::TestMappingImports::test_import_mapping_rule PASSED                       [ 69%]
tests/test_mappings.py::TestMappingImports::test_import_ext_replaced_mapping PASSED               [ 69%]
tests/test_mappings.py::TestATenMappings::test_aten_cuda_namespace PASSED                         [ 69%]
tests/test_mappings.py::TestATenMappings::test_aten_cuda_includes PASSED                          [ 70%]
tests/test_mappings.py::TestC10Mappings::test_c10_cuda_namespace PASSED                           [ 70%]
tests/test_mappings.py::TestC10Mappings::test_c10_device_type PASSED                              [ 70%]
tests/test_mappings.py::TestTorchMappings::test_torch_cuda_namespace PASSED                       [ 71%]
tests/test_mappings.py::TestTorchMappings::test_torch_device_type PASSED                          [ 71%]
tests/test_mappings.py::TestCuBLASMappings::test_cublas_basic PASSED                              [ 71%]
tests/test_mappings.py::TestCuBLASMappings::test_cublas_types PASSED                              [ 71%]
tests/test_mappings.py::TestCuBLASMappings::test_cublas_functions PASSED                          [ 72%]
tests/test_mappings.py::TestCuBLASMappings::test_cublas_gemm PASSED                               [ 72%]
tests/test_mappings.py::TestCuBLASMappings::test_cublas_batched PASSED                            [ 72%]
tests/test_mappings.py::TestCuBLASMappings::test_cublaslt PASSED                                  [ 73%]
tests/test_mappings.py::TestCuRANDMappings::test_curand_basic PASSED                              [ 73%]
tests/test_mappings.py::TestCuRANDMappings::test_curand_types PASSED                              [ 73%]
tests/test_mappings.py::TestCuRANDMappings::test_curand_functions PASSED                          [ 73%]
tests/test_mappings.py::TestCuDNNMappings::test_cudnn_basic PASSED                                [ 74%]
tests/test_mappings.py::TestCuDNNMappings::test_cudnn_types PASSED                                [ 74%]
tests/test_mappings.py::TestCuDNNMappings::test_cudnn_functions PASSED                            [ 74%]
tests/test_mappings.py::TestCUDARuntimeMappings::test_memory_functions PASSED                     [ 75%]
tests/test_mappings.py::TestCUDARuntimeMappings::test_host_memory_functions PASSED                [ 75%]
tests/test_mappings.py::TestCUDARuntimeMappings::test_async_memory_functions PASSED               [ 75%]
tests/test_mappings.py::TestCUDARuntimeMappings::test_device_functions PASSED                     [ 76%]
tests/test_mappings.py::TestCUDARuntimeMappings::test_memcpy_kinds PASSED                         [ 76%]
tests/test_mappings.py::TestCUDARuntimeMappings::test_memory_constants PASSED                     [ 76%]
tests/test_mappings.py::TestCUDARuntimeMappings::test_unsupported_api_noops PASSED                [ 76%]
tests/test_mappings.py::TestStreamEventMappings::test_stream_types PASSED                         [ 77%]
tests/test_mappings.py::TestStreamEventMappings::test_stream_functions PASSED                     [ 77%]
tests/test_mappings.py::TestStreamEventMappings::test_stream_flags PASSED                         [ 77%]
tests/test_mappings.py::TestStreamEventMappings::test_event_functions PASSED                      [ 78%]
tests/test_mappings.py::TestStreamEventMappings::test_event_flags PASSED                          [ 78%]
tests/test_mappings.py::TestErrorHandlingMappings::test_error_types PASSED                        [ 78%]
tests/test_mappings.py::TestErrorHandlingMappings::test_error_functions PASSED                    [ 78%]
tests/test_mappings.py::TestErrorHandlingMappings::test_error_codes PASSED                        [ 79%]
tests/test_mappings.py::TestNCCLMappings::test_nccl_basic PASSED                                  [ 79%]
tests/test_mappings.py::TestNCCLMappings::test_nccl_types PASSED                                  [ 79%]
tests/test_mappings.py::TestNCCLMappings::test_nccl_comm_functions PASSED                         [ 80%]
tests/test_mappings.py::TestNCCLMappings::test_nccl_collective_functions PASSED                   [ 80%]
tests/test_mappings.py::TestLibraryMappings::test_cusparse PASSED                                 [ 80%]
tests/test_mappings.py::TestLibraryMappings::test_cusolver PASSED                                 [ 80%]
tests/test_mappings.py::TestLibraryMappings::test_cufft PASSED                                    [ 81%]
tests/test_mappings.py::TestLibraryMappings::test_cutlass PASSED                                  [ 81%]
tests/test_mappings.py::TestLibraryMappings::test_cub PASSED                                      [ 81%]
tests/test_mappings.py::TestLibraryMappings::test_thrust PASSED                                   [ 82%]
tests/test_mappings.py::TestIntrinsicMappings::test_shuffle_intrinsics_not_mapped PASSED          [ 82%]
tests/test_mappings.py::TestIntrinsicMappings::test_vote_intrinsics_not_mapped PASSED             [ 82%]
tests/test_mappings.py::TestIntrinsicMappings::test_sync_intrinsics_not_mapped PASSED             [ 83%]
tests/test_mappings.py::TestIntrinsicMappings::test_atomic_operations_not_mapped PASSED           [ 83%]
tests/test_mappings.py::TestIntrinsicMappings::test_half_precision_not_mapped PASSED              [ 83%]
tests/test_mappings.py::TestIncludeMappings::test_cuda_headers PASSED                             [ 83%]
tests/test_mappings.py::TestPyTorchCppMappings::test_pytorch_stream_utils PASSED                  [ 84%]
tests/test_mappings.py::TestPyTorchCppMappings::test_pytorch_guards PASSED                        [ 84%]
tests/test_mappings.py::TestPyTorchCppMappings::test_pytorch_handle PASSED                        [ 84%]
tests/test_mappings.py::TestPyTorchCppMappings::test_pytorch_torch_namespace PASSED               [ 85%]
tests/test_mappings.py::TestCUDADriverMappings::test_memory_constants PASSED                      [ 85%]
tests/test_mappings.py::TestMappingCount::test_mapping_count PASSED                               [ 85%]
tests/test_mappings.py::TestMappingCount::test_ext_replaced_mapping PASSED                        [ 85%]
tests/test_mappings.py::TestMappingRobustness::test_no_identity_mappings PASSED                   [ 86%]
tests/test_mappings.py::TestMappingRobustness::test_no_empty_keys_or_values PASSED                [ 86%]
tests/test_mappings.py::TestMappingRobustness::test_all_keys_and_values_are_strings PASSED        [ 86%]
tests/test_mappings.py::TestMappingRobustness::test_cuda_to_musa_consistency PASSED               [ 87%]
tests/test_mappings.py::TestMappingApplication::test_port_cuda_source_basic PASSED                [ 87%]
tests/test_mappings.py::TestMappingApplication::test_port_cuda_source_includes PASSED             [ 87%]
tests/test_mappings.py::TestMappingApplication::test_port_cuda_source_types PASSED                [ 88%]
tests/test_mappings.py::TestMappingApplication::test_port_cuda_source_functions PASSED            [ 88%]
tests/test_mappings.py::TestMappingApplication::test_port_cuda_source_preserves_non_cuda PASSED   [ 88%]
tests/test_mappings.py::TestMappingApplication::test_port_cuda_source_longer_patterns_first PASSED [ 88%]
tests/test_mappings.py::TestMappingApplication::test_port_cuda_source_c10_macros PASSED           [ 89%]
tests/test_mappings.py::TestMappingApplication::test_port_cuda_source_nccl PASSED                 [ 89%]
tests/test_mappings.py::TestMappingSubstringOrdering::test_specific_before_generic PASSED         [ 89%]
tests/test_mappings.py::TestMappingSubstringOrdering::test_include_specific_paths PASSED          [ 90%]
tests/test_mappings.py::TestRuntimeNameConversion::test_cuda_to_musa_name PASSED                  [ 90%]
tests/test_mappings.py::TestRuntimeNameConversion::test_nccl_to_mccl_name PASSED                  [ 90%]
tests/test_mappings.py::TestRuntimeNameConversion::test_cublas_to_mublas_name PASSED              [ 90%]
tests/test_mappings.py::TestRuntimeNameConversion::test_curand_to_murand_name PASSED              [ 91%]
tests/test_mappings.py::TestCDLLWrapper::test_cdll_wrapper_class_exists PASSED                    [ 91%]
tests/test_mappings.py::TestCDLLWrapper::test_libmusart_cuda_to_musa_translation PASSED           [ 91%]
tests/test_mappings.py::TestCDLLWrapper::test_libmccl_nccl_to_mccl_translation PASSED             [ 92%]
tests/test_mappings.py::TestCDLLWrapper::test_libmublas_cublas_to_mublas_translation PASSED       [ 92%]
tests/test_mappings.py::TestCDLLWrapper::test_libmurand_curand_to_murand_translation PASSED       [ 92%]
tests/test_mappings.py::TestCDLLWrapper::test_non_musa_lib_no_translation PASSED                  [ 92%]
tests/test_mappings.py::TestCDLLWrapper::test_sglang_cuda_wrapper_pattern PASSED                  [ 93%]
tests/test_mappings.py::TestDeviceTypeMappingCompilation::test_device_type_test_source_exists SKIPPED [ 93%]
tests/test_mappings.py::TestDeviceTypeMappingCompilation::test_build_device_type_extension SKIPPED [ 93%]
tests/test_mappings.py::TestDeviceTypeMappingCompilation::test_run_device_type_extension SKIPPED  [ 94%]
tests/test_mappings.py::TestDeviceTypeMappingCompilation::test_ported_source_contains_privateuse1 SKIPPED [ 94%]
tests/test_platform.py::TestPlatformDetection::test_import_torchada PASSED                        [ 94%]
tests/test_platform.py::TestPlatformDetection::test_detect_platform PASSED                        [ 95%]
tests/test_platform.py::TestPlatformDetection::test_platform_detection_functions PASSED           [ 95%]
tests/test_platform.py::TestPlatformDetection::test_patches_applied PASSED                        [ 95%]
tests/test_platform.py::TestPlatformDetection::test_get_version PASSED                            [ 95%]
tests/test_platform.py::TestPlatformDetection::test_get_platform PASSED                           [ 96%]
tests/test_platform.py::TestPlatformDetection::test_get_backend PASSED                            [ 96%]
tests/test_platform.py::TestPlatformDetection::test_is_gpu_device PASSED                          [ 96%]
tests/test_platform.py::TestPlatformDetection::test_is_cuda_like_device_alias PASSED              [ 97%]
tests/test_python_compat.py::TestPython38Compatibility::test_all_files_parse PASSED               [ 97%]
tests/test_python_compat.py::TestPython38Compatibility::test_all_modules_importable PASSED        [ 97%]
tests/test_python_compat.py::TestPython38Compatibility::test_no_builtin_generic_types PASSED      [ 97%]
tests/test_python_compat.py::TestPython38Compatibility::test_no_union_type_operator PASSED        [ 98%]
tests/test_python_compat.py::TestPython38Compatibility::test_no_match_statement PASSED            [ 98%]
tests/test_python_compat.py::TestPython38Compatibility::test_no_removeprefix_removesuffix PASSED  [ 98%]
tests/test_python_compat.py::TestPython38Compatibility::test_typing_imports_used PASSED           [ 99%]
tests/test_python_compat.py::TestPython38Compatibility::test_python_version_requirement PASSED    [ 99%]
tests/test_triton_patching.py::test_triton_extra_cuda_namespace_is_available_on_musa PASSED       [ 99%]
tests/test_triton_patching.py::test_triton_extra_cuda_gdc_functions_are_available_on_musa PASSED  [100%]

==================================== 312 passed, 30 skipped in 1.01s ====================================
root@xiaodongye-s80:/ws# 
```