### PR TITLE
feat: add CUDA graph debug dumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,20 @@ with torch.cuda.graph(cuda_graph=g):  # cuda_graph= keyword works on MUSA
     y = model(x)
 ```
 
+To dump MUSA graph dot files for debugging, set
+`TORCHADA_CUDA_GRAPH_DEBUG_DUMP_PATH` before running your program. torchada will
+call `enable_debug_mode()` before each graph capture and `debug_dump(path)` after
+the capture completes:
+
+```bash
+TORCHADA_CUDA_GRAPH_DEBUG_DUMP_PATH=./graph_dumps \
+python serve.py
+```
+
+The value is a dump directory. torchada creates it if needed and writes
+timestamped files such as `graph_1783512345678900000.dot` inside it, so
+repeated captures do not overwrite one another.
+
 ### torch.compile
 
 ```python
@@ -298,7 +312,7 @@ See `src/torchada/_mapping.py` for the complete mapping table (380+ mappings).
 
 ```
 # pyproject.toml or requirements.txt
-torchada>=0.1.70
+torchada>=0.1.71
 ```
 
 ### Step 2: Conditional Import

--- a/README_CN.md
+++ b/README_CN.md
@@ -107,6 +107,18 @@ with torch.cuda.graph(cuda_graph=g):  # cuda_graph= 关键字参数在 MUSA 上�
     y = model(x)
 ```
 
+如果需要 dump MUSA graph 的 dot 文件用于调试，可以在运行前设置
+`TORCHADA_CUDA_GRAPH_DEBUG_DUMP_PATH`。torchada 会在每次 graph capture 前调用
+`enable_debug_mode()`，并在 capture 结束后调用 `debug_dump(path)`：
+
+```bash
+TORCHADA_CUDA_GRAPH_DEBUG_DUMP_PATH=./graph_dumps \
+python serve.py
+```
+
+该变量表示 dump 目录。torchada 会按需创建目录，并在其中写入带时间戳的文件，
+例如 `graph_1783512345678900000.dot`，避免多次 capture 时互相覆盖。
+
 ### torch.compile
 
 ```python
@@ -293,7 +305,7 @@ if torchada.is_gpu_device(device):  # 在 CUDA 和 MUSA 上都能工作
 
 ```
 # pyproject.toml 或 requirements.txt
-torchada>=0.1.70
+torchada>=0.1.71
 ```
 
 ### 步骤 2：条件导入

