### PR TITLE
vllm v0.26.0 compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ See `src/torchada/_mappings/` for 400+ mapping rules grouped by API domain.
 
 ```
 # pyproject.toml or requirements.txt
-torchada>=0.1.76
+torchada>=0.1.77
 ```
 
 ### Step 2: Conditional Import

--- a/README_CN.md
+++ b/README_CN.md
@@ -368,7 +368,7 @@ if torchada.is_gpu_device(device):  # 在 CUDA 和 MUSA 上都能工作
 
 ```
 # pyproject.toml 或 requirements.txt
-torchada>=0.1.76
+torchada>=0.1.77
 ```
 
 ### 步骤 2：条件导入

--- a/benchmarks/benchmark_history.json
+++ b/benchmarks/benchmark_history.json
@@ -3,7 +3,7 @@
   "description": "Historical benchmark results for torchada performance tracking",
   "results": [
     {
-      "version": "0.1.76",
+      "version": "0.1.77",
       "date": "2026-01-29",
       "platform": "MUSA",
       "pytorch_version": "2.7.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torchada"
-version = "0.1.76"
+version = "0.1.77"
 description = "Adapter package for torch_musa to act exactly like PyTorch CUDA"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/torchada/__init__.py
+++ b/src/torchada/__init__.py
@@ -24,7 +24,7 @@ Usage:
     from torch.utils.cpp_extension import CUDAExtension, BuildExtension, CUDA_HOME
 """
 
-__version__ = "0.1.76"
+__version__ = "0.1.77"
 
 from . import cuda, utils
 

--- a/src/torchada/_patch.py
+++ b/src/torchada/_patch.py
@@ -1640,6 +1640,9 @@ class _AcceleratorModuleWrapper(ModuleType):
         "set_device_idx": "set_device",
         "current_device_index": "current_device",
         "current_device_idx": "current_device",
+        # MUSA: torch.accelerator.get_memory_info (torch 2.10+) is absent on
+        # torch_musa 2.9; mem_get_info has the same (free, total) contract.
+        "get_memory_info": "mem_get_info",
     }
 
     # Special attribute mappings for attributes not at top level of torch_musa.

--- a/src/torchada/csrc/stable_compat/cublas_v2.h
+++ b/src/torchada/csrc/stable_compat/cublas_v2.h
@@ -3,3 +3,10 @@
 // the stable_compat include dir for libtorch-stable kernels (torch_utils.h, the
 // allspark w8a16 gemm) that include it directly.
 #include <mublas.h>
+
+// MUSA: libtorch-stable kernels use the cuBLAS handle spelling; map it to the
+// muBLAS handle (defined by <mublas.h> above, and repeated harmlessly by the
+// stable-box header) so those kernels compile against the upstream name.
+#ifndef cublasHandle_t
+#define cublasHandle_t mublasHandle_t
+#endif

--- a/src/torchada/csrc/stable_compat/cuda_runtime.h
+++ b/src/torchada/csrc/stable_compat/cuda_runtime.h
@@ -3,3 +3,32 @@
 // include it (e.g. torch_utils.h) get the MUSA runtime instead. Resolved ahead
 // of any toolchain header via the stable_compat include dir.
 #include <musa_runtime.h>
+
+// MUSA: libtorch-stable kernels use the CUDA runtime spelling for device
+// query/property APIs; map them to the MUSA runtime so those kernels compile
+// against upstream names. Guarded so an active MCC cuda-porting layer that
+// already provides a name takes precedence.
+#ifndef cudaDeviceProp
+#define cudaDeviceProp musaDeviceProp
+#endif
+#ifndef cudaError_t
+#define cudaError_t musaError_t
+#endif
+#ifndef cudaSuccess
+#define cudaSuccess musaSuccess
+#endif
+#ifndef cudaStream_t
+#define cudaStream_t musaStream_t
+#endif
+#ifndef cudaGetDeviceCount
+#define cudaGetDeviceCount musaGetDeviceCount
+#endif
+#ifndef cudaGetDeviceProperties
+#define cudaGetDeviceProperties musaGetDeviceProperties
+#endif
+#ifndef cudaGetDevice
+#define cudaGetDevice musaGetDevice
+#endif
+#ifndef cudaGetErrorString
+#define cudaGetErrorString musaGetErrorString
+#endif

--- a/src/torchada/csrc/stable_compat/torchada_stable_box.h
+++ b/src/torchada/csrc/stable_compat/torchada_stable_box.h
@@ -169,6 +169,23 @@ static inline AOTITorchError torch_get_current_cuda_blas_handle(void** ret) {
   return handle ? 0 : 1;  // fail fast on a null handle instead of crashing in muBLAS
 }
 
+// torch_musa's AOTI C-shim exposes aoti_torch_get_current_musa_stream, not the
+// upstream _cuda_ spelling that libtorch-stable kernels (torch_utils.h) call.
+// Forward so those kernels compile against the upstream name.
+#ifndef TORCHADA_HAVE_AOTI_CUDA_STREAM
+#define TORCHADA_HAVE_AOTI_CUDA_STREAM 1
+static inline AOTITorchError aoti_torch_get_current_cuda_stream(int32_t device_index,
+                                                                void** ret) {
+  return aoti_torch_get_current_musa_stream(device_index, ret);
+}
+#endif
+
+// Some libtorch-stable kernels reference TORCH_UTILS_CHECK, which torch_musa's
+// stable headers do not define; alias it to the stable check macro.
+#ifndef TORCH_UTILS_CHECK
+#define TORCH_UTILS_CHECK STD_TORCH_CHECK
+#endif
+
 namespace torchada_stable {
 
 template <class T>

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -59,7 +59,7 @@ class TestPlatformDetection:
 
         version = torchada.get_version()
         assert version == torchada.__version__
-        assert version == "0.1.76"
+        assert version == "0.1.77"
         assert isinstance(version, str)
 
     def test_project_version_matches_runtime_version(self):


### PR DESCRIPTION
  ## Summary
  vLLM v0.26.0 (via vllm-musa) touches two torch surfaces that torch_musa 2.9
  does not provide as-is:
  1. `torch.accelerator.get_memory_info()` — a torch 2.10+ API, absent on
     torch_musa 2.9 (engine-core startup hits `AttributeError`). 
  2. The kernels vLLM relocated into `csrc/libtorch_stable/` use upstream CUDA
     spellings (`cudaDeviceProp`, `cudaStream_t`, `cublasHandle_t`,
     `aoti_torch_get_current_cuda_stream`, …), but torch_musa's stable ABI only
     exposes the `musa*` names.

  These shims let both build/run unchanged on MUSA, keeping the CUDA→MUSA mapping
  in torchada instead of downstream forks.

  ## Changes
  - **`_patch.py`**: map `torch.accelerator.get_memory_info` →
    `torch.musa.mem_get_info` (same `(free, total)` contract).
  - **`csrc/stable_compat/`**: add `#ifndef`-guarded CUDA→MUSA aliases so
    libtorch-stable kernels compile against upstream names —
    - `cuda_runtime.h`: `cudaDeviceProp`, `cudaError_t`, `cudaSuccess`,
      `cudaStream_t`, `cudaGet{DeviceCount,DeviceProperties,Device,ErrorString}`
    - `cublas_v2.h`: `cublasHandle_t` → `mublasHandle_t`
    - `torchada_stable_box.h`: forward `aoti_torch_get_current_cuda_stream` →
      `aoti_torch_get_current_musa_stream`; define `TORCH_UTILS_CHECK`
    Guards make each alias a no-op where an mcc porting layer already provides
    the name.

  ## Testing
  Rebuilt vllm-musa's stable extension (`_C_stable_libtorch`) against this
  torchada on MTT S5000 (torch_musa 2.9.1). All 4 extensions import; smokes pass:
  FP8 quant (Qwen3-8B/32B-FP8), MLA (DeepSeek-V2-Lite-FP8, FLASHMLA), and
  multi-GPU stable `custom_all_reduce` (Qwen3-32B-FP8, tp2).
