### PR TITLE
fix: translate factory device kwargs via TorchFunctionMode

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ See `src/torchada/_mapping.py` for the complete mapping table (380+ mappings).
 
 ```
 # pyproject.toml or requirements.txt
-torchada>=0.1.61
+torchada>=0.1.62
 ```
 
 ### Step 2: Conditional Import

--- a/README_CN.md
+++ b/README_CN.md
@@ -293,7 +293,7 @@ if torchada.is_gpu_device(device):  # 在 CUDA 和 MUSA 上都能工作
 
 ```
 # pyproject.toml 或 requirements.txt
-torchada>=0.1.61
+torchada>=0.1.62
 ```
 
 ### 步骤 2：条件导入

--- a/benchmarks/benchmark_history.json
+++ b/benchmarks/benchmark_history.json
@@ -3,7 +3,7 @@
   "description": "Historical benchmark results for torchada performance tracking",
   "results": [
     {
-      "version": "0.1.61",
+      "version": "0.1.62",
       "date": "2026-01-29",
       "platform": "MUSA",
       "pytorch_version": "2.7.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torchada"
-version = "0.1.61"
+version = "0.1.62"
 description = "Adapter package for torch_musa to act exactly like PyTorch CUDA"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/torchada/__init__.py
+++ b/src/torchada/__init__.py
@@ -24,7 +24,7 @@ Usage:
     from torch.utils.cpp_extension import CUDAExtension, BuildExtension, CUDA_HOME
 """
 
-__version__ = "0.1.61"
+__version__ = "0.1.62"
 
 from . import cuda, utils
 

--- a/src/torchada/_patch.py
+++ b/src/torchada/_patch.py
@@ -475,6 +475,30 @@ class _FactoryDeviceMode(TorchFunctionMode):
         return func(*args, **kwargs)
 
 
+def _shield_torch_musa_tensor_attrs() -> None:
+    """Exempt torch_musa-injected Tensor attrs from torch_function dispatch.
+
+    torch_musa's ``Tensor.musa`` C relay mis-populates the protocol args
+    (passes the module instead of self), so any active TorchFunctionMode
+    breaks it. The attrs never need device translation; bypass the protocol.
+    """
+    for name in ("musa", "pin_memory", "is_pinned"):
+        attr = getattr(torch.Tensor, name, None)
+        if attr is None or getattr(attr, "_torchada_shielded", False):
+            continue
+
+        def make(orig):
+            @functools.wraps(orig)
+            def shielded(self, *args, **kwargs):
+                with torch._C.DisableTorchFunction():
+                    return orig(self, *args, **kwargs)
+
+            shielded._torchada_shielded = True
+            return shielded
+
+        setattr(torch.Tensor, name, make(attr))
+
+
 def _patch_thread_bootstrap_for_factory_mode() -> None:
     """Enter ``_FactoryDeviceMode`` in every new Python thread.
 
@@ -1795,6 +1819,7 @@ def apply_patches():
     # TorchFunctionMode instead of namespace wrappers (issue #26 eager case,
     # torch.compile cacheability). Entered for the importing thread here and
     # for new threads via the bootstrap patch.
+    _shield_torch_musa_tensor_attrs()
     _FactoryDeviceMode().__enter__()
     _patch_thread_bootstrap_for_factory_mode()
 

--- a/src/torchada/_patch.py
+++ b/src/torchada/_patch.py
@@ -490,6 +490,12 @@ def _shield_torch_musa_tensor_attrs() -> None:
         def make(orig):
             @functools.wraps(orig)
             def shielded(self, *args, **kwargs):
+                # Translation normally comes from _FactoryDeviceMode; keep it
+                # for explicit device arguments despite the disabled protocol.
+                if args and isinstance(args[0], (str, torch.device)):
+                    args = (_translate_device(args[0]),) + args[1:]
+                if "device" in kwargs:
+                    kwargs["device"] = _translate_device(kwargs["device"])
                 with torch._C.DisableTorchFunction():
                     return orig(self, *args, **kwargs)
 

--- a/src/torchada/_patch.py
+++ b/src/torchada/_patch.py
@@ -29,6 +29,7 @@ from types import ModuleType, SimpleNamespace
 from typing import Any, Callable, List, Optional
 
 import torch
+from torch.overrides import TorchFunctionMode
 
 from ._cpp_ops import get_module
 from ._platform import is_musa_platform
@@ -454,71 +455,45 @@ def _patch_graph_context_manager():
         torch.musa.graph = GraphWrapper
 
 
-def _wrap_factory_function(original_fn: Callable) -> Callable:
-    """Wrap tensor factory functions (empty, zeros, ones, etc.) to translate device."""
+class _FactoryDeviceMode(TorchFunctionMode):
+    """Translate ``device=`` kwargs (e.g. ``"cuda"`` -> ``"musa"``) for tensor
+    factory functions without replacing them in the ``torch`` namespace.
 
-    @functools.wraps(original_fn)
-    def wrapped_fn(*args, **kwargs):
-        if "device" in kwargs:
-            kwargs["device"] = _translate_device(kwargs["device"])
-        return original_fn(*args, **kwargs)
+    Replacing the factories with Python wrappers breaks ``torch.compile``:
+    dynamo graphs then reference torchada wrappers instead of the original
+    builtins, so the AOT autograd cache (id-frozen on the originals) bypasses
+    every graph and vLLM-style fullgraph compiles fail their serializability
+    check. A TorchFunctionMode keeps ``torch.*`` identities intact and dynamo
+    inlines the kwarg translation, leaving compiled graphs cacheable.
+    """
 
-    return wrapped_fn
+    def __torch_function__(self, func, types, args=(), kwargs=None):
+        kwargs = kwargs or {}
+        device = kwargs.get("device")
+        if device is not None:
+            kwargs["device"] = _translate_device(device)
+        return func(*args, **kwargs)
 
 
-# List of torch factory functions that accept a device argument
-_FACTORY_FUNCTIONS = [
-    # Basic tensor creation
-    "tensor",
-    "as_tensor",
-    "asarray",
-    # Uninitialized/initialized tensors
-    "empty",
-    "zeros",
-    "ones",
-    "full",
-    # Random tensors
-    "rand",
-    "randn",
-    "randint",
-    "randperm",
-    "normal",
-    # Sequences
-    "arange",
-    "range",
-    "linspace",
-    "logspace",
-    # Special tensors
-    "eye",
-    "empty_strided",
-    "empty_permuted",
-    # From file
-    "from_file",
-    # Like variants
-    "empty_like",
-    "zeros_like",
-    "ones_like",
-    "full_like",
-    "rand_like",
-    "randn_like",
-    "randint_like",
-    # Sparse tensors
-    "sparse_coo_tensor",
-    "sparse_csr_tensor",
-    "sparse_csc_tensor",
-    "sparse_bsr_tensor",
-    "sparse_bsc_tensor",
-    "sparse_compressed_tensor",
-    # Index tensors
-    "tril_indices",
-    "triu_indices",
-    # Window functions
-    "bartlett_window",
-    "blackman_window",
-    "hamming_window",
-    "hann_window",
-    "kaiser_window",
-]
+def _patch_thread_bootstrap_for_factory_mode() -> None:
+    """Enter ``_FactoryDeviceMode`` in every new Python thread.
+
+    TorchFunctionModes are thread-local; the old factory wrappers translated
+    in all threads, so keep that behavior for eager code on worker threads.
+    """
+    import threading
+
+    original_bootstrap = threading.Thread._bootstrap_inner
+    if getattr(original_bootstrap, "_torchada_factory_mode", False):
+        return
+
+    @functools.wraps(original_bootstrap)
+    def bootstrap_with_factory_mode(self):
+        with _FactoryDeviceMode():
+            return original_bootstrap(self)
+
+    bootstrap_with_factory_mode._torchada_factory_mode = True
+    threading.Thread._bootstrap_inner = bootstrap_with_factory_mode
 
 
 class _CudartWrapper:
@@ -1816,33 +1791,12 @@ def apply_patches():
     if hasattr(torch.nn.Module, "cuda"):
         torch.nn.Module.cuda = _wrap_module_cuda(torch.nn.Module.cuda)
 
-    # Patch tensor factory functions to translate device argument
-    # We also need to update _device_constructors cache to include
-    # the original (unwrapped) functions, because PyTorch's __torch_function__
-    # dispatch receives the original C function, not our Python wrapper.
-    original_fns = []
-    for fn_name in _FACTORY_FUNCTIONS:
-        if hasattr(torch, fn_name):
-            original_fn = getattr(torch, fn_name)
-            original_fns.append(original_fn)
-            setattr(torch, fn_name, _wrap_factory_function(original_fn))
-
-    # Update _device_constructors to include original functions
-    # This ensures the device context manager (with torch.device(...):) works
-    # because __torch_function__ receives the original C function
-    try:
-        from torch.utils._device import _device_constructors
-
-        # Get the current set of constructors
-        constructors = _device_constructors()
-
-        # Add original (unwrapped) functions to the constructors set
-        # PyTorch's __torch_function__ receives these, not our wrappers
-        for orig_fn in original_fns:
-            constructors.add(orig_fn)
-
-    except (ImportError, AttributeError):
-        pass  # Older PyTorch versions may not have this
+    # Translate device kwargs of tensor factory functions via a
+    # TorchFunctionMode instead of namespace wrappers (issue #26 eager case,
+    # torch.compile cacheability). Entered for the importing thread here and
+    # for new threads via the bootstrap patch.
+    _FactoryDeviceMode().__enter__()
+    _patch_thread_bootstrap_for_factory_mode()
 
     _patched = True
 

--- a/tests/test_cuda_patching.py
+++ b/tests/test_cuda_patching.py
@@ -2113,6 +2113,7 @@ class TestTensorFactoryFunctions:
         if os.environ.get("TORCHDYNAMO_DISABLE") == "1":
             pytest.skip("Dynamo disabled in environment")
 
+        torch.compiler.save_cache_artifacts()  # flush artifacts of prior tests
         torch.compiler.reset()
 
         def f(x):
@@ -2124,7 +2125,7 @@ class TestTensorFactoryFunctions:
         torch.compile(f, fullgraph=True)(x)
         artifacts = torch.compiler.save_cache_artifacts()
         assert artifacts is not None, "no cache artifacts collected"
-        assert len(artifacts[1].aot_autograd_artifacts) == 1
+        assert len(artifacts[1].aot_autograd_artifacts) >= 1
 
     @pytest.mark.gpu
     def test_tensor_with_cuda_device(self):

--- a/tests/test_cuda_patching.py
+++ b/tests/test_cuda_patching.py
@@ -2062,6 +2062,70 @@ class TestTensorFactoryFunctions:
         x = torch.asarray([1, 2, 3], dtype=torch.float32)
         assert x.device.type == "cpu"
 
+    def test_factory_functions_not_wrapped(self):
+        """Factory functions stay original so torch.compile graphs cache.
+
+        Namespace wrappers put torchada functions into dynamo graphs, which
+        the AOT autograd cache rejects (vLLM "compiled artifact is not
+        serializable"). Translation must come from _FactoryDeviceMode only.
+        """
+        import torch
+
+        for name in ("empty", "zeros", "asarray", "tensor", "full"):
+            fn = getattr(torch, name)
+            assert not hasattr(fn, "__wrapped__"), f"torch.{name} is wrapped"
+
+    @pytest.mark.gpu
+    def test_asarray_cuda_in_thread(self):
+        """device='cuda' translation works on worker threads (mode is
+        thread-local; bootstrap patch must enter it per thread)."""
+        import threading
+
+        import torch
+
+        import torchada
+
+        if not torchada.is_musa_platform():
+            pytest.skip("Only applicable on MUSA platform")
+
+        result = {}
+
+        def make():
+            result["x"] = torch.asarray([1, 2, 3], dtype=torch.float32, device="cuda")
+
+        t = threading.Thread(target=make)
+        t.start()
+        t.join()
+        assert result["x"].device.type == "musa"
+
+    @pytest.mark.gpu
+    def test_compiled_factory_graph_is_cacheable(self):
+        """fullgraph compile of a factory-using fn yields AOT cache artifacts
+        (regression test for vLLM compile-cache enablement, MUSA-0511)."""
+        import os
+
+        import torch
+
+        import torchada
+
+        if not torchada.is_musa_platform():
+            pytest.skip("Only applicable on MUSA platform")
+        if os.environ.get("TORCHDYNAMO_DISABLE") == "1":
+            pytest.skip("Dynamo disabled in environment")
+
+        torch.compiler.reset()
+
+        def f(x):
+            buf = torch.empty(x.shape, device=x.device, dtype=x.dtype)
+            buf.copy_(x)
+            return buf.relu() + 1
+
+        x = torch.randn(32, device="cuda")
+        torch.compile(f, fullgraph=True)(x)
+        artifacts = torch.compiler.save_cache_artifacts()
+        assert artifacts is not None, "no cache artifacts collected"
+        assert len(artifacts[1].aot_autograd_artifacts) == 1
+
     @pytest.mark.gpu
     def test_tensor_with_cuda_device(self):
         """Test torch.tensor with device='cuda' works on MUSA."""

--- a/tests/test_cuda_patching.py
+++ b/tests/test_cuda_patching.py
@@ -2101,7 +2101,7 @@ class TestTensorFactoryFunctions:
     @pytest.mark.gpu
     def test_compiled_factory_graph_is_cacheable(self):
         """fullgraph compile of a factory-using fn yields AOT cache artifacts
-        (regression test for vLLM compile-cache enablement, MUSA-0511)."""
+        (regression test for vLLM compile-cache enablement)."""
         import os
 
         import torch
@@ -2499,7 +2499,7 @@ class TestFlashAttnPatching:
     def test_patch_skipped_when_flash_attn_interface_not_available(self):
         """Test that the patch is gracefully skipped when flash_attn_interface is not installed.
 
-        On platforms without flash_attn_interface (e.g. yeahdongcn container), sgl_kernel.flash_attn
+        On platforms without flash_attn_interface, sgl_kernel.flash_attn
         should NOT be available unless sgl_kernel was already installed.
         """
         import sys

--- a/tests/test_cuda_patching.py
+++ b/tests/test_cuda_patching.py
@@ -2099,6 +2099,20 @@ class TestTensorFactoryFunctions:
         assert result["x"].device.type == "musa"
 
     @pytest.mark.gpu
+    def test_pin_memory_translates_cuda_device(self):
+        """Shielded tensor attrs still translate explicit device='cuda' args."""
+        import torch
+
+        import torchada
+
+        if not torchada.is_musa_platform():
+            pytest.skip("Only applicable on MUSA platform")
+
+        x = torch.randn(4)
+        pinned = x.pin_memory(device="cuda")
+        assert pinned.is_pinned(device="cuda")
+
+    @pytest.mark.gpu
     def test_compiled_factory_graph_is_cacheable(self):
         """fullgraph compile of a factory-using fn yields AOT cache artifacts
         (regression test for vLLM compile-cache enablement)."""
@@ -2112,6 +2126,8 @@ class TestTensorFactoryFunctions:
             pytest.skip("Only applicable on MUSA platform")
         if os.environ.get("TORCHDYNAMO_DISABLE") == "1":
             pytest.skip("Dynamo disabled in environment")
+        if getattr(getattr(torch, "compiler", None), "save_cache_artifacts", None) is None:
+            pytest.skip("torch.compiler.save_cache_artifacts not available")
 
         # Other tests in this module leak torch.library state that breaks any
         # later in-process compile; probe in a fresh interpreter.

--- a/tests/test_cuda_patching.py
+++ b/tests/test_cuda_patching.py
@@ -2113,19 +2113,30 @@ class TestTensorFactoryFunctions:
         if os.environ.get("TORCHDYNAMO_DISABLE") == "1":
             pytest.skip("Dynamo disabled in environment")
 
-        torch.compiler.save_cache_artifacts()  # flush artifacts of prior tests
-        torch.compiler.reset()
+        # Other tests in this module leak torch.library state that breaks any
+        # later in-process compile; probe in a fresh interpreter.
+        import subprocess
+        import sys
 
-        def f(x):
-            buf = torch.empty(x.shape, device=x.device, dtype=x.dtype)
-            buf.copy_(x)
-            return buf.relu() + 1
-
-        x = torch.randn(32, device="cuda")
-        torch.compile(f, fullgraph=True)(x)
-        artifacts = torch.compiler.save_cache_artifacts()
-        assert artifacts is not None, "no cache artifacts collected"
-        assert len(artifacts[1].aot_autograd_artifacts) >= 1
+        probe = (
+            "import torchada, torch\n"
+            "def f(x):\n"
+            "    buf = torch.empty(x.shape, device=x.device, dtype=x.dtype)\n"
+            "    buf.copy_(x)\n"
+            "    return buf.relu() + 1\n"
+            "x = torch.randn(32, device='cuda')\n"
+            "torch.compile(f, fullgraph=True)(x)\n"
+            "art = torch.compiler.save_cache_artifacts()\n"
+            "assert art is not None, 'no cache artifacts collected'\n"
+            "assert len(art[1].aot_autograd_artifacts) == 1, art[1]\n"
+        )
+        env = dict(os.environ)
+        env.pop("TORCHDYNAMO_DISABLE", None)
+        env.pop("VLLM_DISABLE_COMPILE_CACHE", None)
+        result = subprocess.run(
+            [sys.executable, "-c", probe], env=env, capture_output=True, text=True
+        )
+        assert result.returncode == 0, result.stderr[-2000:]
 
     @pytest.mark.gpu
     def test_tensor_with_cuda_device(self):


### PR DESCRIPTION
Rework of https://github.com/MooreThreads/torchada/pull/27 to support torch.compile cache in vllm-musa.