### PR TITLE
compat: expose torch.cuda.streams for torch 2.11 MUSA

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ See `src/torchada/_mappings/` for 400+ mapping rules grouped by API domain.
 
 ```
 # pyproject.toml or requirements.txt
-torchada>=0.1.78
+torchada>=0.1.79
 ```
 
 ### Step 2: Conditional Import

--- a/README_CN.md
+++ b/README_CN.md
@@ -375,7 +375,7 @@ if torchada.is_gpu_device(device):  # 在 CUDA 和 MUSA 上都能工作
 
 ```
 # pyproject.toml 或 requirements.txt
-torchada>=0.1.78
+torchada>=0.1.79
 ```
 
 ### 步骤 2：条件导入

--- a/benchmarks/benchmark_history.json
+++ b/benchmarks/benchmark_history.json
@@ -3,7 +3,7 @@
   "description": "Historical benchmark results for torchada performance tracking",
   "results": [
     {
-      "version": "0.1.78",
+      "version": "0.1.79",
       "date": "2026-01-29",
       "platform": "MUSA",
       "pytorch_version": "2.7.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torchada"
-version = "0.1.78"
+version = "0.1.79"
 description = "Adapter package for torch_musa to act exactly like PyTorch CUDA"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/torchada/__init__.py
+++ b/src/torchada/__init__.py
@@ -24,7 +24,7 @@ Usage:
     from torch.utils.cpp_extension import CUDAExtension, BuildExtension, CUDA_HOME
 """
 
-__version__ = "0.1.78"
+__version__ = "0.1.79"
 
 from . import cuda, utils
 

--- a/src/torchada/_patch.py
+++ b/src/torchada/_patch.py
@@ -718,6 +718,7 @@ class _CudaModuleWrapper(ModuleType):
     # Maps attribute name -> dot-separated path within torch_musa
     _SPECIAL_ATTRS = {
         "StreamContext": "core.stream.StreamContext",
+        "streams": "core.stream",
     }
 
     # Attribute name remappings (CUDA name -> MUSA name)
@@ -835,6 +836,19 @@ def _patch_torch_cuda_module():
         # Patch torch.cuda.amp
         if hasattr(torch.musa, "amp"):
             sys.modules["torch.cuda.amp"] = torch.musa.amp
+
+        # PyTorch 2.11 Dynamo guards access torch.cuda.streams.Stream.  The
+        # torch_musa stream module lives at torch_musa.core.stream and is not
+        # exported as torch_musa.streams, so expose the CUDA-compatible module
+        # path without replacing any stream implementation.
+        try:
+            import torch_musa.core.stream as musa_streams
+
+            if not hasattr(torch.musa, "streams"):
+                torch.musa.streams = musa_streams
+            sys.modules["torch.cuda.streams"] = musa_streams
+        except ImportError:
+            pass
 
         # Patch torch.cuda.graphs - MUSAGraph should be accessible as CUDAGraph
         if hasattr(torch.musa, "graphs"):

--- a/tests/test_cuda_patching.py
+++ b/tests/test_cuda_patching.py
@@ -712,6 +712,20 @@ class TestStreamAndEvent:
 
             assert torch.cuda.StreamContext is torch_musa.core.stream.StreamContext
 
+    def test_streams_module(self):
+        """Test the torch.cuda.streams module path used by PyTorch Dynamo."""
+        import sys
+        import torch
+
+        import torchada
+
+        if torchada.is_musa_platform():
+            import torch_musa.core.stream
+
+            assert torch.cuda.streams is torch_musa.core.stream
+            assert sys.modules["torch.cuda.streams"] is torch_musa.core.stream
+            assert torch.cuda.streams.Stream is torch_musa.core.stream.Stream
+
     def test_stream_cuda_stream_property(self):
         """Test stream.cuda_stream returns same value as stream.musa_stream on MUSA."""
         import torch

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -59,7 +59,7 @@ class TestPlatformDetection:
 
         version = torchada.get_version()
         assert version == torchada.__version__
-        assert version == "0.1.78"
+        assert version == "0.1.79"
         assert isinstance(version, str)
 
     def test_project_version_matches_runtime_version(self):


### PR DESCRIPTION
## Summary

Expose the MUSA stream module through the CUDA-compatible `torch.cuda.streams` path.

PyTorch 2.11 Dynamo guards access `torch.cuda.streams.Stream`. torchada 0.1.78 redirects this path to `torch_musa`, but torch_musa 2.11 exposes the implementation at `torch_musa.core.stream` and does not export `torch_musa.streams`, causing compiled vLLM startup to fail with:

```text
AttributeError: module 'torch_musa' has no attribute 'streams'
```

The shim maps both the attribute and `sys.modules["torch.cuda.streams"]` to `torch_musa.core.stream`.

## Validation

- `torch.cuda.streams is torch_musa.core.stream`: PASS on MUSA 3.3.5 / torch 2.11.0.post1+musa5.2.0.
- Candidate vLLM compiled startup: PASS after the shim; the previous Dynamo guard failure disappeared.
- vLLM dense A/B on the same 4-GPU host: candidate performance remained positive across BS 1/4/16/64.
