### PR TITLE
feat(stable-abi): build libtorch-stable kernels on MUSA (vLLM + SGLang)

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ See `src/torchada/_mapping.py` for the complete mapping table (380+ mappings).
 
 ```
 # pyproject.toml or requirements.txt
-torchada>=0.1.62
+torchada>=0.1.63
 ```
 
 ### Step 2: Conditional Import

--- a/README_CN.md
+++ b/README_CN.md
@@ -293,7 +293,7 @@ if torchada.is_gpu_device(device):  # 在 CUDA 和 MUSA 上都能工作
 
 ```
 # pyproject.toml 或 requirements.txt
-torchada>=0.1.62
+torchada>=0.1.63
 ```
 
 ### 步骤 2：条件导入

--- a/benchmarks/benchmark_history.json
+++ b/benchmarks/benchmark_history.json
@@ -3,7 +3,7 @@
   "description": "Historical benchmark results for torchada performance tracking",
   "results": [
     {
-      "version": "0.1.62",
+      "version": "0.1.63",
       "date": "2026-01-29",
       "platform": "MUSA",
       "pytorch_version": "2.7.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torchada"
-version = "0.1.62"
+version = "0.1.63"
 description = "Adapter package for torch_musa to act exactly like PyTorch CUDA"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/torchada/__init__.py
+++ b/src/torchada/__init__.py
@@ -24,7 +24,7 @@ Usage:
     from torch.utils.cpp_extension import CUDAExtension, BuildExtension, CUDA_HOME
 """
 
-__version__ = "0.1.62"
+__version__ = "0.1.63"
 
 from . import cuda, utils
 

--- a/src/torchada/_mapping.py
+++ b/src/torchada/_mapping.py
@@ -312,6 +312,18 @@ _MAPPING_RULE = {
     "CUDAStreamGuard": "MUSAStreamGuard",
     "CUDAEvent": "MUSAEvent",
     # =========================================================================
+    # libtorch-stable / AOTI C-ABI shims. Projects that depend on torch_musa
+    # (e.g. vLLM and SGLang) are migrating their kernels to the PyTorch stable
+    # ABI (csrc/libtorch_stable). Those kernels call the aoti_torch_*_cuda_* C
+    # symbols, which torch_musa exposes under *_musa_*. The C++ getCurrent*Stream
+    # rules above do not match these C names.
+    # =========================================================================
+    "aoti_torch_get_current_cuda_stream": "aoti_torch_get_current_musa_stream",
+    # Stable-ABI impl blocks register under the LITERAL dispatch-key token (the
+    # stable C ABI does not translate CUDA->MUSA the way torch.library's Python
+    # path does). MUSA tensors are PrivateUse1, so re-key the stable impl block.
+    "STABLE_TORCH_LIBRARY_IMPL(_C, CUDA": "STABLE_TORCH_LIBRARY_IMPL(_C, PrivateUse1",
+    # =========================================================================
     # CUDA header includes
     # =========================================================================
     "cuda_runtime.h": "musa_runtime.h",

--- a/src/torchada/csrc/stable_compat/torch/headeronly/core/Dispatch.h
+++ b/src/torchada/csrc/stable_compat/torch/headeronly/core/Dispatch.h
@@ -1,0 +1,73 @@
+#pragma once
+// torchada stable-ABI compat: torch/headeronly/core/Dispatch.h
+//
+// libtorch-stable kernels (e.g. vLLM, SGLang) need the THO_DISPATCH_* macros
+// from PyTorch's torch/headeronly/core/Dispatch.h, which postdates torch_musa
+// 2.9.0. We ship
+// the macros (verbatim from upstream) plus the two symbols they reference that
+// torch_musa lacks (torch::headeronly::impl::ScalarTypeToCPPTypeT, toString),
+// aliased to the c10 equivalents that DO exist on torch_musa. torchada exposes
+// this directory via include_paths() so it shadows the (absent) torch header.
+#include <torch/headeronly/core/ScalarType.h>
+#include <torch/headeronly/macros/Macros.h>
+#include <torch/headeronly/util/Exception.h>  // STD_TORCH_CHECK
+#include <c10/core/ScalarType.h>
+
+namespace torch {
+namespace headeronly {
+namespace impl {
+template <torch::headeronly::ScalarType N>
+using ScalarTypeToCPPTypeT =
+    typename c10::impl::ScalarTypeToCPPType<static_cast<c10::ScalarType>(N)>::type;
+}  // namespace impl
+inline const char* toString(torch::headeronly::ScalarType t) {
+  return c10::toString(static_cast<c10::ScalarType>(t));
+}
+}  // namespace headeronly
+}  // namespace torch
+
+#define THO_PRIVATE_CASE_TYPE_USING_HINT_TMPL(PRELUDE, enum_type, HINT, ...) \
+  case enum_type: {                                                          \
+    PRELUDE(enum_type);                                                      \
+    using HINT [[maybe_unused]] =                                            \
+        torch::headeronly::impl::ScalarTypeToCPPTypeT<enum_type>;            \
+    return __VA_ARGS__();                                                    \
+  }
+
+#define THO_DISPATCH_CASE_TMPL(CASE_TYPE_USING_HINT, enum_type, ...) \
+  CASE_TYPE_USING_HINT(enum_type, scalar_t, __VA_ARGS__)
+
+namespace detail {
+inline torch::headeronly::ScalarType scalar_type(torch::headeronly::ScalarType s) {
+  return s;
+}
+}  // namespace detail
+
+#define THO_DISPATCH_SWITCH_TMPL(                                          \
+    PRELUDE, CHECK_NOT_IMPLEMENTED, TYPE, NAME, ...)                       \
+  [&] {                                                                    \
+    const auto& the_type = TYPE;                                          \
+    constexpr const char* at_dispatch_name = NAME;                        \
+    torch::headeronly::ScalarType _st = ::detail::scalar_type(the_type);  \
+    PRELUDE(at_dispatch_name, _st);                                       \
+    C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wswitch-enum")           \
+    switch (_st) {                                                        \
+      __VA_ARGS__                                                         \
+      default:                                                           \
+        CHECK_NOT_IMPLEMENTED(                                           \
+            false, '"', at_dispatch_name, "\" not implemented for '",    \
+            torch::headeronly::toString(_st), "'");                      \
+    }                                                                    \
+    C10_DIAGNOSTIC_POP()                                                 \
+  }()
+
+#define THO_EMPTY(...)
+
+#define THO_PRIVATE_CASE_TYPE_USING_HINT(enum_type, HINT, ...) \
+  THO_PRIVATE_CASE_TYPE_USING_HINT_TMPL(THO_EMPTY, enum_type, HINT, __VA_ARGS__)
+
+#define THO_DISPATCH_SWITCH(TYPE, NAME, ...) \
+  THO_DISPATCH_SWITCH_TMPL(THO_EMPTY, STD_TORCH_CHECK, TYPE, NAME, __VA_ARGS__)
+
+#define THO_DISPATCH_CASE(enum_type, ...) \
+  THO_DISPATCH_CASE_TMPL(THO_PRIVATE_CASE_TYPE_USING_HINT, enum_type, __VA_ARGS__)

--- a/src/torchada/csrc/stable_compat/torchada_stable_box.h
+++ b/src/torchada/csrc/stable_compat/torchada_stable_box.h
@@ -1,0 +1,107 @@
+#pragma once
+// torchada stable-ABI compat: TORCH_BOX + small helpers.
+//
+// torch_musa 2.9.0's torch::stable runtime predates the TORCH_BOX boxer family
+// (it lacks guts::typelist / UnboxType / the boxer templates), so
+// STABLE_TORCH_LIBRARY_IMPL(_C, CUDA, ...) { ops.impl("x", TORCH_BOX(&x)); }
+// in a project's stable torch_bindings.cpp (e.g. vLLM, SGLang) does not compile.
+// torch_musa DOES ship the from<>/to<> StableIValue conversions, so we
+// synthesize TORCH_BOX with plain
+// std traits over those — no dependency on the newer boxer machinery.
+//
+// Force-include this header (mcc -include) when building libtorch_stable sources.
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/stableivalue_conversions.h>
+#include <torch/csrc/stable/tensor.h>
+#include <c10/util/ArrayRef.h>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+// torch_musa's stable headers predate torch::headeronly::HeaderOnlyArrayRef
+// (used by some op prototypes in libtorch_stable/ops.h, e.g. the FP8-quant
+// group_shape arg). Alias to c10::ArrayRef so those prototypes compile -- no
+// impl is needed for the ops that use it.
+namespace torch {
+namespace headeronly {
+template <typename T>
+using HeaderOnlyArrayRef = c10::ArrayRef<T>;
+using IntHeaderOnlyArrayRef = c10::ArrayRef<int64_t>;
+}  // namespace headeronly
+}  // namespace torch
+
+// torch_musa's stable ops.h predates torch::stable::contiguous (used by
+// libtorch_stable/layernorm_kernels.cu when input.stride(-1) != 1). Provide it
+// with the same aoti_torch_call_dispatcher pattern torch_musa already uses for
+// empty_like/narrow. Schema:
+//   aten::contiguous(Tensor(a) self, *, MemoryFormat memory_format=contiguous)
+//     -> Tensor(a)
+// MemoryFormat::Contiguous == 0; box it as int64 -- aoti_torch_call_dispatcher
+// reads each StableIValue per the resolved op schema, so the int slot is
+// reinterpreted as the MemoryFormat enum. torch_musa ships no from(MemoryFormat)
+// overload, which is why the enum can't be passed directly.
+#include <torch/csrc/stable/ops.h>
+#include <array>
+namespace torch {
+namespace stable {
+inline Tensor contiguous(const Tensor& self) {
+  std::array<StableIValue, 2> stack{from(self), from(static_cast<int64_t>(0))};
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_call_dispatcher("aten::contiguous", "", stack.data()));
+  return to<Tensor>(stack[0]);
+}
+}  // namespace stable
+}  // namespace torch
+
+// CUDA_VERSION guards in the kernels: define low so the sm100/Blackwell fast
+// paths (also gated on cc_major>=10) compile out on MUSA. torchada also passes
+// -DCUDA_VERSION=0 via the build, but define here for direct/JIT use.
+#ifndef CUDA_VERSION
+#define CUDA_VERSION 0
+#endif
+
+// Compile stub: torch_get_current_cuda_blas_handle has no MUSA stable-ABI
+// equivalent. Only cublas/GEMM kernels use it; torch_utils.h defines an unused
+// inline that references it, so a stub is enough to compile non-GEMM kernels.
+static inline AOTITorchError torch_get_current_cuda_blas_handle(void** ret) {
+  *ret = nullptr;
+  return 0;  // success
+}
+
+namespace torchada_stable {
+
+template <class T>
+using strip_t = std::remove_cv_t<std::remove_reference_t<T>>;
+
+template <class F>
+struct fn_traits;
+template <class R, class... A>
+struct fn_traits<R (*)(A...)> {
+  using ret = R;
+  using args = std::tuple<strip_t<A>...>;
+};
+
+template <auto Fn, class Tup, std::size_t... I>
+inline void invoke_boxed(StableIValue* stack, std::index_sequence<I...>) {
+  // Materialize args as lvalues so they bind to Tensor& parameters.
+  Tup args{to<std::tuple_element_t<I, Tup>>(stack[I])...};
+  using R = typename fn_traits<decltype(Fn)>::ret;
+  if constexpr (std::is_void_v<R>) {
+    std::apply(Fn, args);
+  } else {
+    stack[0] = from(std::apply(Fn, args));
+  }
+}
+
+template <auto Fn>
+inline void boxed(StableIValue* stack, uint64_t /*nargs*/, uint64_t /*nout*/) {
+  using Tup = typename fn_traits<decltype(Fn)>::args;
+  invoke_boxed<Fn, Tup>(stack,
+                        std::make_index_sequence<std::tuple_size_v<Tup>>());
+}
+
+}  // namespace torchada_stable
+
+#ifndef TORCH_BOX
+#define TORCH_BOX(func) (&::torchada_stable::boxed<func>)
+#endif

--- a/src/torchada/csrc/stable_compat/torchada_stable_box.h
+++ b/src/torchada/csrc/stable_compat/torchada_stable_box.h
@@ -63,9 +63,12 @@ inline Tensor contiguous(const Tensor& self) {
 // Compile stub: torch_get_current_cuda_blas_handle has no MUSA stable-ABI
 // equivalent. Only cublas/GEMM kernels use it; torch_utils.h defines an unused
 // inline that references it, so a stub is enough to compile non-GEMM kernels.
+// It returns a non-zero error (not success) so that if a GEMM kernel actually
+// calls it, the AOTI error check at the call site fails fast instead of
+// proceeding with a null handle and crashing deep inside the BLAS call.
 static inline AOTITorchError torch_get_current_cuda_blas_handle(void** ret) {
   *ret = nullptr;
-  return 0;  // success
+  return 1;  // failure: cuBLAS handle is unsupported on the MUSA stable ABI
 }
 
 namespace torchada_stable {
@@ -95,6 +98,11 @@ inline void invoke_boxed(StableIValue* stack, std::index_sequence<I...>) {
 
 template <auto Fn>
 inline void boxed(StableIValue* stack, uint64_t /*nargs*/, uint64_t /*nout*/) {
+  // The op's C++ signature is the source of truth for how many stack slots are
+  // read/written, so nargs/nout are redundant with it and intentionally unused.
+  // A schema/signature mismatch is an author error caught by the stable-ABI
+  // unit test, which exercises every signature shape (void / Tensor / int
+  // returns, scalar args).
   using Tup = typename fn_traits<decltype(Fn)>::args;
   invoke_boxed<Fn, Tup>(stack,
                         std::make_index_sequence<std::tuple_size_v<Tup>>());

--- a/src/torchada/utils/cpp_extension.py
+++ b/src/torchada/utils/cpp_extension.py
@@ -35,6 +35,12 @@ from .._platform import Platform, detect_platform, is_musa_platform
 # Flag to track if torch_musa patches have been applied
 _musa_patches_applied = False
 
+# Flag to track if the libtorch-stable header backport has been applied. Kept
+# separate from _musa_patches_applied so the (in-memory) import-time patches and
+# the (on-disk) header backport are triggered independently — see
+# _ensure_stable_headers_patched.
+_stable_headers_patched = False
+
 
 def _get_cuda_home() -> Optional[str]:
     """
@@ -145,6 +151,114 @@ def _patch_simple_porting_open(musa_sp):
     musa_sp.open = open_with_surrogateescape
 
 
+def _patch_torch_musa_stable_headers() -> None:
+    """Backport the libtorch-stable ``Tensor`` accessors that stable-ABI kernels
+    (as built by vLLM, SGLang, and other torch_musa-dependent projects) use but
+    torch_musa 2.9.0's older ``torch::stable`` snapshot omits: ``element_size`` /
+    ``mutable_data_ptr<T>`` / ``const_data_ptr<T>``, and mark ``tensor_inl.h``
+    method definitions ``inline`` (they are emitted in every TU that includes
+    them, which is a multiple-definition/ODR error otherwise).
+
+    Patches BOTH the ``torch/include`` copy and the torch_musa
+    ``generated_cuda_compatible/include`` copy. Idempotent + best-effort: a
+    read-only install, or a future torch_musa that already ships these, is a
+    no-op.
+
+    This writes into the ``torch`` / ``torch_musa`` site-packages headers, so it
+    is invoked lazily by ``_ensure_stable_headers_patched`` from the setuptools
+    extension build entry points (``_create_musa_extension`` and the
+    BuildExtension) rather than at ``import torchada`` — a bare import, or a
+    pure-inference run, never mutates those headers. (The JIT ``load`` /
+    ``load_inline`` helpers are intentionally excluded: torchada builds its own
+    cpp ops through them at import, which would re-introduce an import-time
+    write; libtorch-stable kernels are built via setuptools, not JIT-loaded.)
+    """
+    import re
+
+    try:
+        import torch
+    except ImportError:
+        return
+
+    roots = [os.path.join(os.path.dirname(torch.__file__), "include")]
+    try:
+        import torch_musa
+
+        roots.append(os.path.join(os.path.dirname(torch_musa.__file__),
+                                  "share", "generated_cuda_compatible", "include"))
+    except ImportError:
+        pass
+
+    # Injected as one block, anchored just before ``numel()``. ``mutable_data_ptr``
+    # is the sentinel: absent in stock torch_musa, present after we patch, so the
+    # presence check below makes re-runs a no-op.
+    anchor = "  int64_t numel() const {"
+    methods = (
+        "  template <typename T>\n"
+        "  T* mutable_data_ptr() const { return reinterpret_cast<T*>(data_ptr()); }\n"
+        "  template <typename T>\n"
+        "  const T* const_data_ptr() const {\n"
+        "    return reinterpret_cast<const T*>(data_ptr());\n"
+        "  }\n"
+        "  int64_t element_size() const {\n"
+        "    return static_cast<int64_t>(\n"
+        "        aoti_torch_dtype_element_size(static_cast<int32_t>(scalar_type())));\n"
+        "  }\n\n"
+    ) + anchor
+    # Only column-0 method definitions are matched; call sites inside bodies are
+    # indented and so never match, and the negative lookahead keeps already-inline
+    # / template / comment lines untouched, which makes the rewrite idempotent.
+    inl_pat = re.compile(
+        r"^(?!\s*(?:inline|template|//|\*))"
+        r"([A-Za-z_][\w:<>,\s\*&]*?\bTensor::[A-Za-z_]\w*\s*\()"
+    )
+    for root in roots:
+        ts = os.path.join(root, "torch", "csrc", "stable", "tensor_struct.h")
+        ti = os.path.join(root, "torch", "csrc", "stable", "tensor_inl.h")
+        try:
+            if os.path.exists(ts):
+                with open(ts, encoding="utf-8") as f:
+                    s = f.read()
+                if "mutable_data_ptr" not in s and anchor in s:
+                    with open(ts, "w", encoding="utf-8") as f:
+                        f.write(s.replace(anchor, methods, 1))
+            if os.path.exists(ti):
+                with open(ti, encoding="utf-8") as f:
+                    lines = f.read().splitlines(keepends=True)
+                changed = False
+                for i, line in enumerate(lines):
+                    if "inline" not in line and inl_pat.match(line):
+                        lines[i] = "inline " + line
+                        changed = True
+                if changed:
+                    with open(ti, "w", encoding="utf-8") as f:
+                        f.write("".join(lines))
+        except OSError:
+            pass  # read-only headers / no write perms — best effort
+
+
+def _ensure_stable_headers_patched() -> None:
+    """Apply the libtorch-stable header backport once, lazily, at build time.
+
+    Separated from ``_apply_musa_patches`` (which runs at ``import torchada``)
+    so a bare import — or a pure-inference run that never builds an extension —
+    does not write into the ``torch`` / ``torch_musa`` site-packages headers.
+    Called from the MUSA setuptools extension build entry points (extension
+    construction + ``BuildExtension.build_extensions``); the flag makes all calls
+    after the first an instant no-op. Best-effort: never let it break a build.
+    """
+    global _stable_headers_patched
+    if _stable_headers_patched:
+        return
+    if not is_musa_platform():
+        return
+    try:
+        _patch_torch_musa_stable_headers()
+    except Exception:  # noqa: BLE001  never let header patching break the build
+        pass
+    _stable_headers_patched = True
+
+
 def _apply_musa_patches():
     """
     Apply patches to torch_musa modules for CUDA compatibility.
@@ -185,6 +299,12 @@ def _apply_musa_patches():
         # Patch simple_porting.open to tolerate non-UTF-8 source files
         # This preserves SimplePorting's original logic while allowing undecodable bytes to round-trip
         _patch_simple_porting_open(musa_sp)
+
+        # NOTE: the libtorch-stable header backport is intentionally NOT applied
+        # here. It writes into the torch / torch_musa site-packages headers, so
+        # it is deferred to the build entry points via
+        # _ensure_stable_headers_patched() — a bare ``import torchada`` (e.g. for
+        # inference) must not mutate those headers.
 
         _musa_patches_applied = True
 
@@ -255,20 +375,28 @@ def include_paths(cuda: Optional[bool] = None, device_type: Optional[str] = None
     platform = detect_platform()
 
     if platform == Platform.MUSA:
+        paths: List[str] = []
         try:
             import torch_musa.utils.musa_extension as musa_ext
 
             if hasattr(musa_ext, "include_paths"):
                 # musa_ext uses musa=bool parameter, not cuda= or device_type=
-                return musa_ext.include_paths(musa=include_device)
+                paths = list(musa_ext.include_paths(musa=include_device))
         except ImportError:
             pass
 
-        # Fallback: construct paths manually
-        paths = []
-        musa_home = _get_cuda_home()
-        if musa_home:
-            paths.append(os.path.join(musa_home, "include"))
+        if not paths:
+            # Fallback: construct paths manually
+            musa_home = _get_cuda_home()
+            if musa_home:
+                paths.append(os.path.join(musa_home, "include"))
+
+        # Auto-append torchada's libtorch-stable ABI compat headers so
+        # libtorch-stable kernels (vLLM, SGLang, ...) resolve
+        # <torch/headeronly/core/Dispatch.h> on MUSA. Appended LAST so a future
+        # torch_musa shipping the real header wins.
+        if include_device:
+            paths.append(stable_compat_include_dir())
         return paths
 
     else:
@@ -287,6 +415,31 @@ def include_paths(cuda: Optional[bool] = None, device_type: Optional[str] = None
         else:
             # PyTorch < 2.6
             return torch_include_paths(cuda=include_device)
+
+
+def stable_compat_include_dir() -> str:
+    """Directory holding torchada's libtorch-stable ABI compat headers.
+
+    Add to an extension's ``include_dirs`` so libtorch-stable
+    ``csrc/libtorch_stable`` kernels (vLLM, SGLang, ...) build on torch_musa: it
+    shadows the (absent) ``torch/headeronly/core/Dispatch.h`` with a THO_DISPATCH
+    shim. Pair with ``stable_compat_box_header`` (force-include) to also get the
+    ``TORCH_BOX`` shim + ``CUDA_VERSION`` define.
+    """
+    return os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        "csrc",
+        "stable_compat",
+    )
+
+
+def stable_compat_box_header() -> str:
+    """Path to the force-include header providing ``TORCH_BOX`` for the stable ABI.
+
+    Pass via ``-include`` in extra_compile_args when building libtorch-stable
+    sources (mcc/g++ both accept ``-include <path>``).
+    """
+    return os.path.join(stable_compat_include_dir(), "torchada_stable_box.h")
 
 
 def library_paths(cuda: Optional[bool] = None, device_type: Optional[str] = None) -> List[str]:
@@ -445,6 +598,9 @@ def _create_musa_extension(name: str, sources: List[str], *args, **kwargs):
     """
     # Ensure patches are applied
     _apply_musa_patches()
+    # Building a MUSA extension: apply the (on-disk) libtorch-stable header
+    # backport now so csrc/libtorch_stable/*.cu can compile.
+    _ensure_stable_headers_patched()
 
     # Translate 'nvcc' to 'mcc' in extra_compile_args
     kwargs = _translate_compile_args(kwargs)
@@ -533,6 +689,9 @@ def _get_build_extension_class():
                     return _MAPPING_RULE.copy()
 
                 def build_extensions(self):
+                    # Building now: apply the (on-disk) libtorch-stable header
+                    # backport before the compiler reads the torch headers.
+                    _ensure_stable_headers_patched()
                     # Register .cu, .cuh as valid source extensions
                     self.compiler.src_extensions += [".cu", ".cuh"]
                     super().build_extensions()

--- a/src/torchada/utils/cpp_extension.py
+++ b/src/torchada/utils/cpp_extension.py
@@ -244,8 +244,9 @@ def _ensure_stable_headers_patched() -> None:
     so a bare import — or a pure-inference run that never builds an extension —
     does not write into the ``torch`` / ``torch_musa`` site-packages headers.
     Called from the MUSA setuptools extension build entry points (extension
-    construction + ``BuildExtension.build_extensions``); the flag makes all calls
-    after the first an instant no-op. Best-effort: never let it break a build.
+    construction + ``BuildExtension.build_extensions``); once the backport
+    succeeds the flag makes further calls an instant no-op. Best-effort: never
+    let it break a build.
     """
     global _stable_headers_patched
     if _stable_headers_patched:
@@ -254,9 +255,11 @@ def _ensure_stable_headers_patched() -> None:
         return
     try:
         _patch_torch_musa_stable_headers()
+        # Only mark done on success; an unexpected failure leaves the flag unset
+        # so a later build retries (the backport is idempotent).
+        _stable_headers_patched = True
     except Exception:  # noqa: BLE001  never let header patching break the build
         pass
-    _stable_headers_patched = True
 
 
 def _apply_musa_patches():

--- a/tests/csrc/stable_abi_ops.cu
+++ b/tests/csrc/stable_abi_ops.cu
@@ -1,0 +1,87 @@
+/*
+ * torchada libtorch-stable ABI shim coverage.
+ *
+ * Exercises the torchada stable-ABI compat shim (TORCH_BOX boxer +
+ * THO_DISPATCH Dispatch.h shim) across DIVERSE stable-ABI signature shapes, so
+ * we know the shim is generally usable — not just for the activation case:
+ *   - void return + two Tensor args          (negate)
+ *   - void return + Tensor args + scalar arg (scale, double)
+ *   - single Tensor return                    (passthrough -> from<Tensor>)
+ *   - scalar (int) return                     (numel_of  -> from<int64_t>)
+ *   - THO_DISPATCH over float / half / bfloat16
+ *
+ * Written in plain CUDA; torchada ports it to MUSA. Uses only stable::Tensor
+ * methods present on stock torch_musa (data_ptr/numel/scalar_type) so the test
+ * is self-contained (no torch_musa header patch required).
+ */
+// NOTE: stable-ABI kernels are intentionally ATen-independent — do NOT include
+// ATen headers here (ATen/Dispatch.h also defines ::detail::scalar_type and
+// would clash with the headeronly Dispatch shim). Launch on the default stream.
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/tensor.h>
+#include <torch/headeronly/core/Dispatch.h>  // torchada THO_DISPATCH shim
+#include <cuda_runtime.h>
+
+template <typename scalar_t>
+__global__ void affine_kernel(const scalar_t* __restrict__ in,
+                              scalar_t* __restrict__ out, double a, double b,
+                              int64_t n) {
+  int64_t i = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (i < n) {
+    out[i] = static_cast<scalar_t>(a * static_cast<double>(in[i]) + b);
+  }
+}
+
+template <typename scalar_t>
+static void launch_affine_typed(const torch::stable::Tensor& in,
+                                torch::stable::Tensor& out, double a, double b,
+                                int64_t n) {
+  const int threads = 256;
+  const int blocks = static_cast<int>((n + threads - 1) / threads);
+  affine_kernel<scalar_t><<<blocks, threads>>>(  // default stream
+      static_cast<const scalar_t*>(in.data_ptr()),
+      static_cast<scalar_t*>(out.data_ptr()), a, b, n);
+}
+
+static void affine(const torch::stable::Tensor& in, torch::stable::Tensor& out,
+                   double a, double b) {
+  const int64_t n = in.numel();
+  if (n == 0) return;
+  THO_DISPATCH_SWITCH(
+      in.scalar_type(), "torchada_stable_affine",
+      THO_DISPATCH_CASE(torch::headeronly::ScalarType::Float,
+                        [&] { launch_affine_typed<scalar_t>(in, out, a, b, n); })
+      THO_DISPATCH_CASE(torch::headeronly::ScalarType::Half,
+                        [&] { launch_affine_typed<scalar_t>(in, out, a, b, n); })
+      THO_DISPATCH_CASE(torch::headeronly::ScalarType::BFloat16,
+                        [&] { launch_affine_typed<scalar_t>(in, out, a, b, n); }));
+}
+
+// void return, two Tensor args
+void negate(torch::stable::Tensor& out, torch::stable::Tensor& input) {
+  affine(input, out, -1.0, 0.0);
+}
+// void return, Tensor args + double scalar arg
+void scale(torch::stable::Tensor& out, torch::stable::Tensor& input, double s) {
+  affine(input, out, s, 0.0);
+}
+// single Tensor return (boxer must from<Tensor>)
+torch::stable::Tensor passthrough(torch::stable::Tensor& input) { return input; }
+// scalar int return (boxer must from<int64_t>)
+int64_t numel_of(torch::stable::Tensor& input) { return input.numel(); }
+
+STABLE_TORCH_LIBRARY(torchada_stable_test, m) {
+  m.def("negate(Tensor! out, Tensor input) -> ()");
+  m.def("scale(Tensor! out, Tensor input, float s) -> ()");
+  m.def("passthrough(Tensor input) -> Tensor");
+  m.def("numel_of(Tensor input) -> int");
+}
+
+// MUSA tensors are PrivateUse1; torchada's _mapping.py rewrites the upstream
+// STABLE_TORCH_LIBRARY_IMPL(..., CUDA, ...) device key to PrivateUse1.
+STABLE_TORCH_LIBRARY_IMPL(torchada_stable_test, PrivateUse1, m) {
+  m.impl("negate", TORCH_BOX(&negate));
+  m.impl("scale", TORCH_BOX(&scale));
+  m.impl("passthrough", TORCH_BOX(&passthrough));
+  m.impl("numel_of", TORCH_BOX(&numel_of));
+}

--- a/tests/test_stable_abi.py
+++ b/tests/test_stable_abi.py
@@ -1,0 +1,101 @@
+"""End-to-end test: the torchada libtorch-stable ABI shim is generally usable.
+
+Builds tests/csrc/stable_abi_ops.cu through torchada (cuda->musa porting + the
+shipped stable_compat headers) and runs the ops on MUSA, exercising diverse
+stable-ABI signature shapes (void / Tensor / int returns; Tensor + scalar args;
+THO_DISPATCH over float/half/bfloat16). This is the runtime counterpart to the
+pure-Python rules in test_stable_abi_mappings.py.
+"""
+
+import glob
+import os
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+import torchada  # noqa: F401  apply MUSA patches first
+from torchada.utils.cpp_extension import (
+    stable_compat_box_header,
+    stable_compat_include_dir,
+)
+
+CSRC = os.path.join(os.path.dirname(__file__), "csrc")
+OPS_CU = os.path.join(CSRC, "stable_abi_ops.cu")
+
+
+def _gpu_available() -> bool:
+    import torch
+
+    return hasattr(torch, "musa") and torch.musa.is_available()
+
+
+_SETUP_TEMPLATE = """\
+import torchada  # noqa: F401
+from setuptools import setup
+from torch.utils.cpp_extension import CUDAExtension, BuildExtension
+
+setup(
+    name="torchada_stable_test",
+    ext_modules=[CUDAExtension(
+        name="torchada_stable_test",
+        sources=["stable_abi_ops.cu"],
+        include_dirs=[{inc!r}],
+        extra_compile_args={{
+            "nvcc": ["-DCUDA_VERSION=0", "-DENABLE_FP8", "-include", {box!r}],
+            "cxx": ["force_mcc", "-include", {box!r}],
+        }},
+        # AOTI stable-ABI shims live in libtorch_cpu.so.
+        libraries=["c10", "torch", "torch_cpu", "torch_python", "musart"],
+    )],
+    cmdclass={{"build_ext": BuildExtension}},
+)
+"""
+
+
+@pytest.mark.musa
+@pytest.mark.gpu
+@pytest.mark.slow
+@pytest.mark.skipif(not _gpu_available(), reason="requires a MUSA GPU")
+def test_stable_abi_shim_general_signatures(tmp_path):
+    import torch
+
+    shutil.copy(OPS_CU, tmp_path)
+    (tmp_path / "setup.py").write_text(
+        _SETUP_TEMPLATE.format(inc=stable_compat_include_dir(),
+                               box=stable_compat_box_header()))
+
+    res = subprocess.run(
+        [sys.executable, "setup.py", "build_ext", "--inplace"],
+        cwd=tmp_path, capture_output=True, text=True)
+    assert res.returncode == 0, f"build failed:\n{res.stderr[-4000:]}"
+
+    so = glob.glob(str(tmp_path / "torchada_stable_test*.so"))
+    assert so, "extension .so not produced"
+    torch.ops.load_library(so[0])
+
+    ns = torch.ops.torchada_stable_test
+    dev = "cuda"  # torchada -> musa
+
+    for dt in (torch.float32, torch.float16, torch.bfloat16):
+        # bf16 carries ~3 significant digits; scale-by-3 amplifies its rounding.
+        tol = 1e-1 if dt == torch.bfloat16 else 1e-2
+        x = torch.randn(128, device=dev, dtype=dt)
+        # (1) void return + two Tensor args + THO_DISPATCH (negation is exact)
+        out = torch.empty_like(x)
+        ns.negate(out, x)
+        torch.musa.synchronize()
+        assert torch.allclose(out.float(), -x.float(), atol=1e-2), f"negate {dt}"
+        # (2) void return + Tensor args + double scalar arg
+        out2 = torch.empty_like(x)
+        ns.scale(out2, x, 3.0)
+        torch.musa.synchronize()
+        assert torch.allclose(out2.float(), x.float() * 3.0, atol=tol, rtol=tol), \
+            f"scale {dt}"
+
+    # (3) single Tensor return  -> from<Tensor>
+    x = torch.randn(8, device=dev)
+    assert ns.passthrough(x).data_ptr() == x.data_ptr()
+    # (4) scalar int return     -> from<int64_t>
+    assert int(ns.numel_of(x)) == 8

--- a/tests/test_stable_abi_mappings.py
+++ b/tests/test_stable_abi_mappings.py
@@ -1,0 +1,77 @@
+"""Mapping-rule tests for the libtorch-stable ABI shim.
+
+These are pure-Python (no GPU): they verify torchada's _mapping.py knows how to
+port libtorch-stable kernels (as built by vLLM, SGLang, and other
+torch_musa-dependent projects, which target a newer PyTorch stable ABI than
+torch_musa ships) to MUSA. The end-to-end build+run is in test_stable_abi.py.
+"""
+
+import pytest
+
+
+class TestStableAbiMappingRules:
+    def test_aoti_stream_symbol_rule(self):
+        """The AOTI C-ABI stream getter must map cuda->musa (the C++
+        getCurrentCUDAStream rule does not match this C name)."""
+        from torchada._mapping import _MAPPING_RULE
+
+        assert (
+            _MAPPING_RULE["aoti_torch_get_current_cuda_stream"]
+            == "aoti_torch_get_current_musa_stream"
+        )
+
+    def test_stable_impl_dispatch_key_rekey(self):
+        """STABLE_TORCH_LIBRARY_IMPL registers under the literal dispatch-key
+        token; MUSA tensors are PrivateUse1, so the block must be re-keyed."""
+        from torchada._mapping import _MAPPING_RULE
+
+        assert (
+            _MAPPING_RULE["STABLE_TORCH_LIBRARY_IMPL(_C, CUDA"]
+            == "STABLE_TORCH_LIBRARY_IMPL(_C, PrivateUse1"
+        )
+
+    def test_cuda_header_rules_present(self):
+        from torchada._mapping import _MAPPING_RULE
+
+        assert _MAPPING_RULE["cuda.h"] == "musa.h"
+        assert _MAPPING_RULE["cuda_runtime.h"] == "musa_runtime.h"
+
+
+class TestStableAbiSourcePorting:
+    """Porting a representative stable-ABI source applies the rules."""
+
+    def _port(self, src: str) -> str:
+        from torchada.utils.cpp_extension import _port_cuda_source
+
+        return _port_cuda_source(src)
+
+    def test_port_rewrites_aoti_stream(self):
+        ported = self._port(
+            "auto s = aoti_torch_get_current_cuda_stream(0, &p);")
+        assert "aoti_torch_get_current_musa_stream" in ported
+        assert "aoti_torch_get_current_cuda_stream" not in ported
+
+    def test_port_rekeys_stable_impl_block(self):
+        ported = self._port(
+            "STABLE_TORCH_LIBRARY_IMPL(_C, CUDA, ops) { ops.impl(\"x\", f); }")
+        assert "STABLE_TORCH_LIBRARY_IMPL(_C, PrivateUse1" in ported
+
+
+class TestStableCompatHeadersShipped:
+    """torchada ships the stable-ABI compat headers + exposes their paths."""
+
+    def test_dispatch_shim_exists(self):
+        import os
+        from torchada.utils.cpp_extension import stable_compat_include_dir
+
+        d = stable_compat_include_dir()
+        assert os.path.isfile(
+            os.path.join(d, "torch", "headeronly", "core", "Dispatch.h"))
+
+    def test_box_header_exists_and_defines_torch_box(self):
+        import os
+        from torchada.utils.cpp_extension import stable_compat_box_header
+
+        h = stable_compat_box_header()
+        assert os.path.isfile(h)
+        assert "define TORCH_BOX" in open(h).read()


### PR DESCRIPTION
## Summary

Enables PyTorch **libtorch-stable / AOTI C-ABI** kernels (`csrc/libtorch_stable`,
as built by vLLM, SGLang, and other torch_musa-dependent projects) to compile and
run on MUSA. Those kernels target a newer `torch::stable` snapshot than
`torch_musa` 2.9.0 ships and register through the AOTI C ABI, so they don't port
or compile under the existing rules. This bridges the gap so MUSA consumers keep
building as upstream migrates to the stable ABI.

## What changed (all in torchada)

- **Mapping rules** (`_mapping.py`): `aoti_torch_get_current_cuda_stream` →
  `…_musa_stream`, and re-key `STABLE_TORCH_LIBRARY_IMPL(_C, CUDA` → `PrivateUse1`
  (the stable C ABI doesn't translate the device key like `torch.library` does;
  MUSA tensors are `PrivateUse1`).
- **Shipped compat headers** (`csrc/stable_compat/`):
  - `torch/headeronly/core/Dispatch.h` — the `THO_DISPATCH_*` macros (postdate
    torch_musa 2.9.0) + `ScalarTypeToCPPTypeT`/`toString` aliased to c10. Surfaced
    on the include path so it shadows the absent torch header.
  - `torchada_stable_box.h` — force-include providing `TORCH_BOX` (synthesized
    over torch_musa's `from<>`/`to<>` conversions), `HeaderOnlyArrayRef`,
    `torch::stable::contiguous`, a `CUDA_VERSION` guard, and a cuBLAS-handle stub.
- **Runtime header backport** (`utils/cpp_extension.py`): injects the
  libtorch-stable `Tensor` accessors torch_musa omits (`element_size`,
  `mutable_data_ptr<T>`, `const_data_ptr<T>`) and marks `tensor_inl.h` defs
  `inline` (ODR). **Applied lazily at build time** — triggered from
  `_create_musa_extension` and `BuildExtension.build_extensions`, not from
  `import torchada` — so a bare import or a pure-inference run never mutates the
  `torch`/`torch_musa` site-packages headers. Idempotent + best-effort
  (read-only installs no-op).
- **New helpers** `stable_compat_include_dir()` / `stable_compat_box_header()`;
  `include_paths()` auto-appends the compat dir (last) for MUSA device builds.

## Design notes

- Forward-compatible: compat headers are appended last on the include path and
  the backport is gated on the symbol being absent, so a future `torch_musa` that
  ships the real stable ABI silently takes over with no torchada change.
- JIT `load`/`load_inline` intentionally do **not** trigger the backport —
  torchada builds its own cpp ops through them at import, which would re-introduce
  an import-time write; libtorch-stable kernels are built via setuptools.

## Test plan

- `tests/test_stable_abi_mappings.py` — pure-Python: the two mapping rules,
  `_port_cuda_source` rewriting, and the shipped headers.
- `tests/test_stable_abi.py` (+ `tests/csrc/stable_abi_ops.cu`) — end-to-end:
  builds a stable-ABI extension through torchada and runs it on MUSA across diverse
  signatures (void/Tensor/int returns, scalar args, `THO_DISPATCH` over
  float/half/bfloat16).

Validated on MTT S5000 (`torch_musa` 2.9.0, mcc clang-14): mapping **7/7 passed**,
e2e build+run **passed**; confirmed `import torchada` leaves `torch`/`torch_musa`
headers untouched while the setuptools build applies the backport.

## Risk / compatibility

- Non-MUSA platforms unaffected (every path gated on `Platform.MUSA` /
  `import torch_musa`). API changes are additive only.
- The build-time backport edits files under the `torch`/`torch_musa` include
  trees; it is idempotent and only inserts missing symbols.