--- a/benchmarks/benchmark_history.json
+++ b/benchmarks/benchmark_history.json
@@ -3,7 +3,7 @@
   "description": "Historical benchmark results for torchada performance tracking",
   "results": [
     {
-      "version": "0.1.69",
+      "version": "0.1.71",
       "date": "2026-01-29",
       "platform": "MUSA",
       "pytorch_version": "2.7.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torchada"
-version = "0.1.70"
+version = "0.1.71"
 description = "Adapter package for torch_musa to act exactly like PyTorch CUDA"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/torchada/__init__.py
+++ b/src/torchada/__init__.py
@@ -24,7 +24,7 @@ Usage:
     from torch.utils.cpp_extension import CUDAExtension, BuildExtension, CUDA_HOME
 """
 
-__version__ = "0.1.70"
+__version__ = "0.1.71"
 
 from . import cuda, utils
 

--- a/src/torchada/_patch.py
+++ b/src/torchada/_patch.py
@@ -23,7 +23,9 @@ Usage:
 
 import functools
 import inspect
+import os
 import sys
+import time
 import warnings
 from types import ModuleType, SimpleNamespace
 from typing import Any, Callable, List, Optional
@@ -387,6 +389,66 @@ def _patch_torch_generator():
 
 # Store original graph class for patching
 _original_graph_class = None
+_cuda_graph_debug_dump_dir: Optional[str] = None
+
+
+def _configure_cuda_graph_debug_dump_dir() -> Optional[str]:
+    """Cache the optional graph debug dump directory from the environment."""
+    global _cuda_graph_debug_dump_dir
+
+    path_setting = os.environ.get("TORCHADA_CUDA_GRAPH_DEBUG_DUMP_PATH")
+    if not path_setting:
+        _cuda_graph_debug_dump_dir = None
+        return None
+
+    dump_dir = os.path.abspath(os.path.expanduser(path_setting))
+    try:
+        os.makedirs(dump_dir, exist_ok=True)
+    except Exception as exc:  # noqa: BLE001
+        warnings.warn(f"TORCHADA_CUDA_GRAPH_DEBUG_DUMP_PATH={path_setting!r} is unusable: {exc!r}")
+        _cuda_graph_debug_dump_dir = None
+        return None
+
+    _cuda_graph_debug_dump_dir = dump_dir
+    return dump_dir
+
+
+def _resolve_cuda_graph_debug_dump_path(dump_dir: str) -> str:
+    """Resolve the configured graph debug directory to a timestamped dot path."""
+    timestamp = str(time.time_ns())
+    return os.path.join(dump_dir, f"graph_{timestamp}.dot")
+
+
+def _enable_cuda_graph_debug_mode(graph_obj: Any) -> bool:
+    enable_debug_mode = getattr(graph_obj, "enable_debug_mode", None)
+    if enable_debug_mode is None:
+        warnings.warn(
+            "TORCHADA_CUDA_GRAPH_DEBUG_DUMP_PATH is set but "
+            "graph.enable_debug_mode() is unavailable"
+        )
+        return False
+
+    try:
+        enable_debug_mode()
+    except Exception as exc:  # noqa: BLE001
+        warnings.warn(f"graph.enable_debug_mode() failed: {exc!r}")
+        return False
+    return True
+
+
+def _dump_cuda_graph_debug_dot(graph_obj: Any, dump_dir: str) -> None:
+    debug_dump = getattr(graph_obj, "debug_dump", None)
+    if debug_dump is None:
+        warnings.warn(
+            "TORCHADA_CUDA_GRAPH_DEBUG_DUMP_PATH is set but "
+            "graph.debug_dump(path) is unavailable"
+        )
+        return
+
+    try:
+        debug_dump(_resolve_cuda_graph_debug_dump_path(dump_dir))
+    except Exception as exc:  # noqa: BLE001
+        warnings.warn(f"graph.debug_dump() failed: {exc!r}")
 
 
 def _patch_graph_context_manager():
@@ -406,6 +468,7 @@ def _patch_graph_context_manager():
     if not hasattr(torch.cuda, "graph"):
         return
 
+    _configure_cuda_graph_debug_dump_dir()
     _original_graph_class = torch.cuda.graph
 
     class GraphWrapper:
@@ -428,6 +491,10 @@ def _patch_graph_context_manager():
             if graph_obj is None:
                 raise TypeError("graph() missing required argument: 'cuda_graph'")
 
+            self._graph_obj = graph_obj
+            self._debug_dump_dir = None
+            self._debug_enabled = False
+
             # Create the original graph instance
             self._wrapped = _original_graph_class(
                 graph_obj,
@@ -437,10 +504,19 @@ def _patch_graph_context_manager():
             )
 
         def __enter__(self):
+            if _cuda_graph_debug_dump_dir:
+                self._debug_dump_dir = _cuda_graph_debug_dump_dir
+                self._debug_enabled = _enable_cuda_graph_debug_mode(self._graph_obj)
+            else:
+                self._debug_dump_dir = None
+                self._debug_enabled = False
             return self._wrapped.__enter__()
 
         def __exit__(self, exc_type, exc_value, traceback):
-            return self._wrapped.__exit__(exc_type, exc_value, traceback)
+            result = self._wrapped.__exit__(exc_type, exc_value, traceback)
+            if exc_type is None and self._debug_enabled and self._debug_dump_dir:
+                _dump_cuda_graph_debug_dot(self._graph_obj, self._debug_dump_dir)
+            return result
 
     # Copy over class attributes and docstring
     GraphWrapper.__doc__ = _original_graph_class.__doc__
@@ -1865,6 +1941,7 @@ def apply_patches():
     - Device string translation ("cuda" -> "musa")
     - torch.distributed with 'nccl' backend -> 'mccl'
     - torch.cuda.CUDAGraph -> torch.musa.MUSAGraph
+    - optional CUDA graph debug dumps via TORCHADA_CUDA_GRAPH_DEBUG_DUMP_PATH
     - torch.cuda.nccl -> torch.musa.mccl
     - torch.amp.autocast(device_type='cuda') -> 'musa'
     - torch.utils.cpp_extension (CUDAExtension, BuildExtension) -> MUSA versions

--- a/tests/test_cuda_patching.py
+++ b/tests/test_cuda_patching.py
@@ -351,6 +351,58 @@ class TestCUDAGraph:
         ctx = torch.cuda.graph(cuda_graph=g, pool=pool, stream=stream)
         assert ctx is not None
 
+    @pytest.mark.musa
+    def test_graph_context_manager_debug_dump(self, tmp_path, monkeypatch):
+        """Graph debug dump captures a real GEMM graph and writes a dot file."""
+        import torch
+
+        import torchada
+        from torchada import _patch
+
+        if not torchada.is_musa_platform():
+            pytest.skip("MUSA-only test")
+        if torch.cuda.device_count() == 0:
+            pytest.skip("No GPU available")
+
+        monkeypatch.chdir(tmp_path)
+        dump_dir = tmp_path / "graph_dumps"
+        monkeypatch.setattr(_patch, "_cuda_graph_debug_dump_dir", None)
+        monkeypatch.setenv("TORCHADA_CUDA_GRAPH_DEBUG_DUMP_PATH", "graph_dumps")
+        _patch._configure_cuda_graph_debug_dump_dir()
+        assert _patch._cuda_graph_debug_dump_dir == str(dump_dir)
+        monkeypatch.chdir(tmp_path.parent)
+
+        a = torch.randn(32, 32, device="cuda", dtype=torch.float32)
+        b = torch.randn(32, 32, device="cuda", dtype=torch.float32)
+        out = torch.empty(32, 32, device="cuda", dtype=torch.float32)
+
+        # Warm up GEMM before graph capture so the captured region is stable.
+        torch.mm(a, b, out=out)
+        expected = out.detach().clone()
+        torch.cuda.synchronize()
+
+        graph = torch.cuda.CUDAGraph()
+        dump_files = []
+        try:
+            with torch.cuda.graph(cuda_graph=graph):
+                torch.mm(a, b, out=out)
+
+            dump_files = sorted(dump_dir.glob("graph_*.dot"))
+            assert len(dump_files) == 1
+            assert dump_files[0].is_file()
+            assert dump_files[0].stat().st_size > 0
+
+            out.zero_()
+            graph.replay()
+            torch.cuda.synchronize()
+            torch.testing.assert_close(out, expected, rtol=1e-4, atol=1e-4)
+        finally:
+            for path in dump_files:
+                try:
+                    path.unlink()
+                except FileNotFoundError:
+                    pass
+
 
 class TestDistributedBackend:
     """Test distributed backend patching."""
@@ -3111,9 +3163,7 @@ class TestStableCompatHeaders:
 
         from torchada.utils.cpp_extension import stable_compat_include_dir
 
-        p = os.path.join(
-            stable_compat_include_dir(), "torch", "headeronly", "core", "Dispatch.h"
-        )
+        p = os.path.join(stable_compat_include_dir(), "torch", "headeronly", "core", "Dispatch.h")
         assert os.path.isfile(p), f"Dispatch.h shim missing: {p}"
         text = open(p, encoding="utf-8").read()
         # The THO_DISPATCH_* macros vLLM/SGLang stable kernels use.
@@ -3127,9 +3177,7 @@ class TestStableCompatHeaders:
 
         from torchada.utils.cpp_extension import stable_compat_include_dir
 
-        p = os.path.join(
-            stable_compat_include_dir(), "torch", "csrc", "stable", "device.h"
-        )
+        p = os.path.join(stable_compat_include_dir(), "torch", "csrc", "stable", "device.h")
         assert os.path.isfile(p), f"device.h shim missing: {p}"
         text = open(p, encoding="utf-8").read()
         assert "struct Device" in text
@@ -3146,9 +3194,7 @@ class TestStableCompatHeaders:
         from torchada.utils.cpp_extension import stable_compat_include_dir
 
         text = open(
-            os.path.join(
-                stable_compat_include_dir(), "torch", "csrc", "stable", "device.h"
-            ),
+            os.path.join(stable_compat_include_dir(), "torch", "csrc", "stable", "device.h"),
             encoding="utf-8",
         ).read()
         assert "int32_t type_;" not in text, "type_ left uninitialized"
@@ -3162,9 +3208,7 @@ class TestStableCompatHeaders:
 
         from torchada.utils.cpp_extension import stable_compat_include_dir
 
-        p = os.path.join(
-            stable_compat_include_dir(), "torch", "csrc", "stable", "macros.h"
-        )
+        p = os.path.join(stable_compat_include_dir(), "torch", "csrc", "stable", "macros.h")
         assert os.path.isfile(p), f"macros.h shim missing: {p}"
         assert "library.h" in open(p, encoding="utf-8").read()
 
@@ -3257,10 +3301,7 @@ class TestStableCompatHeaders:
     def test_include_paths_appends_stable_compat_on_musa(self):
         """include_paths() auto-appends the stable_compat dir for device builds on MUSA."""
         import torchada
-        from torchada.utils.cpp_extension import (
-            include_paths,
-            stable_compat_include_dir,
-        )
+        from torchada.utils.cpp_extension import include_paths, stable_compat_include_dir
 
         if not torchada.is_musa_platform():
             pytest.skip("Only applicable on MUSA platform")
@@ -3273,10 +3314,7 @@ class TestStableCompatHeaders:
     def test_include_paths_omits_stable_compat_for_cpu_only(self):
         """include_paths(device_type='cpu') does not add the device stable_compat dir."""
         import torchada
-        from torchada.utils.cpp_extension import (
-            include_paths,
-            stable_compat_include_dir,
-        )
+        from torchada.utils.cpp_extension import include_paths, stable_compat_include_dir
 
         if not torchada.is_musa_platform():
             pytest.skip("Only applicable on MUSA platform")

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -59,7 +59,7 @@ class TestPlatformDetection:
 
         version = torchada.get_version()
         assert version == torchada.__version__
-        assert version == "0.1.70"
+        assert version == "0.1.71"
         assert isinstance(version, str)
 
     def test_project_version_matches_runtime_version(self):


### PR DESCRIPTION
## Summary

Adds an optional CUDA graph debug dump path for MUSA graph capture:

- Read `TORCHADA_CUDA_GRAPH_DEBUG_DUMP_PATH` once during CUDA graph patch setup and cache the dump directory.
- Call `graph.enable_debug_mode()` before graph capture when the dump directory is configured.
- Call `graph.debug_dump(...)` after a successful graph capture and write timestamped files named `graph_<time_ns>.dot`.
- Document the environment variable in English and Chinese READMEs.
- Add a real MUSA GEMM graph capture test that verifies a dot file is emitted and removes the dump file afterward.

## Validation

```text
TORCH_DEVICE_BACKEND_AUTOLOAD=0 PYTHONPATH=src python -m pytest tests/test_cuda_patching.py::TestCUDAGraph -q
```

Result:

```text
12 passed, 2 warnings in 9.93s
```

The warnings are from `torch_musa` debug dumping and confirm the generated dot path:

```text
/tmp/pytest-of-root/pytest-1/test_graph_context_manager_deb0/graph_dumps/graph_1783672385347873460.dot
```
