### PR TITLE
Keep CUDA->MUSA mapping defines out of in-place porting

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ See `src/torchada/_mapping.py` for the complete mapping table (380+ mappings).
 
 ```
 # pyproject.toml or requirements.txt
-torchada>=0.1.72
+torchada>=0.1.73
 ```
 
 ### Step 2: Conditional Import

--- a/README_CN.md
+++ b/README_CN.md
@@ -305,7 +305,7 @@ if torchada.is_gpu_device(device):  # 在 CUDA 和 MUSA 上都能工作
 
 ```
 # pyproject.toml 或 requirements.txt
-torchada>=0.1.72
+torchada>=0.1.73
 ```
 
 ### 步骤 2：条件导入

--- a/benchmarks/benchmark_history.json
+++ b/benchmarks/benchmark_history.json
@@ -3,7 +3,7 @@
   "description": "Historical benchmark results for torchada performance tracking",
   "results": [
     {
-      "version": "0.1.72",
+      "version": "0.1.73",
       "date": "2026-01-29",
       "platform": "MUSA",
       "pytorch_version": "2.7.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torchada"
-version = "0.1.72"
+version = "0.1.73"
 description = "Adapter package for torch_musa to act exactly like PyTorch CUDA"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/torchada/__init__.py
+++ b/src/torchada/__init__.py
@@ -24,7 +24,7 @@ Usage:
     from torch.utils.cpp_extension import CUDAExtension, BuildExtension, CUDA_HOME
 """
 
-__version__ = "0.1.72"
+__version__ = "0.1.73"
 
 from . import cuda, utils
 

--- a/src/torchada/utils/cpp_extension.py
+++ b/src/torchada/utils/cpp_extension.py
@@ -92,17 +92,25 @@ _MUSA_NATIVE_EXTS = (
 # alias (`#define cudaCheck cudaCheckImpl` still ports), so only the degenerate
 # mapping is skipped.
 _SELF_REF_DEFINE_RE = re.compile(
-    r"^\s*#\s*define\s+(\w+)(?:\([^()]*\))?\s+(\w+)(?:\([^()]*\))?\s*$"
+    r"^\s*#\s*define\s+(\w+)(?:\([^()]*\))?\s+\(*\s*(\w+)\s*(?:\([^()]*\))?\s*\)*\s*$"
 )
+_BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+_LINE_COMMENT_RE = re.compile(r"//.*")
 
 
 def _collapses_to_self_reference(ported: str) -> bool:
     """Whether a ported logical line became a self-referential ``#define X X``.
 
-    Takes the whole logical line: a mapping header may put the replacement past
-    a backslash continuation, and that form collapses identically.
+    Matches the whole logical line, since a mapping may put its replacement past
+    a backslash continuation. Trailing comments and redundant parentheses around
+    the replacement are ignored first: ``#define X (X)`` and ``#define X X /* n */``
+    shadow the real definition exactly as ``#define X X`` does, and vendor headers
+    routinely annotate their mappings. Only the decision reads the stripped text;
+    the line itself is emitted untouched.
     """
     flat = re.sub(r"\\\s*\n\s*", " ", ported)
+    flat = _BLOCK_COMMENT_RE.sub(" ", flat)
+    flat = _LINE_COMMENT_RE.sub("", flat)
     match = _SELF_REF_DEFINE_RE.match(flat)
     return match is not None and match.group(1) == match.group(2)
 

--- a/src/torchada/utils/cpp_extension.py
+++ b/src/torchada/utils/cpp_extension.py
@@ -82,6 +82,30 @@ _MUSA_NATIVE_EXTS = (
     ".muh",
 )
 
+# A vendor mapping header spells each CUDA name in terms of its MUSA
+# counterpart (`#define cudaEventDisableTiming musaEventDisableTiming`,
+# `#define CU_MEMORYTYPE_DEVICE MU_MEMORYTYPE_DEVICE`). Substituting the defined
+# name as well collapses the line to `#define musaX musaX` -- a self-reference
+# that shadows the real definition (`driver_types.h`) and leaves the symbol
+# expanding to an undeclared identifier. Such a line is already MUSA-aware, so
+# it is kept verbatim. Names never collide across the two sides of a genuine
+# alias (`#define cudaCheck cudaCheckImpl` still ports), so only the degenerate
+# mapping is skipped.
+_SELF_REF_DEFINE_RE = re.compile(
+    r"^\s*#\s*define\s+(\w+)(?:\([^()]*\))?\s+(\w+)(?:\([^()]*\))?\s*$"
+)
+
+
+def _collapses_to_self_reference(ported: str) -> bool:
+    """Whether a ported logical line became a self-referential ``#define X X``.
+
+    Takes the whole logical line: a mapping header may put the replacement past
+    a backslash continuation, and that form collapses identically.
+    """
+    flat = re.sub(r"\\\s*\n\s*", " ", ported)
+    match = _SELF_REF_DEFINE_RE.match(flat)
+    return match is not None and match.group(1) == match.group(2)
+
 
 def _get_cuda_home() -> Optional[str]:
     """
@@ -293,10 +317,11 @@ def _patch_simple_porting_open(musa_sp):
 
 def _patch_simple_porting_modify_file(musa_sp):
     """Make ``SimplePorting.modify_file`` (a) only rewrite compiled C/C++/CUDA
-    files and (b) read the whole source before writing, so porting a file **in
-    place** (destination path == source path) is safe.
+    files, (b) read the whole source before writing, so porting a file **in
+    place** (destination path == source path) is safe, and (c) keep CUDA→MUSA
+    mapping lines that substitution would collapse into a self-reference.
 
-    Two problems with the stock method under in-place porting:
+    Three problems with the stock method under in-place porting:
 
     1. ``SimplePorting.run`` walks *every* file in the tree and calls
        ``modify_file`` on each, regardless of extension. In the legacy
@@ -318,6 +343,16 @@ def _patch_simple_porting_modify_file(musa_sp):
        the source handle is open, zeroing the file when src == dst. Reading all
        lines up front before opening the destination makes the in-place write
        safe.
+
+    3. A project-local vendor header may already map CUDA onto MUSA itself
+       (``#define cudaEventDisableTiming musaEventDisableTiming``). Substituting
+       the defined name turns it into ``#define musaEventDisableTiming
+       musaEventDisableTiming``, which shadows the runtime's real definition
+       with a self-reference, so the symbol expands to an undeclared identifier
+       and every translation unit using it fails to compile. In mirror mode the
+       original header stayed intact and only the throwaway copy was mangled;
+       in place there is no intact copy left. Lines that collapse this way are
+       kept verbatim -- see ``_collapses_to_self_reference``.
     """
 
     def modify_file(self, cuda_filepath, musa_filepath):
@@ -343,15 +378,38 @@ def _patch_simple_porting_modify_file(musa_sp):
             )
         with open(cuda_filepath, encoding="utf-8", errors="surrogateescape") as f:
             lines = f.readlines()
-        out = []
-        for line in lines:
+
+        def port_line(line):
             if line.startswith("*") or line.startswith("/") or line == "":
-                out.append(line)
-                continue
+                return line
             for k, v in self.mapping_rule:
                 if "cub/" not in line:
                     line = line.replace(k, v)
-            out.append(line)
+            return line
+
+        out = []
+        src_group = []
+        ported_group = []
+
+        def flush_group():
+            ported_text = "".join(ported_group)
+            if _collapses_to_self_reference(ported_text):
+                out.append("".join(src_group))
+            else:
+                out.append(ported_text)
+            src_group.clear()
+            ported_group.clear()
+
+        # Accumulate each logical line (backslash continuations included) so a
+        # mapping that collapses to `#define X X` can be reverted as a whole.
+        for line in lines:
+            src_group.append(line)
+            ported_group.append(port_line(line))
+            if not line.rstrip("\n").endswith("\\"):
+                flush_group()
+        if src_group:
+            flush_group()
+
         with open(musa_filepath, "w", encoding="utf-8", errors="surrogateescape") as f_musa:
             f_musa.writelines(out)
 

--- a/tests/test_inplace_porting.py
+++ b/tests/test_inplace_porting.py
@@ -155,6 +155,44 @@ def test_vendor_mapping_defines_are_kept_verbatim(tmp_path):
     assert "#define musaEventDisableTiming musaEventDisableTiming" not in ported
 
 
+def test_annotated_and_parenthesized_mappings_are_kept_verbatim(tmp_path):
+    """Mappings still collapse when annotated or wrapped in redundant parens.
+
+    `#define X (X)` and `#define X X /* note */` shadow the real definition
+    exactly as `#define X X` does, and vendor headers routinely write both.
+    """
+    source_dir = tmp_path / "gpu_vendor"
+    source_dir.mkdir()
+    header = source_dir / "musa.h"
+    header.write_text(
+        "#define cudaEventDisableTiming musaEventDisableTiming /**< no timing */\n"
+        "#define cudaHostRegisterIoMemory musaHostRegisterIoMemory // mapped I/O\n"
+        "#define cudaSuccess (musaSuccess)\n"
+        "#define CU_MEMORYTYPE_DEVICE \\\n"
+        "    MU_MEMORYTYPE_DEVICE /* device memory */\n",
+        encoding="utf-8",
+    )
+
+    command = _build_extension_command()
+    command._port_directory(
+        str(source_dir),
+        {
+            "cudaEventDisableTiming": "musaEventDisableTiming",
+            "cudaHostRegisterIoMemory": "musaHostRegisterIoMemory",
+            "cudaSuccess": "musaSuccess",
+            "CU_MEMORYTYPE_DEVICE": "MU_MEMORYTYPE_DEVICE",
+        },
+    )
+
+    ported = header.read_text(encoding="utf-8")
+    assert "#define cudaEventDisableTiming musaEventDisableTiming /**< no timing */\n" in ported
+    assert "#define cudaHostRegisterIoMemory musaHostRegisterIoMemory // mapped I/O\n" in ported
+    assert "#define cudaSuccess (musaSuccess)\n" in ported
+    assert (
+        "#define CU_MEMORYTYPE_DEVICE \\\n    MU_MEMORYTYPE_DEVICE /* device memory */\n"
+    ) in ported
+
+
 def test_aliasing_defines_still_port(tmp_path):
     """Only the degenerate mapping is skipped; a real alias must still port."""
     source_dir = tmp_path / "csrc"
@@ -162,7 +200,10 @@ def test_aliasing_defines_still_port(tmp_path):
     header = source_dir / "helpers.h"
     header.write_text(
         f"#define {TOKEN}_ALIAS {TOKEN}_IMPL\n"
+        f"#define {TOKEN}_ALIAS2 {TOKEN}_IMPL // aliased\n"
+        f"#define {TOKEN}_PAREN ({TOKEN}_IMPL)\n"
         f"#define {TOKEN}_FLAG 0x02\n"
+        f"#define {TOKEN}_FLAG2 0x02 /**< annotated */\n"
         f"void call() {{ {TOKEN}(); }}\n",
         encoding="utf-8",
     )
@@ -172,7 +213,10 @@ def test_aliasing_defines_still_port(tmp_path):
 
     assert header.read_text(encoding="utf-8") == (
         f"#define {PORTED_TOKEN}_ALIAS {PORTED_TOKEN}_IMPL\n"
+        f"#define {PORTED_TOKEN}_ALIAS2 {PORTED_TOKEN}_IMPL // aliased\n"
+        f"#define {PORTED_TOKEN}_PAREN ({PORTED_TOKEN}_IMPL)\n"
         f"#define {PORTED_TOKEN}_FLAG 0x02\n"
+        f"#define {PORTED_TOKEN}_FLAG2 0x02 /**< annotated */\n"
         f"void call() {{ {PORTED_TOKEN}(); }}\n"
     )
 

--- a/tests/test_inplace_porting.py
+++ b/tests/test_inplace_porting.py
@@ -113,6 +113,70 @@ def test_overlapping_roots_are_ported_once(tmp_path, monkeypatch):
     assert command._ported_dirs == {os.path.realpath(source_dir)}
 
 
+def test_vendor_mapping_defines_are_kept_verbatim(tmp_path):
+    """A header that already maps CUDA onto MUSA must survive porting.
+
+    Substituting the defined name too would leave `#define musaX musaX`, which
+    shadows the runtime's real value with a self-reference.
+    """
+    source_dir = tmp_path / "gpu_vendor"
+    source_dir.mkdir()
+    header = source_dir / "musa.h"
+    header.write_text(
+        "#define cudaEventDisableTiming musaEventDisableTiming\n"
+        "#define CU_MEMORYTYPE_DEVICE MU_MEMORYTYPE_DEVICE\n"
+        "#define cudaStreamWaitEvent(s) musaStreamWaitEvent(s)\n"
+        "#define CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED \\\n"
+        "    MU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED\n",
+        encoding="utf-8",
+    )
+
+    command = _build_extension_command()
+    command._port_directory(
+        str(source_dir),
+        {
+            "cudaEventDisableTiming": "musaEventDisableTiming",
+            "cudaStreamWaitEvent": "musaStreamWaitEvent",
+            "CU_MEMORYTYPE_DEVICE": "MU_MEMORYTYPE_DEVICE",
+            "CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED": (
+                "MU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED"
+            ),
+        },
+    )
+
+    ported = header.read_text(encoding="utf-8")
+    assert "#define cudaEventDisableTiming musaEventDisableTiming\n" in ported
+    assert "#define CU_MEMORYTYPE_DEVICE MU_MEMORYTYPE_DEVICE\n" in ported
+    assert "#define cudaStreamWaitEvent(s) musaStreamWaitEvent(s)\n" in ported
+    assert (
+        "#define CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED \\\n"
+        "    MU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED\n"
+    ) in ported
+    assert "#define musaEventDisableTiming musaEventDisableTiming" not in ported
+
+
+def test_aliasing_defines_still_port(tmp_path):
+    """Only the degenerate mapping is skipped; a real alias must still port."""
+    source_dir = tmp_path / "csrc"
+    source_dir.mkdir()
+    header = source_dir / "helpers.h"
+    header.write_text(
+        f"#define {TOKEN}_ALIAS {TOKEN}_IMPL\n"
+        f"#define {TOKEN}_FLAG 0x02\n"
+        f"void call() {{ {TOKEN}(); }}\n",
+        encoding="utf-8",
+    )
+
+    command = _build_extension_command()
+    command._port_directory(str(source_dir), MAPPING)
+
+    assert header.read_text(encoding="utf-8") == (
+        f"#define {PORTED_TOKEN}_ALIAS {PORTED_TOKEN}_IMPL\n"
+        f"#define {PORTED_TOKEN}_FLAG 0x02\n"
+        f"void call() {{ {PORTED_TOKEN}(); }}\n"
+    )
+
+
 def test_source_parent_is_not_filtered_as_system_include(tmp_path, monkeypatch):
     from torchada.utils.cpp_extension import BuildExtension
 

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -59,7 +59,7 @@ class TestPlatformDetection:
 
         version = torchada.get_version()
         assert version == torchada.__version__
-        assert version == "0.1.72"
+        assert version == "0.1.73"
         assert isinstance(version, str)
 
     def test_project_version_matches_runtime_version(self):


### PR DESCRIPTION
## Problem

A project-local vendor header may map the CUDA API onto MUSA itself:

```c
#define cudaEventDisableTiming musaEventDisableTiming
#define CU_MEMORYTYPE_DEVICE   MU_MEMORYTYPE_DEVICE
```

Substituting the *defined name* as well collapses the line to `#define musaEventDisableTiming musaEventDisableTiming`. That self-reference shadows the runtime's real definition (`driver_types.h`: `#define musaEventDisableTiming 0x02`), so the symbol expands to a bare undeclared identifier and every translation unit using it fails:

```
gpu_vendor/musa.h:111:32: error: 'musaEventDisableTiming' was not declared in this scope
  111 | #define musaEventDisableTiming musaEventDisableTiming
```

with the giveaway warning alongside it:

```
gpu_vendor/musa.h:132: warning: "musaHostRegisterIoMemory" redefined
driver_types.h:47: note: this is the location of the previous definition
```

Mirror-mode porting left the original header intact and only mangled the throwaway copy, so this was invisible; porting in place leaves no unmangled copy behind and the header is lost for the whole build.

## Fix

Keep a `#define` verbatim when substitution would collapse it into `#define X X`. Two details that matter:

- The check runs on the **logical** line: a mapping may put its replacement past a backslash continuation, and that form collapses identically while a per-physical-line check silently misses it.
- It keys on the **self-reference**, not on a `cuda` prefix, so `CU_*` -> `MU_*` driver mappings are covered too.

A genuine alias (`#define cudaCheck cudaCheckImpl`) still ports, since its two sides never collide.

## Verification

- `tests/test_inplace_porting.py`: 2 new cases (vendor mapping header kept verbatim, incl. the continuation and function-like forms; aliasing defines still port). Full file 12 passed.
- Full suite on MUSA: failure set identical to `main` (9 pre-existing `TestTorchAcceleratorPatching` failures needing a real device) — no regressions.
- Against the real downstream that hit this (Mooncake `-DWITH_EP=ON` on MUSA, which builds its EP/PG torch extensions through torchada): with **unmodified upstream** sources, both extensions now compile and `import mooncake.ep` succeeds. The porter leaves `gpu_vendor/musa.h` byte-identical (65 mappings intact); previously the PG extension failed to compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)