### PR TITLE
Update vllm triton config dir

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,5 +212,10 @@ The C++ extension provides CUDA-compatible APIs including:
 
 - All patches are applied at import time via `apply_patches()`
 - Patches only affect torch APIs, not system resources
-- No network access or file system modifications
+- No network access. The only import-time file system modification is
+  best-effort and confined to torchada's own installed MoE config directory:
+  `set_default_moe_config_dir()` creates space-free filename aliases
+  (symlink, or atomic copy) for the bundled tuning configs so vLLM's
+  `VLLM_TUNED_CONFIG_FOLDER` lookup resolves. It is idempotent and silently
+  skipped when the install location is read-only.
 - C++ extension building uses standard torch/setuptools mechanisms

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ See `src/torchada/_mapping.py` for the complete mapping table (380+ mappings).
 
 ```
 # pyproject.toml or requirements.txt
-torchada>=0.1.60
+torchada>=0.1.61
 ```
 
 ### Step 2: Conditional Import

--- a/README_CN.md
+++ b/README_CN.md
@@ -293,7 +293,7 @@ if torchada.is_gpu_device(device):  # 在 CUDA 和 MUSA 上都能工作
 
 ```
 # pyproject.toml 或 requirements.txt
-torchada>=0.1.60
+torchada>=0.1.61
 ```
 
 ### 步骤 2：条件导入

