### PR TITLE
Fix nested torch CUDA header porting

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ See `src/torchada/_mappings/` for 400+ mapping rules grouped by API domain.
 
 ```
 # pyproject.toml or requirements.txt
-torchada>=0.1.75
+torchada>=0.1.76
 ```
 
 ### Step 2: Conditional Import

--- a/README_CN.md
+++ b/README_CN.md
@@ -368,7 +368,7 @@ if torchada.is_gpu_device(device):  # 在 CUDA 和 MUSA 上都能工作
 
 ```
 # pyproject.toml 或 requirements.txt
-torchada>=0.1.75
+torchada>=0.1.76
 ```
 
 ### 步骤 2：条件导入

--- a/benchmarks/benchmark_history.json
+++ b/benchmarks/benchmark_history.json
@@ -3,7 +3,7 @@
   "description": "Historical benchmark results for torchada performance tracking",
   "results": [
     {
-      "version": "0.1.75",
+      "version": "0.1.76",
       "date": "2026-01-29",
       "platform": "MUSA",
       "pytorch_version": "2.7.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torchada"
-version = "0.1.75"
+version = "0.1.76"
 description = "Adapter package for torch_musa to act exactly like PyTorch CUDA"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/torchada/__init__.py
+++ b/src/torchada/__init__.py
@@ -24,7 +24,7 @@ Usage:
     from torch.utils.cpp_extension import CUDAExtension, BuildExtension, CUDA_HOME
 """
 
-__version__ = "0.1.75"
+__version__ = "0.1.76"
 
 from . import cuda, utils
 

--- a/src/torchada/utils/cpp_extension.py
+++ b/src/torchada/utils/cpp_extension.py
@@ -306,12 +306,14 @@ def _patch_simple_porting_load_replaced_mapping(musa_sp):
 
 
 def _narrow_cuda_header_mapping(mapping_rule):
-    """Keep the cuda.h mapping from rewriting project-local header names."""
+    """Port CUDA headers without rewriting project-local header names."""
     narrowed = [(key, value) for key, value in mapping_rule if key != "cuda.h"]
     narrowed.extend(
         [
             ('#include <cuda.h>', '#include <musa.h>'),
             ('#include "cuda.h"', '#include "musa.h"'),
+            ('#include <torch/cuda.h>', '#include <torch/musa.h>'),
+            ('#include "torch/cuda.h"', '#include "torch/musa.h"'),
         ]
     )
     return sorted(narrowed, key=lambda item: len(item[0]), reverse=True)

--- a/tests/test_cpp_extension.py
+++ b/tests/test_cpp_extension.py
@@ -129,6 +129,22 @@ class TestCUDAExtension:
         assert rules['#include <cuda.h>'] == '#include <musa.h>'
         assert rules['#include "cuda.h"'] == '#include "musa.h"'
 
+    def test_porting_translates_torch_cuda_header(self):
+        from torchada.utils.cpp_extension import _narrow_cuda_header_mapping, _replace_porting_line
+
+        rules = _narrow_cuda_header_mapping([("cuda.h", "musa.h")])
+
+        assert (
+            _replace_porting_line("#include <torch/cuda.h>\n", rules) == "#include <torch/musa.h>\n"
+        )
+        assert (
+            _replace_porting_line('#include "torch/cuda.h"\n', rules) == '#include "torch/musa.h"\n'
+        )
+
+        project_include = '#include "project/decode_jpegs_cuda.h"\n'
+        assert _replace_porting_line(project_include, rules) == project_include
+
+
 class TestMusaPatches:
     """Test patches applied to torch_musa for extension building."""
 

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -59,7 +59,7 @@ class TestPlatformDetection:
 
         version = torchada.get_version()
         assert version == torchada.__version__
-        assert version == "0.1.75"
+        assert version == "0.1.76"
         assert isinstance(version, str)
 
     def test_project_version_matches_runtime_version(self):


### PR DESCRIPTION
## Summary

- keep the broad `cuda.h` replacement narrowed to exact include directives
- translate both angle-bracket and quoted `torch/cuda.h` includes to `torch/musa.h`
- add regression coverage that preserves project-local names such as `project/decode_jpegs_cuda.h`

## Motivation

vLLM `csrc/cuda_view.cu` includes `<torch/cuda.h>`. The narrowed header rules in torchada 0.1.75 correctly avoided rewriting project-local filenames, but they only restored exact mappings for top-level `<cuda.h>` and missed this nested PyTorch header.

## Validation

- `PYTHONPATH=src python -m pytest tests/test_cpp_extension.py::TestCUDAExtension tests/test_inplace_porting.py -q` (`19 passed`)
- local torch_musa 2.7.1 `BuildExtension._port_directory()` regression using the vLLM `cuda_view.cu` include pattern: `torch/cuda.h` became `torch/musa.h`, `cuda_runtime.h` became `musa_runtime.h`, and `decode_jpegs_cuda.h` remained unchanged
- `git diff --check`, isort, and Ruff passed for the changed files