### PR TITLE
Workaround only_qv for mate FA3 interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ See `src/torchada/_mapping.py` for the complete mapping table (380+ mappings).
 
 ```
 # pyproject.toml or requirements.txt
-torchada>=0.1.67
+torchada>=0.1.68
 ```
 
 ### Step 2: Conditional Import

--- a/README_CN.md
+++ b/README_CN.md
@@ -293,7 +293,7 @@ if torchada.is_gpu_device(device):  # 在 CUDA 和 MUSA 上都能工作
 
 ```
 # pyproject.toml 或 requirements.txt
-torchada>=0.1.67
+torchada>=0.1.68
 ```
 
 ### 步骤 2：条件导入

--- a/benchmarks/benchmark_history.json
+++ b/benchmarks/benchmark_history.json
@@ -3,7 +3,7 @@
   "description": "Historical benchmark results for torchada performance tracking",
   "results": [
     {
-      "version": "0.1.67",
+      "version": "0.1.68",
       "date": "2026-01-29",
       "platform": "MUSA",
       "pytorch_version": "2.7.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torchada"
-version = "0.1.67"
+version = "0.1.68"
 description = "Adapter package for torch_musa to act exactly like PyTorch CUDA"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/torchada/__init__.py
+++ b/src/torchada/__init__.py
@@ -24,7 +24,7 @@ Usage:
     from torch.utils.cpp_extension import CUDAExtension, BuildExtension, CUDA_HOME
 """
 
-__version__ = "0.1.67"
+__version__ = "0.1.68"
 
 from . import cuda, utils
 

--- a/src/torchada/_patch.py
+++ b/src/torchada/_patch.py
@@ -1370,8 +1370,9 @@ def _patch_flash_attn():
     # not implement that parameter yet and would otherwise raise
     # ``TypeError: ... got an unexpected keyword argument 'only_qv'``. Wrap the
     # flash attention functions so the argument is dropped before delegating,
-    # but only when the underlying implementation doesn't already accept it, so
-    # a future native implementation is passed through untouched. Mutating the
+    # but only for implementations we can prove ignore it (see
+    # ``_accepts_only_qv``), so a future native implementation -- or one that
+    # forwards the argument -- is passed through untouched. Mutating the
     # functions on the module in place keeps ``sgl_kernel.flash_attn`` and
     # ``flash_attn_interface`` pointing at the same (wrapped) callables.
     _ignore_only_qv_param = "_torchada_ignores_only_qv"
@@ -1384,6 +1385,20 @@ def _patch_flash_attn():
 
         setattr(wrapper, _ignore_only_qv_param, True)
         return wrapper
+
+    def _accepts_only_qv(func: Callable) -> bool:
+        # Be conservative so a meaningful ``only_qv`` is never silently dropped:
+        # report False (i.e. safe to strip) only when the signature is
+        # introspectable AND declares no ``only_qv`` parameter AND accepts no
+        # arbitrary ``**kwargs`` (which could forward ``only_qv`` onward).
+        # Anything we can't prove ignores the argument is left untouched.
+        try:
+            params = inspect.signature(func).parameters
+        except (ValueError, TypeError):
+            return True
+        if "only_qv" in params:
+            return True
+        return any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
 
     # Harden every public flash attention entry point the module advertises,
     # plus a few well-known names in case the package exposes them lazily via a
@@ -1403,7 +1418,7 @@ def _patch_flash_attn():
         _func = getattr(flash_attn_interface, _name, None)
         if _func is None or inspect.isclass(_func) or not callable(_func):
             continue
-        if getattr(_func, _ignore_only_qv_param, False) or _has_param(_func, "only_qv"):
+        if getattr(_func, _ignore_only_qv_param, False) or _accepts_only_qv(_func):
             continue
         setattr(flash_attn_interface, _name, _drop_only_qv(_func))
 

--- a/src/torchada/_patch.py
+++ b/src/torchada/_patch.py
@@ -478,9 +478,23 @@ def _wrap_factory_function(original_fn: Callable) -> Callable:
 # Minimal fallback used only if torch's private device-constructor registry is
 # unavailable; the live set is normally discovered at runtime (see below).
 _FALLBACK_FACTORY_FUNCTIONS = (
-    "tensor", "as_tensor", "asarray", "empty", "zeros", "ones", "full",
-    "rand", "randn", "randint", "arange", "linspace", "eye",
-    "empty_like", "zeros_like", "ones_like", "full_like",
+    "tensor",
+    "as_tensor",
+    "asarray",
+    "empty",
+    "zeros",
+    "ones",
+    "full",
+    "rand",
+    "randn",
+    "randint",
+    "arange",
+    "linspace",
+    "eye",
+    "empty_like",
+    "zeros_like",
+    "ones_like",
+    "full_like",
 )
 
 # Factories that accept an explicit ``device=`` but that torch does NOT device-
@@ -522,6 +536,7 @@ def _discover_factory_functions() -> List[str]:
         if callable(getattr(torch, extra, None)):
             names.add(extra)
     return sorted(names)
+
 
 # Salt mixed into the AOT-autograd cache key for the wrapped factories; bump to
 # invalidate cached artifacts if the wrapping behavior changes.
@@ -1349,6 +1364,48 @@ def _patch_flash_attn():
     sgl_kernel = sys.modules["sgl_kernel"]
     sgl_kernel.flash_attn = flash_attn_interface
     sys.modules["sgl_kernel.flash_attn"] = flash_attn_interface
+
+    # Newer callers (e.g. sglang's FA3 path) pass an ``only_qv`` argument to the
+    # flash attention entry points. The MUSA flash_attn_interface package does
+    # not implement that parameter yet and would otherwise raise
+    # ``TypeError: ... got an unexpected keyword argument 'only_qv'``. Wrap the
+    # flash attention functions so the argument is dropped before delegating,
+    # but only when the underlying implementation doesn't already accept it, so
+    # a future native implementation is passed through untouched. Mutating the
+    # functions on the module in place keeps ``sgl_kernel.flash_attn`` and
+    # ``flash_attn_interface`` pointing at the same (wrapped) callables.
+    _ignore_only_qv_param = "_torchada_ignores_only_qv"
+
+    def _drop_only_qv(original: Callable) -> Callable:
+        @functools.wraps(original)
+        def wrapper(*args, **kwargs):
+            kwargs.pop("only_qv", None)
+            return original(*args, **kwargs)
+
+        setattr(wrapper, _ignore_only_qv_param, True)
+        return wrapper
+
+    # Harden every public flash attention entry point the module advertises,
+    # plus a few well-known names in case the package exposes them lazily via a
+    # module-level ``__getattr__`` (PEP 562), which would keep them out of
+    # ``dir()``. flash_attn_varlen_func and flash_attn_with_kvcache are the ones
+    # sglang's FA3 path forwards ``only_qv`` into.
+    candidate_names = {n for n in dir(flash_attn_interface) if n.startswith("flash_attn")}
+    candidate_names.update(
+        (
+            "flash_attn_func",
+            "flash_attn_varlen_func",
+            "flash_attn_with_kvcache",
+        )
+    )
+
+    for _name in sorted(candidate_names):
+        _func = getattr(flash_attn_interface, _name, None)
+        if _func is None or inspect.isclass(_func) or not callable(_func):
+            continue
+        if getattr(_func, _ignore_only_qv_param, False) or _has_param(_func, "only_qv"):
+            continue
+        setattr(flash_attn_interface, _name, _drop_only_qv(_func))
 
 
 class _CDLLWrapper:

--- a/tests/test_cuda_patching.py
+++ b/tests/test_cuda_patching.py
@@ -2587,6 +2587,83 @@ class TestFlashAttnPatching:
             assert hasattr(sgl_flash_attn, func_name), f"Missing {func_name}"
             assert callable(getattr(sgl_flash_attn, func_name)), f"{func_name} not callable"
 
+    def test_only_qv_argument_is_dropped(self):
+        """Newer sglang FA3 callers forward an ``only_qv`` keyword down into the
+        sgl_kernel.flash_attn kernels. The MUSA flash_attn_interface doesn't
+        implement that parameter, so _patch_flash_attn must wrap those entry
+        points to silently drop the argument before delegating -- while leaving
+        an implementation that natively supports it untouched.
+
+        Uses fully synthetic modules so it runs on any platform.
+        """
+        import sys
+        from types import ModuleType
+
+        from torchada._patch import _patch_flash_attn
+
+        # Save and shadow any real modules we are about to replace.
+        shadowed = ("flash_attn_interface", "sgl_kernel", "sgl_kernel.flash_attn")
+        saved = {name: sys.modules.pop(name, None) for name in shadowed}
+
+        try:
+            calls = {}
+
+            fake_fai = ModuleType("flash_attn_interface")
+
+            def flash_attn_varlen_func(q, k, v, causal=False):
+                # No ``only_qv`` parameter -> must be wrapped to drop it.
+                calls["varlen"] = dict(q=q, k=k, v=v, causal=causal)
+                return "varlen-ok"
+
+            def flash_attn_with_kvcache(q, only_qv=False):
+                # Already accepts ``only_qv`` -> must be left untouched.
+                calls["kvcache_only_qv"] = only_qv
+                return "kvcache-ok"
+
+            fake_fai.flash_attn_varlen_func = flash_attn_varlen_func
+            fake_fai.flash_attn_with_kvcache = flash_attn_with_kvcache
+            native_kvcache = fake_fai.flash_attn_with_kvcache
+            sys.modules["flash_attn_interface"] = fake_fai
+
+            # Pre-seed a stub sgl_kernel package so the patch doesn't import a
+            # real one (which may require CUDA/MUSA).
+            fake_sgl = ModuleType("sgl_kernel")
+            fake_sgl.__path__ = []
+            fake_sgl.__package__ = "sgl_kernel"
+            sys.modules["sgl_kernel"] = fake_sgl
+
+            _patch_flash_attn()
+
+            # varlen kernel had no only_qv -> wrapped, argument dropped, the
+            # rest of the call forwarded unchanged.
+            assert (
+                fake_fai.flash_attn_varlen_func(1, 2, 3, causal=True, only_qv=True) == "varlen-ok"
+            )
+            assert calls["varlen"] == {"q": 1, "k": 2, "v": 3, "causal": True}
+
+            # Identity preserved: a fresh import resolves to the same wrapped
+            # object (sgl_kernel.flash_attn IS flash_attn_interface).
+            from sgl_kernel.flash_attn import flash_attn_varlen_func as imported
+
+            assert imported is fake_fai.flash_attn_varlen_func
+
+            # kvcache kernel natively supports only_qv -> not wrapped, still
+            # receives the argument.
+            assert fake_fai.flash_attn_with_kvcache is native_kvcache
+            assert fake_fai.flash_attn_with_kvcache(0, only_qv=True) == "kvcache-ok"
+            assert calls["kvcache_only_qv"] is True
+
+            # Idempotent: re-running the patch does not double-wrap.
+            wrapped = fake_fai.flash_attn_varlen_func
+            _patch_flash_attn()
+            assert fake_fai.flash_attn_varlen_func is wrapped
+        finally:
+            for name in shadowed:
+                sys.modules.pop(name, None)
+            for name, mod in saved.items():
+                if mod is not None:
+                    sys.modules[name] = mod
+
 
 class TestAcceleratorModuleWrapper:
     """Test the _AcceleratorModuleWrapper priority / fallback logic in isolation.

--- a/tests/test_cuda_patching.py
+++ b/tests/test_cuda_patching.py
@@ -2591,8 +2591,12 @@ class TestFlashAttnPatching:
         """Newer sglang FA3 callers forward an ``only_qv`` keyword down into the
         sgl_kernel.flash_attn kernels. The MUSA flash_attn_interface doesn't
         implement that parameter, so _patch_flash_attn must wrap those entry
-        points to silently drop the argument before delegating -- while leaving
-        an implementation that natively supports it untouched.
+        points to silently drop the argument before delegating.
+
+        The wrap must be conservative: it only strips ``only_qv`` from callables
+        that provably ignore it. Implementations that declare ``only_qv``, accept
+        ``**kwargs`` (which may forward it onward), or aren't introspectable are
+        left untouched so a meaningful argument is never silently dropped.
 
         Uses fully synthetic modules so it runs on any platform.
         """
@@ -2620,9 +2624,20 @@ class TestFlashAttnPatching:
                 calls["kvcache_only_qv"] = only_qv
                 return "kvcache-ok"
 
+            def flash_attn_kwargs_func(q, **kwargs):
+                # Accepts only_qv via **kwargs -> may forward it -> leave alone.
+                calls["kwargs_only_qv"] = kwargs.get("only_qv")
+                return "kwargs-ok"
+
             fake_fai.flash_attn_varlen_func = flash_attn_varlen_func
             fake_fai.flash_attn_with_kvcache = flash_attn_with_kvcache
+            fake_fai.flash_attn_kwargs_func = flash_attn_kwargs_func
+            # A non-introspectable C callable (inspect.signature raises) -> must
+            # be left alone rather than guessed at.
+            fake_fai.flash_attn_builtin = iter
             native_kvcache = fake_fai.flash_attn_with_kvcache
+            native_kwargs = fake_fai.flash_attn_kwargs_func
+            native_builtin = fake_fai.flash_attn_builtin
             sys.modules["flash_attn_interface"] = fake_fai
 
             # Pre-seed a stub sgl_kernel package so the patch doesn't import a
@@ -2652,6 +2667,16 @@ class TestFlashAttnPatching:
             assert fake_fai.flash_attn_with_kvcache is native_kvcache
             assert fake_fai.flash_attn_with_kvcache(0, only_qv=True) == "kvcache-ok"
             assert calls["kvcache_only_qv"] is True
+
+            # **kwargs callable may forward only_qv -> not wrapped, still
+            # receives the argument.
+            assert fake_fai.flash_attn_kwargs_func is native_kwargs
+            assert fake_fai.flash_attn_kwargs_func(0, only_qv=True) == "kwargs-ok"
+            assert calls["kwargs_only_qv"] is True
+
+            # Non-introspectable callable -> left untouched rather than risk
+            # dropping an argument it may consume.
+            assert fake_fai.flash_attn_builtin is native_builtin
 
             # Idempotent: re-running the patch does not double-wrap.
             wrapped = fake_fai.flash_attn_varlen_func


### PR DESCRIPTION
UT:

```bash
============================================ 360 passed, 15 skipped, 4 warnings in 84.44s (0:01:24) =============================================
```

E2E (sglang-main + torchada):

```bash
root@worker34079:/home/dist/models/Wan-AI/Wan2.1-T2V-1.3B-Diffusers# sglang serve --model-path $PWD --port 11000 --log-level=debug --model-type diffusion 
INFO 06-25 10:20:21 [__init__.py:44] Available plugins for group vllm.platform_plugins:
INFO 06-25 10:20:21 [__init__.py:46] - musa -> vllm_musa:musa_platform_plugin
INFO 06-25 10:20:21 [__init__.py:49] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 06-25 10:20:21 [__init__.py:44] Available plugins for group vllm.platform_plugins:
INFO 06-25 10:20:21 [__init__.py:46] - musa -> vllm_musa:musa_platform_plugin
INFO 06-25 10:20:21 [__init__.py:49] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 06-25 10:20:21 [__init__.py:238] Platform plugin musa is activated
2026-06-25 10:20:21 | template_heuristics | 140213766195008 | INFO : MUSA-0087: Inductor template heuristic registration is default-off (Eagle3 draft compile crash on TP=8 M2.5). Set VLLM_MUSA_ENABLE_INDUCTOR_HEURISTICS=1 to opt in for non-Eagle3 workloads.
INFO 06-25 10:20:21 [__init__.py:238] Platform plugin musa is activated
2026-06-25 10:20:21 | warnings | 140213766195008 | WARNING : /home/dist/yeahdongcn/sglang/python/sglang/srt/layers/quantization/awq/awq.py:52: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

flash_attn is installed but failed to import: cannot import name '_wrapped_flash_attn_backward' from 'flash_attn.flash_attn_interface' (/usr/local/lib/python3.10/dist-packages/flash_attn/flash_attn_interface.py). Falling back to native PyTorch attention.
2026-06-25 10:20:24 | hf_diffusers_utils | 140213766195008 | INFO : Diffusers version: 0.33.0.dev0
[06-25 10:20:24] Ulysses degree not set, using default value 1
[06-25 10:20:24] Ring degree not set, using default value 1
[06-25 10:20:24] server_args: {"model_path": "/home/dist/models/Wan-AI/Wan2.1-T2V-1.3B-Diffusers", "model_id": null, "backend": "auto", "attention_backend": null, "attention_backend_config": {}, "component_attention_backends": {}, "cache_dit_config": null, "nccl_port": null, "trust_remote_code": false, "revision": null, "num_gpus": 1, "performance_mode": "auto", "base_gpu_id": 0, "gpu_ids": null, "tp_size": 1, "sp_degree": 1, "ulysses_degree": 1, "ring_degree": 1, "dp_size": 1, "dp_degree": 1, "enable_cfg_parallel": false, "cfg_parallel_degree": 1, "hsdp_replicate_dim": 1, "hsdp_shard_dim": 1, "dist_timeout": 3600, "pipeline_class_name": null, "lora_path": null, "lora_nickname": "default", "lora_scale": 1.0, "lora_merge_mode": "auto", "lora_weight_name": null, "component_paths": {}, "transformer_weights_path": null, "component_transformer_weights_paths": {}, "quantization": null, "quantization_ignored_layers": null, "lora_target_modules": null, "dit_cpu_offload": true, "dit_layerwise_offload": false, "layerwise_offload_components": null, "dit_offload_prefetch_size": 0.0, "text_encoder_cpu_offload": true, "image_encoder_cpu_offload": true, "vae_cpu_offload": false, "use_fsdp_inference": false, "pin_cpu_memory": true, "ltx2_two_stage_device_mode": null, "comfyui_mode": false, "enable_torch_compile": false, "enable_layerwise_nvtx_marker": false, "warmup_mode": "server", "warmup": true, "server_warmup": true, "warmup_resolutions": null, "warmup_steps": 1, "disable_autocast": false, "master_port": 30005, "host": "127.0.0.1", "port": 11000, "webui": false, "webui_port": 12312, "scheduler_port": 5614, "batching_mode": "dynamic", "batching_max_size": 1, "batching_delay_ms": 0.0, "batching_config": null, "enable_batching_metrics": false, "strict_ports": false, "output_path": "outputs/", "input_save_path": "inputs/uploads", "prompt_file_path": null, "model_paths": {}, "model_loaded": {"transformer": true, "vae": true, "video_vae": true, "audio_vae": true, "video_dit": true, "audio_dit": true, "dual_tower_bridge": true}, "boundary_ratio": null, "disagg_role": "monolithic", "disagg_timeout": 3600, "disagg_downstream_wait_timeout": 1800, "disagg_dispatch_policy": "round_robin", "disagg_mode": false, "disagg_instance_id": 0, "disagg_max_slots_per_instance": 8, "disagg_transfer_redundancy": 1.25, "disagg_role_device": "auto", "disagg_transfer_backend": "auto", "disagg_transfer_pool_size": 268435456, "disagg_transfer_pin_memory": "auto", "disagg_p2p_hostname": "127.0.0.1", "disagg_ib_device": null, "disagg_server_addr": null, "encoder_urls": null, "denoiser_urls": null, "decoder_urls": null, "encoder_tp": null, "denoiser_tp": null, "denoiser_sp": null, "denoiser_ulysses": null, "denoiser_ring": null, "decoder_sp": null, "decoder_tp": null, "pool_work_endpoint": null, "pool_result_endpoint": null, "pool_control_endpoint": null, "pool_control_advertised_endpoint": null, "log_level": "debug", "uvicorn_access_log_exclude_prefixes": [], "enable_trace": false, "otlp_traces_endpoint": "localhost:4317"}
[06-25 10:20:24] Starting server...
INFO 06-25 10:20:31 [__init__.py:44] Available plugins for group vllm.platform_plugins:
INFO 06-25 10:20:31 [__init__.py:46] - musa -> vllm_musa:musa_platform_plugin
INFO 06-25 10:20:31 [__init__.py:49] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 06-25 10:20:31 [__init__.py:44] Available plugins for group vllm.platform_plugins:
INFO 06-25 10:20:31 [__init__.py:46] - musa -> vllm_musa:musa_platform_plugin
INFO 06-25 10:20:31 [__init__.py:49] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 06-25 10:20:31 [__init__.py:238] Platform plugin musa is activated
2026-06-25 10:20:31 | template_heuristics | 139864292972352 | INFO : MUSA-0087: Inductor template heuristic registration is default-off (Eagle3 draft compile crash on TP=8 M2.5). Set VLLM_MUSA_ENABLE_INDUCTOR_HEURISTICS=1 to opt in for non-Eagle3 workloads.
INFO 06-25 10:20:31 [__init__.py:238] Platform plugin musa is activated
2026-06-25 10:20:31 | warnings | 139864292972352 | WARNING : /home/dist/yeahdongcn/sglang/python/sglang/srt/layers/quantization/awq/awq.py:52: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

flash_attn is installed but failed to import: cannot import name '_wrapped_flash_attn_backward' from 'flash_attn.flash_attn_interface' (/usr/local/lib/python3.10/dist-packages/flash_attn/flash_attn_interface.py). Falling back to native PyTorch attention.
[06-25 10:20:33] Scheduler bind at endpoint: tcp://127.0.0.1:5614
[06-25 10:20:33] torch.compile cache: TORCHINDUCTOR_CACHE_DIR=/root/.cache/sgl_diffusion/torch_compile_cache/inductor TRITON_CACHE_DIR=/root/.cache/sgl_diffusion/torch_compile_cache/triton
[06-25 10:20:33] Initializing distributed environment with world_size=1, device=musa:0, timeout=3600
[06-25 10:20:33] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://127.0.0.1:30005 backend=nccl timeout=3600
[06-25 10:20:33] Setting distributed timeout to 3600 seconds
[06-25 10:20:33] No pipeline_class_name specified, using model_index.json
[06-25 10:20:33] Auto-registered config classes for pipeline 'ComfyUIFluxPipeline': PipelineConfig=FluxPipelineConfig, SamplingParams=FluxSamplingParams
[06-25 10:20:33] Auto-registered config classes for pipeline 'ComfyUIQwenImagePipeline': PipelineConfig=QwenImagePipelineConfig, SamplingParams=QwenImageSamplingParams
[06-25 10:20:33] Auto-registered config classes for pipeline 'ComfyUIQwenImageEditPipeline': PipelineConfig=QwenImageEditPlusPipelineConfig, SamplingParams=QwenImageEditPlusSamplingParams
[06-25 10:20:33] Auto-registered config classes for pipeline 'ComfyUIZImagePipeline': PipelineConfig=ZImagePipelineConfig, SamplingParams=ZImageSamplingParams
[06-25 10:20:33] Auto-registered config classes for pipeline 'Krea2Pipeline': PipelineConfig=Krea2PipelineConfig, SamplingParams=Krea2SamplingParams
[06-25 10:20:33] Auto-registered config classes for pipeline 'LTX2TwoStageHQPipeline': PipelineConfig=LTX2PipelineConfig, SamplingParams=LTX23HQSamplingParams
[06-25 10:20:33] Auto-registered config classes for pipeline 'MOVA': PipelineConfig=MOVAPipelineConfig, SamplingParams=MOVASamplingParams
[06-25 10:20:33] Auto-registered config classes for pipeline 'MOVAPipeline': PipelineConfig=MOVAPipelineConfig, SamplingParams=MOVASamplingParams
[06-25 10:20:33] Auto-registered config classes for pipeline 'SanaWMPipeline': PipelineConfig=SanaWMPipelineConfig, SamplingParams=SanaWMSamplingParams
[06-25 10:20:33] Auto-registered config classes for pipeline 'SanaWMTwoStagePipeline': PipelineConfig=SanaWMPipelineConfig, SamplingParams=SanaWMSamplingParams
[06-25 10:20:33] Auto-registered config classes for pipeline 'SanaWMRealtimePipeline': PipelineConfig=SanaWMRealtimeConfig, SamplingParams=SanaWMSamplingParams
[06-25 10:20:33] Registering pipelines complete, 41 pipelines registered
[06-25 10:20:33] Diffusers version: 0.33.0.dev0
[06-25 10:20:33] Resolved model name 'Wan-AI/Wan2.1-T2V-1.3B-Diffusers' from partial path match.
[06-25 10:20:33] Using native sglang backend for model '/home/dist/models/Wan-AI/Wan2.1-T2V-1.3B-Diffusers'
[06-25 10:20:33] Found model info: ModelInfo(pipeline_cls=<class 'sglang.multimodal_gen.runtime.pipelines.wan_pipeline.WanPipeline'>, sampling_param_cls=<class 'sglang.multimodal_gen.configs.sample.wan.WanT2V_1_3B_SamplingParams'>, pipeline_config_cls=<class 'sglang.multimodal_gen.configs.pipeline_configs.wan.WanT2V480PConfig'>)
[06-25 10:20:33] Using pipeline from model_index.json: WanPipeline
[06-25 10:20:33] Loading pipeline modules...
[06-25 10:20:33] Model already exists locally and is complete
[06-25 10:20:33] Model path: /home/dist/models/Wan-AI/Wan2.1-T2V-1.3B-Diffusers
[06-25 10:20:33] Diffusers version: 0.33.0.dev0
[06-25 10:20:33] Loading pipeline modules from config: {'_class_name': 'WanPipeline', '_diffusers_version': '0.33.0.dev0', 'scheduler': ['diffusers', 'UniPCMultistepScheduler'], 'text_encoder': ['transformers', 'UMT5EncoderModel'], 'tokenizer': ['transformers', 'T5TokenizerFast'], 'transformer': ['diffusers', 'WanTransformer3DModel'], 'vae': ['diffusers', 'AutoencoderKLWan']}
[06-25 10:20:33] Loading required components: ['text_encoder', 'tokenizer', 'vae', 'transformer', 'scheduler']
[06-25 10:20:33] Resolved component path: /home/dist/models/Wan-AI/Wan2.1-T2V-1.3B-Diffusers/text_encoder
[06-25 10:20:33] Resolved component path: /home/dist/models/Wan-AI/Wan2.1-T2V-1.3B-Diffusers/tokenizer
[06-25 10:20:33] Resolved component path: /home/dist/models/Wan-AI/Wan2.1-T2V-1.3B-Diffusers/vae
[06-25 10:20:33] Resolved component path: /home/dist/models/Wan-AI/Wan2.1-T2V-1.3B-Diffusers/transformer
[06-25 10:20:33] Resolved component path: /home/dist/models/Wan-AI/Wan2.1-T2V-1.3B-Diffusers/scheduler
[06-25 10:20:33] Memory-aware component load order: ['text_encoder', 'transformer', 'vae', 'tokenizer', 'scheduler']
Loading required modules:   0%|                                                                                                 | 0/5 [00:00<?, ?it/s][06-25 10:20:33] Loading text_encoder from /home/dist/models/Wan-AI/Wan2.1-T2V-1.3B-Diffusers/text_encoder. avail mem: 79.25 GB
[06-25 10:20:33] HF model config: {'architectures': ['UMT5EncoderModel'], 'classifier_dropout': 0.0, 'd_ff': 10240, 'd_kv': 64, 'd_model': 4096, 'decoder_start_token_id': 0, 'dense_act_fn': 'gelu_new', 'dropout_rate': 0.1, 'eos_token_id': 1, 'feed_forward_proj': 'gated-gelu', 'initializer_factor': 1.0, 'is_encoder_decoder': True, 'is_gated_act': True, 'layer_norm_epsilon': 1e-06, 'num_decoder_layers': 24, 'num_heads': 64, 'num_layers': 24, 'output_past': True, 'pad_token_id': 0, 'relative_attention_max_distance': 128, 'relative_attention_num_buckets': 32, 'scalable_attention': True, 'tie_word_embeddings': False, 'use_cache': True, 'vocab_size': 256384}
[06-25 10:20:38] [RunAI Streamer] Overall time to stream 21.2 GiB of all files to cpu: 4.27s, 5.0 GiB/s
[06-25 10:20:59] Applied FSDP to 26 submodules in FSDPUMT5EncoderModel using explicit shard conditions
[06-25 10:20:59] Loaded text_encoder: FSDPUMT5EncoderModel (sgl-diffusion version). model size: 21.16 GB, consumed GPU mem: 0.24 GB, avail GPU mem: 79.00 GB
Loading required modules:  20%|█████████████████▊                                                                       | 1/5 [00:25<01:43, 25.80s/it][06-25 10:20:59] Loading transformer from /home/dist/models/Wan-AI/Wan2.1-T2V-1.3B-Diffusers/transformer. avail mem: 79.01 GB
[06-25 10:20:59] HF model config: {'_class_name': 'WanTransformer3DModel', 'added_kv_proj_dim': None, 'attention_head_dim': 128, 'cross_attn_norm': True, 'eps': 1e-06, 'ffn_dim': 8960, 'freq_dim': 256, 'image_dim': None, 'in_channels': 16, 'num_attention_heads': 12, 'num_layers': 30, 'out_channels': 16, 'patch_size': [1, 2, 2], 'qk_norm': 'rms_norm_across_heads', 'rope_max_seq_len': 1024, 'text_dim': 4096}
[06-25 10:20:59] Loading WanTransformer3DModel from 2 safetensors file(s) : ['/home/dist/models/Wan-AI/Wan2.1-T2V-1.3B-Diffusers/transformer/diffusion_pytorch_model-00001-of-00002.safetensors', '/home/dist/models/Wan-AI/Wan2.1-T2V-1.3B-Diffusers/transformer/diffusion_pytorch_model-00002-of-00002.safetensors'], param_dtype: torch.bfloat16
[06-25 10:20:59] quantization config: None
[06-25 10:20:59] Using FlashAttention (FA3) backend
[06-25 10:20:59] Using FlashAttention (FA3) backend
[06-25 10:21:00] [RunAI Streamer] Overall time to stream 5.3 GiB of all files to cpu: 0.55s, 9.7 GiB/s
[06-25 10:21:01] Casting checkpoint tensors to target dtype during load: torch.float32->torch.bfloat16 x765 (e.g. blocks.0.attn2.norm_k.weight, blocks.0.attn2.norm_q.weight, blocks.0.attn2.to_k.bias)
[06-25 10:21:02] Loaded transformer: WanTransformer3DModel (sgl-diffusion version). model size: 2.64 GB, consumed GPU mem: -0.00 GB, avail GPU mem: 79.01 GB
[06-25 10:21:02] Attention backends for transformer: fa
Loading required modules:  40%|███████████████████████████████████▌                                                     | 2/5 [00:28<00:36, 12.15s/it][06-25 10:21:02] Loading vae from /home/dist/models/Wan-AI/Wan2.1-T2V-1.3B-Diffusers/vae. avail mem: 79.01 GB
[06-25 10:21:02] HF model config: {'_class_name': 'AutoencoderKLWan', 'attn_scales': [], 'base_dim': 96, 'dim_mult': [1, 2, 4, 4], 'dropout': 0.0, 'latents_mean': [-0.7571, -0.7089, -0.9113, 0.1075, -0.1745, 0.9653, -0.1517, 1.5508, 0.4134, -0.0715, 0.5517, -0.3632, -0.1922, -0.9497, 0.2503, -0.2921], 'latents_std': [2.8184, 1.4541, 2.3275, 2.6558, 1.2196, 1.7708, 2.6052, 2.0743, 3.2687, 2.1526, 2.8652, 1.5579, 1.6382, 1.1253, 2.8251, 1.916], 'num_res_blocks': 2, 'temperal_downsample': [False, True, True], 'z_dim': 16}
[06-25 10:21:02] VAE unexpected keys: ['encoder.conv_in.bias', 'encoder.conv_in.weight', 'encoder.conv_out.bias', 'encoder.conv_out.weight', 'encoder.down_blocks.0.conv1.bias', 'encoder.down_blocks.0.conv1.weight', 'encoder.down_blocks.0.conv2.bias', 'encoder.down_blocks.0.conv2.weight', 'encoder.down_blocks.0.norm1.gamma', 'encoder.down_blocks.0.norm2.gamma', 'encoder.down_blocks.1.conv1.bias', 'encoder.down_blocks.1.conv1.weight', 'encoder.down_blocks.1.conv2.bias', 'encoder.down_blocks.1.conv2.weight', 'encoder.down_blocks.1.norm1.gamma', 'encoder.down_blocks.1.norm2.gamma', 'encoder.down_blocks.10.conv1.bias', 'encoder.down_blocks.10.conv1.weight', 'encoder.down_blocks.10.conv2.bias', 'encoder.down_blocks.10.conv2.weight', 'encoder.down_blocks.10.norm1.gamma', 'encoder.down_blocks.10.norm2.gamma', 'encoder.down_blocks.2.resample.1.bias', 'encoder.down_blocks.2.resample.1.weight', 'encoder.down_blocks.3.conv1.bias', 'encoder.down_blocks.3.conv1.weight', 'encoder.down_blocks.3.conv2.bias', 'encoder.down_blocks.3.conv2.weight', 'encoder.down_blocks.3.conv_shortcut.bias', 'encoder.down_blocks.3.conv_shortcut.weight', 'encoder.down_blocks.3.norm1.gamma', 'encoder.down_blocks.3.norm2.gamma', 'encoder.down_blocks.4.conv1.bias', 'encoder.down_blocks.4.conv1.weight', 'encoder.down_blocks.4.conv2.bias', 'encoder.down_blocks.4.conv2.weight', 'encoder.down_blocks.4.norm1.gamma', 'encoder.down_blocks.4.norm2.gamma', 'encoder.down_blocks.5.resample.1.bias', 'encoder.down_blocks.5.resample.1.weight', 'encoder.down_blocks.5.time_conv.bias', 'encoder.down_blocks.5.time_conv.weight', 'encoder.down_blocks.6.conv1.bias', 'encoder.down_blocks.6.conv1.weight', 'encoder.down_blocks.6.conv2.bias', 'encoder.down_blocks.6.conv2.weight', 'encoder.down_blocks.6.conv_shortcut.bias', 'encoder.down_blocks.6.conv_shortcut.weight', 'encoder.down_blocks.6.norm1.gamma', 'encoder.down_blocks.6.norm2.gamma', 'encoder.down_blocks.7.conv1.bias', 'encoder.down_blocks.7.conv1.weight', 'encoder.down_blocks.7.conv2.bias', 'encoder.down_blocks.7.conv2.weight', 'encoder.down_blocks.7.norm1.gamma', 'encoder.down_blocks.7.norm2.gamma', 'encoder.down_blocks.8.resample.1.bias', 'encoder.down_blocks.8.resample.1.weight', 'encoder.down_blocks.8.time_conv.bias', 'encoder.down_blocks.8.time_conv.weight', 'encoder.down_blocks.9.conv1.bias', 'encoder.down_blocks.9.conv1.weight', 'encoder.down_blocks.9.conv2.bias', 'encoder.down_blocks.9.conv2.weight', 'encoder.down_blocks.9.norm1.gamma', 'encoder.down_blocks.9.norm2.gamma', 'encoder.mid_block.attentions.0.norm.gamma', 'encoder.mid_block.attentions.0.proj.bias', 'encoder.mid_block.attentions.0.proj.weight', 'encoder.mid_block.attentions.0.to_qkv.bias', 'encoder.mid_block.attentions.0.to_qkv.weight', 'encoder.mid_block.resnets.0.conv1.bias', 'encoder.mid_block.resnets.0.conv1.weight', 'encoder.mid_block.resnets.0.conv2.bias', 'encoder.mid_block.resnets.0.conv2.weight', 'encoder.mid_block.resnets.0.norm1.gamma', 'encoder.mid_block.resnets.0.norm2.gamma', 'encoder.mid_block.resnets.1.conv1.bias', 'encoder.mid_block.resnets.1.conv1.weight', 'encoder.mid_block.resnets.1.conv2.bias', 'encoder.mid_block.resnets.1.conv2.weight', 'encoder.mid_block.resnets.1.norm1.gamma', 'encoder.mid_block.resnets.1.norm2.gamma', 'encoder.norm_out.gamma']
[06-25 10:21:02] Loaded vae: AutoencoderKLWan (sgl-diffusion version). model size: 0.27 GB, consumed GPU mem: 0.31 GB, avail GPU mem: 78.71 GB
Loading required modules:  60%|█████████████████████████████████████████████████████▍                                   | 3/5 [00:28<00:13,  6.73s/it][06-25 10:21:02] Loading tokenizer from /home/dist/models/Wan-AI/Wan2.1-T2V-1.3B-Diffusers/tokenizer. avail mem: 78.71 GB
[06-25 10:21:04] Loaded tokenizer: T5Tokenizer (sgl-diffusion version). model size: NA GB, consumed GPU mem: 0.00 GB, avail GPU mem: 78.70 GB
Loading required modules:  80%|███████████████████████████████████████████████████████████████████████▏                 | 4/5 [00:30<00:04,  4.65s/it][06-25 10:21:04] Loading scheduler from /home/dist/models/Wan-AI/Wan2.1-T2V-1.3B-Diffusers/scheduler. avail mem: 78.70 GB
[06-25 10:21:04] HF model config: {'_class_name': 'UniPCMultistepScheduler', 'beta_end': 0.02, 'beta_schedule': 'linear', 'beta_start': 0.0001, 'disable_corrector': [], 'dynamic_thresholding_ratio': 0.995, 'final_sigmas_type': 'zero', 'flow_shift': 3.0, 'lower_order_final': True, 'num_train_timesteps': 1000, 'predict_x0': True, 'prediction_type': 'flow_prediction', 'rescale_betas_zero_snr': False, 'sample_max_value': 1.0, 'solver_order': 2, 'solver_p': None, 'solver_type': 'bh2', 'steps_offset': 0, 'thresholding': False, 'timestep_spacing': 'linspace', 'trained_betas': None, 'use_beta_sigmas': False, 'use_exponential_sigmas': False, 'use_flow_sigmas': True, 'use_karras_sigmas': False}
[06-25 10:21:04] Loaded scheduler: UniPCMultistepScheduler (sgl-diffusion version). model size: NA GB, consumed GPU mem: 0.00 GB, avail GPU mem: 78.70 GB
Loading required modules: 100%|█████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:30<00:00,  6.03s/it]
[06-25 10:21:04] Memory usage of loaded modules (GiB): {'text_encoder': 0.24379348754882812, 'transformer': -0.0020751953125, 'vae': 0.305206298828125, 'tokenizer': 0.0020751953125, 'scheduler': 0.0}. avail mem: 78.7 GB
[06-25 10:21:04] Module load summary: required_modules=['text_encoder', 'tokenizer', 'vae', 'transformer', 'scheduler'] loaded_modules=['text_encoder', 'transformer', 'vae', 'tokenizer', 'scheduler'] memory_usages_gb={'text_encoder': 0.24379348754882812, 'transformer': -0.0020751953125, 'vae': 0.305206298828125, 'tokenizer': 0.0020751953125, 'scheduler': 0.0} total_consumed_gb=0.55 available_after_gb=78.70
[06-25 10:21:04] Creating pipeline stages...
[06-25 10:21:04] Using FlashAttention (FA3) backend
[06-25 10:21:04] Using fa attention backend
[06-25 10:21:04] Pipeline instantiated
[06-25 10:21:04] Worker 0: Initialized device, model, and distributed environment.
[06-25 10:21:04] Worker 0: Scheduler loop started.
[06-25 10:21:04] Rank 0 scheduler listening on tcp://*:5614
[06-25 10:21:04] All workers are ready
[06-25 10:21:04] Starting FastAPI server.
[2026-06-25 10:21:04] INFO:     Started server process [17922]
[2026-06-25 10:21:04] INFO:     Waiting for application startup.
[06-25 10:21:04] AsyncSchedulerClient initialized with zmq.asyncio.Context
[06-25 10:21:04] ZMQ Broker is listening for offline jobs on tcp://127.0.0.1:11001
[2026-06-25 10:21:04] INFO:     Application startup complete.
[2026-06-25 10:21:04] INFO:     Uvicorn running on http://127.0.0.1:11000 (Press CTRL+C to quit)
[2026-06-25 10:21:05] INFO:     127.0.0.1:57612 - "GET /health HTTP/1.1" 200 OK
[06-25 10:21:05] Diffusers version: 0.33.0.dev0
[06-25 10:21:05] Using native sglang backend for model '/home/dist/models/Wan-AI/Wan2.1-T2V-1.3B-Diffusers'
[06-25 10:21:05] Found model info: ModelInfo(pipeline_cls=<class 'sglang.multimodal_gen.runtime.pipelines.wan_pipeline.WanPipeline'>, sampling_param_cls=<class 'sglang.multimodal_gen.configs.sample.wan.WanT2V_1_3B_SamplingParams'>, pipeline_config_cls=<class 'sglang.multimodal_gen.configs.pipeline_configs.wan.WanT2V480PConfig'>)
Warmup requests:   0%|                                                                                                         | 0/1 [00:00<?, ?req/s][06-25 10:21:18] SGLANG_USE_SGL_FA3_KERNEL=True, use sgl-kernel implementation for FlashAttention v3 
[06-25 10:21:18] /usr/local/lib/python3.10/dist-packages/torch/amp/autocast_mode.py:332: UserWarning: In musa autocast, but the target dtype torch.float32 is not supported. Disabling autocast.
 musa Autocast only supports dtypes of torch.float16, torch.bfloat16 currently.
  warnings.warn(error_message)

Warmup requests: 100%|███████████████████████████████████████| 1/1 [00:14<00:00, 14.69s/req, server warmup req (832x480x17f, 2/50 steps), last=14.68s]
[06-25 10:21:19] The server is fired up and ready to roll!
```