--- a/benchmarks/benchmark_history.json
+++ b/benchmarks/benchmark_history.json
@@ -3,7 +3,7 @@
   "description": "Historical benchmark results for torchada performance tracking",
   "results": [
     {
-      "version": "0.1.60",
+      "version": "0.1.61",
       "date": "2026-01-29",
       "platform": "MUSA",
       "pytorch_version": "2.7.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torchada"
-version = "0.1.60"
+version = "0.1.61"
 description = "Adapter package for torch_musa to act exactly like PyTorch CUDA"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/torchada/__init__.py
+++ b/src/torchada/__init__.py
@@ -24,7 +24,7 @@ Usage:
     from torch.utils.cpp_extension import CUDAExtension, BuildExtension, CUDA_HOME
 """
 
-__version__ = "0.1.60"
+__version__ = "0.1.61"
 
 from . import cuda, utils
 

--- a/src/torchada/triton/autotune/fused_moe/__init__.py
+++ b/src/torchada/triton/autotune/fused_moe/__init__.py
@@ -1,6 +1,7 @@
 import importlib.metadata
 import logging
 import os
+import re
 import shutil
 from typing import Optional
 
@@ -10,11 +11,18 @@ _TRITON_DIR_PREFIX = "triton_"
 
 
 def _installed_triton_version() -> Optional[str]:
-    """Installed triton version without the (heavy) `import triton`."""
+    """Installed triton release (e.g. "3.2.0") without the (heavy) `import triton`.
+
+    Only the leading release segment is kept so PEP 440 variants such as
+    "3.2.0.post1", "3.2.0rc1", or "3.2.0+gitabcdef" all match the
+    "triton_3_2_0" config directory instead of falling back to "newest".
+    """
     try:
-        return importlib.metadata.version("triton").split("+")[0]
+        version = importlib.metadata.version("triton")
     except importlib.metadata.PackageNotFoundError:
         return None
+    match = re.match(r"\d+(?:\.\d+)*", version)
+    return match.group(0) if match else None
 
 
 def _pick_triton_config_dir(configs_root: str) -> Optional[str]:
@@ -70,10 +78,18 @@ def _alias_space_free_names(config_dir: str) -> None:
         except OSError:
             if os.path.lexists(alias):
                 continue
+            # Copy via a temp name + atomic replace so an interrupted copy
+            # can never leave a truncated JSON behind at the alias path.
+            tmp = f"{alias}.tmp.{os.getpid()}"
             try:
-                shutil.copy2(os.path.join(config_dir, name), alias)
+                shutil.copy2(os.path.join(config_dir, name), tmp)
+                os.replace(tmp, alias)
             except OSError as exc:
                 logger.debug("Cannot alias MoE config %s: %s", name, exc)
+                try:
+                    os.unlink(tmp)
+                except OSError:
+                    pass
 
 
 def _vllm_tuned_config_dir(base: str) -> Optional[str]:

--- a/src/torchada/triton/autotune/fused_moe/__init__.py
+++ b/src/torchada/triton/autotune/fused_moe/__init__.py
@@ -1,4 +1,94 @@
+import importlib.metadata
+import logging
 import os
+import shutil
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_TRITON_DIR_PREFIX = "triton_"
+
+
+def _installed_triton_version() -> Optional[str]:
+    """Installed triton version without the (heavy) `import triton`."""
+    try:
+        return importlib.metadata.version("triton").split("+")[0]
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def _pick_triton_config_dir(configs_root: str) -> Optional[str]:
+    """Pick `configs/triton_<ver>/` for the installed triton, else the newest."""
+    if not os.path.isdir(configs_root):
+        return None
+    subdirs = [
+        d
+        for d in os.listdir(configs_root)
+        if d.startswith(_TRITON_DIR_PREFIX) and os.path.isdir(os.path.join(configs_root, d))
+    ]
+    if not subdirs:
+        return None
+
+    version = _installed_triton_version()
+    if version is not None:
+        exact = _TRITON_DIR_PREFIX + version.replace(".", "_")
+        if exact in subdirs:
+            return os.path.join(configs_root, exact)
+
+    def _version_key(name: str):
+        parts = name[len(_TRITON_DIR_PREFIX) :].split("_")
+        return tuple(int(p) if p.isdigit() else -1 for p in parts)
+
+    return os.path.join(configs_root, max(subdirs, key=_version_key))
+
+
+def _alias_space_free_names(config_dir: str) -> None:
+    """Alias `...block_shape=[128, 128].json` to `...block_shape=[128,128].json`.
+
+    vLLM builds the lookup filename with spaces stripped
+    (`get_config_file_name` does `.replace(" ", "")`), while the tuning
+    scripts save filenames with `str(list)` spaces (which is what SGLang
+    looks up). Keep both names: symlink where possible, copy otherwise.
+    Idempotent and best-effort — on failure vLLM falls back to its default
+    config, exactly the pre-alias behavior.
+    """
+    try:
+        names = os.listdir(config_dir)
+    except OSError as exc:
+        logger.debug("Cannot list MoE config dir %s: %s", config_dir, exc)
+        return
+    for name in names:
+        if " " not in name or not name.endswith(".json"):
+            continue
+        alias = os.path.join(config_dir, name.replace(" ", ""))
+        if os.path.lexists(alias):
+            continue
+        try:
+            os.symlink(name, alias)
+        except FileExistsError:
+            continue  # another process won the race
+        except OSError:
+            if os.path.lexists(alias):
+                continue
+            try:
+                shutil.copy2(os.path.join(config_dir, name), alias)
+            except OSError as exc:
+                logger.debug("Cannot alias MoE config %s: %s", name, exc)
+
+
+def _vllm_tuned_config_dir(base: str) -> Optional[str]:
+    """Resolve the directory vLLM's flat VLLM_TUNED_CONFIG_FOLDER lookup needs.
+
+    vLLM (`get_moe_configs`) joins the env folder directly with the config
+    filename — it does not walk `configs/triton_<ver>/` subdirectories the
+    way SGLang does — so the env must point inside the version subdir, with
+    space-free filename aliases in place.
+    """
+    config_dir = _pick_triton_config_dir(os.path.join(base, "configs"))
+    if config_dir is None:
+        return None
+    _alias_space_free_names(config_dir)
+    return config_dir
 
 
 def set_default_moe_config_dir():
@@ -8,4 +98,5 @@ def set_default_moe_config_dir():
         os.environ["SGLANG_MOE_CONFIG_DIR"] = default_path
 
     if "VLLM_TUNED_CONFIG_FOLDER" not in os.environ:
-        os.environ["VLLM_TUNED_CONFIG_FOLDER"] = default_path
+        vllm_dir = _vllm_tuned_config_dir(default_path)
+        os.environ["VLLM_TUNED_CONFIG_FOLDER"] = vllm_dir or default_path

--- a/tests/test_moe_config_dir.py
+++ b/tests/test_moe_config_dir.py
@@ -1,0 +1,87 @@
+"""Tests for the fused_moe default config dir resolution (vLLM env redirect)."""
+
+import json
+import os
+
+import pytest
+
+from torchada.triton.autotune import fused_moe
+
+
+SPACED = "E=128,N=1536,device_name=MTT_S5000,dtype=fp8_w8a8,block_shape=[128, 128].json"
+SPACE_FREE = SPACED.replace(" ", "")
+PLAIN = "E=32,N=768,device_name=MTT_S5000.json"
+
+
+@pytest.fixture
+def config_tree(tmp_path):
+    """A fake torchada fused_moe package dir with one triton config subdir."""
+    triton_dir = tmp_path / "configs" / "triton_3_2_0"
+    triton_dir.mkdir(parents=True)
+    for name in (SPACED, PLAIN):
+        (triton_dir / name).write_text(json.dumps({"1": {"BLOCK_SIZE_M": 16}}))
+    return tmp_path
+
+
+def test_resolves_triton_subdir_and_aliases(config_tree):
+    resolved = fused_moe._vllm_tuned_config_dir(str(config_tree))
+    assert resolved == str(config_tree / "configs" / "triton_3_2_0")
+    # vLLM's flat, space-free lookup must now hit both configs.
+    assert os.path.exists(os.path.join(resolved, SPACE_FREE))
+    assert os.path.exists(os.path.join(resolved, PLAIN))
+    # SGLang's spaced lookup is untouched.
+    assert os.path.exists(os.path.join(resolved, SPACED))
+
+
+def test_alias_is_idempotent(config_tree):
+    first = fused_moe._vllm_tuned_config_dir(str(config_tree))
+    before = sorted(os.listdir(first))
+    second = fused_moe._vllm_tuned_config_dir(str(config_tree))
+    assert first == second
+    assert sorted(os.listdir(second)) == before
+
+
+def test_alias_content_matches_source(config_tree):
+    resolved = fused_moe._vllm_tuned_config_dir(str(config_tree))
+    with open(os.path.join(resolved, SPACE_FREE)) as f:
+        assert json.load(f) == {"1": {"BLOCK_SIZE_M": 16}}
+
+
+def test_exact_triton_version_dir_wins(tmp_path, monkeypatch):
+    for ver in ("triton_3_1_0", "triton_3_2_0"):
+        (tmp_path / "configs" / ver).mkdir(parents=True)
+    monkeypatch.setattr(fused_moe, "_installed_triton_version", lambda: "3.1.0")
+    resolved = fused_moe._vllm_tuned_config_dir(str(tmp_path))
+    assert resolved == str(tmp_path / "configs" / "triton_3_1_0")
+
+
+def test_newest_dir_fallback_when_version_unknown(tmp_path, monkeypatch):
+    for ver in ("triton_3_1_0", "triton_3_2_0"):
+        (tmp_path / "configs" / ver).mkdir(parents=True)
+    monkeypatch.setattr(fused_moe, "_installed_triton_version", lambda: None)
+    resolved = fused_moe._vllm_tuned_config_dir(str(tmp_path))
+    assert resolved == str(tmp_path / "configs" / "triton_3_2_0")
+
+
+def test_newest_dir_fallback_when_no_exact_match(tmp_path, monkeypatch):
+    for ver in ("triton_3_1_0", "triton_3_2_0"):
+        (tmp_path / "configs" / ver).mkdir(parents=True)
+    monkeypatch.setattr(fused_moe, "_installed_triton_version", lambda: "9.9.9")
+    resolved = fused_moe._vllm_tuned_config_dir(str(tmp_path))
+    assert resolved == str(tmp_path / "configs" / "triton_3_2_0")
+
+
+def test_missing_configs_root_returns_none(tmp_path):
+    assert fused_moe._vllm_tuned_config_dir(str(tmp_path)) is None
+
+
+def test_env_redirect_set_at_import():
+    """`import torchada` (done by conftest) must leave the env pointing at a
+    real directory whose space-containing configs all have space-free twins."""
+    folder = os.environ.get("VLLM_TUNED_CONFIG_FOLDER")
+    assert folder and os.path.isdir(folder)
+    if os.path.dirname(fused_moe.__file__) not in folder:
+        pytest.skip("VLLM_TUNED_CONFIG_FOLDER overridden by the environment")
+    spaced = [n for n in os.listdir(folder) if " " in n and n.endswith(".json")]
+    for name in spaced:
+        assert os.path.exists(os.path.join(folder, name.replace(" ", "")))

--- a/tests/test_moe_config_dir.py
+++ b/tests/test_moe_config_dir.py
@@ -1,5 +1,6 @@
 """Tests for the fused_moe default config dir resolution (vLLM env redirect)."""
 
+import importlib.metadata
 import json
 import os
 
@@ -55,6 +56,20 @@ def test_exact_triton_version_dir_wins(tmp_path, monkeypatch):
     assert resolved == str(tmp_path / "configs" / "triton_3_1_0")
 
 
+@pytest.mark.parametrize(
+    "raw",
+    ["3.2.0", "3.2.0.post1", "3.2.0rc1", "3.2.0+git9d8d5e91", "3.2.0.dev20260601"],
+)
+def test_pep440_variants_match_release_dir(tmp_path, monkeypatch, raw):
+    """post/rc/dev/local-version suffixes must still exact-match triton_3_2_0
+    (not silently fall back to the newest directory)."""
+    for ver in ("triton_3_1_0", "triton_3_2_0"):
+        (tmp_path / "configs" / ver).mkdir(parents=True)
+    monkeypatch.setattr(importlib.metadata, "version", lambda name: raw)
+    resolved = fused_moe._vllm_tuned_config_dir(str(tmp_path))
+    assert resolved == str(tmp_path / "configs" / "triton_3_2_0")
+
+
 def test_newest_dir_fallback_when_version_unknown(tmp_path, monkeypatch):
     for ver in ("triton_3_1_0", "triton_3_2_0"):
         (tmp_path / "configs" / ver).mkdir(parents=True)
@@ -79,9 +94,10 @@ def test_env_redirect_set_at_import():
     """`import torchada` (done by conftest) must leave the env pointing at a
     real directory whose space-containing configs all have space-free twins."""
     folder = os.environ.get("VLLM_TUNED_CONFIG_FOLDER")
-    assert folder and os.path.isdir(folder)
+    assert folder
     if os.path.dirname(fused_moe.__file__) not in folder:
         pytest.skip("VLLM_TUNED_CONFIG_FOLDER overridden by the environment")
+    assert os.path.isdir(folder)
     spaced = [n for n in os.listdir(folder) if " " in n and n.endswith(".json")]
     for name in spaced:
         assert os.path.exists(os.path.join(folder, name.replace(" ", "")))


### PR DESCRIPTION
Tested `Qwen3-30B-A3B-FP8`, PASS — FULL_AND_PIECEWISE ladders ran, config census 100% torchada (E=128,N=768,fp8_w8a8), 0 fallbacks, 200 OK "Paris".