### PR TITLE
Fix TorchScript CUDA device translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ See `src/torchada/_mappings/` for 400+ mapping rules grouped by API domain.
 
 ```
 # pyproject.toml or requirements.txt
-torchada>=0.1.80
+torchada>=0.1.81
 ```
 
 ### Step 2: Conditional Import

--- a/README_CN.md
+++ b/README_CN.md
@@ -375,7 +375,7 @@ if torchada.is_gpu_device(device):  # 在 CUDA 和 MUSA 上都能工作
 
 ```
 # pyproject.toml 或 requirements.txt
-torchada>=0.1.80
+torchada>=0.1.81
 ```
 
 ### 步骤 2：条件导入

--- a/benchmarks/benchmark_history.json
+++ b/benchmarks/benchmark_history.json
@@ -3,7 +3,7 @@
   "description": "Historical benchmark results for torchada performance tracking",
   "results": [
     {
-      "version": "0.1.80",
+      "version": "0.1.81",
       "date": "2026-01-29",
       "platform": "MUSA",
       "pytorch_version": "2.7.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torchada"
-version = "0.1.80"
+version = "0.1.81"
 description = "Adapter package for torch_musa to act exactly like PyTorch CUDA"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/torchada/__init__.py
+++ b/src/torchada/__init__.py
@@ -24,7 +24,7 @@ Usage:
     from torch.utils.cpp_extension import CUDAExtension, BuildExtension, CUDA_HOME
 """
 
-__version__ = "0.1.80"
+__version__ = "0.1.81"
 
 from . import cuda, utils
 

--- a/src/torchada/_patch.py
+++ b/src/torchada/_patch.py
@@ -566,6 +566,66 @@ def _wrap_factory_function(original_fn: Callable) -> Callable:
     return wrapped_fn
 
 
+def _register_jit_builtin_alias(original_fn: Callable, wrapped_fn: Callable) -> None:
+    """Keep a wrapped torch factory function scriptable as its original op."""
+    try:
+        from torch.jit._builtins import _find_builtin, _register_builtin
+
+        builtin = _find_builtin(original_fn)
+        if builtin is not None:
+            _register_builtin(wrapped_fn, builtin)
+    except (ImportError, AttributeError):
+        pass
+
+
+def _rewrite_jit_cuda_device_constants(block: Any) -> None:
+    """Translate typed CUDA device constants in a JIT graph block to MUSA."""
+    for node in block.nodes():
+        if (
+            node.kind() == "prim::Constant"
+            and node.hasAttribute("value")
+            and node.kindOf("value") == "s"
+            and str(node.output().type()) == "Device"
+        ):
+            device = node.s("value")
+            translated = _translate_device(device)
+            if translated != device:
+                node.s_("value", translated)
+
+        for nested_block in node.blocks():
+            _rewrite_jit_cuda_device_constants(nested_block)
+
+
+def _rewrite_scripted_object_device_constants(scripted: Any) -> Any:
+    """Translate CUDA device constants in a scripted function or module."""
+    graph = getattr(scripted, "graph", None)
+    if graph is not None:
+        _rewrite_jit_cuda_device_constants(graph)
+
+    modules = getattr(scripted, "modules", None)
+    if modules is not None:
+        for module in modules():
+            script_module = getattr(module, "_c", None)
+            if script_module is None:
+                continue
+            for method_name in script_module._method_names():
+                method = script_module._get_method(method_name)
+                _rewrite_jit_cuda_device_constants(method.graph)
+    return scripted
+
+
+def _wrap_jit_script(original_script: Callable) -> Callable:
+    """Rewrite CUDA device constants immediately after scripting."""
+
+    @functools.wraps(original_script)
+    def wrapped_script(*args, **kwargs):
+        return _rewrite_scripted_object_device_constants(
+            original_script(*args, **kwargs)
+        )
+
+    return wrapped_script
+
+
 # Minimal fallback used only if torch's private device-constructor registry is
 # unavailable; the live set is normally discovered at runtime (see below).
 _FALLBACK_FACTORY_FUNCTIONS = (
@@ -2038,7 +2098,9 @@ def apply_patches():
         if original_fn is None or hasattr(original_fn, "__wrapped__"):
             continue  # missing on this torch, or already wrapped
         original_fns.append(original_fn)
-        setattr(torch, fn_name, _wrap_factory_function(original_fn))
+        wrapped_fn = _wrap_factory_function(original_fn)
+        _register_jit_builtin_alias(original_fn, wrapped_fn)
+        setattr(torch, fn_name, wrapped_fn)
         wrapped_names.append(fn_name)
 
     # PyTorch's __torch_function__ dispatch (e.g. the ``with torch.device(...):``
@@ -2054,6 +2116,11 @@ def apply_patches():
         pass
 
     _mark_factory_wrappers_cacheable(wrapped_names)
+
+    if not getattr(torch.jit.script, "_torchada_device_wrapper", False):
+        wrapped_script = _wrap_jit_script(torch.jit.script)
+        wrapped_script._torchada_device_wrapper = True
+        torch.jit.script = wrapped_script
 
     _patched = True
 

--- a/tests/test_device_strings.py
+++ b/tests/test_device_strings.py
@@ -10,6 +10,25 @@ def _make_torch_device(device: str):
     return torch.device(device)
 
 
+def _script_arange_default(count: int):
+    return torch.arange(count)
+
+
+def _script_arange_cuda(count: int):
+    return torch.arange(count, device="cuda")
+
+
+def _script_cuda_string():
+    return "cuda"
+
+
+class _ScriptFactoryModule(torch.nn.Module):
+    def forward(self, count: int, indexed: bool):
+        if indexed:
+            return torch.arange(count, device="cuda:0")
+        return torch.arange(count, device="cuda")
+
+
 class TestTensorDevicePatching:
     """Test tensor device string patching."""
 
@@ -405,6 +424,81 @@ class TestDeviceIndexVariants:
 
         scripted = torch.jit.script(_make_torch_device)
         assert scripted("musa") == torch.device("musa")
+
+    def test_wrapped_factory_remains_a_torchscript_builtin(self):
+        """Test importing torchada keeps torch factories scriptable."""
+        import torchada
+        from torch.jit._builtins import _find_builtin
+
+        if not torchada.is_musa_platform():
+            pytest.skip("MUSA platform required with patched torch factories")
+
+        assert _find_builtin(torch.arange) == "aten::arange"
+        scripted = torch.jit.script(_script_arange_default)
+        assert torch.equal(scripted(4), torch.arange(4))
+
+    def test_torchscript_function_translates_cuda_device_constant(self):
+        """Test scripted factory calls translate a CUDA device constant."""
+        import torchada
+
+        if not torchada.is_musa_platform():
+            pytest.skip("MUSA platform required with patched torch factories")
+
+        scripted = torch.jit.script(_script_arange_cuda)
+        graph = str(scripted.graph)
+        assert 'Device = prim::Constant[value="musa"]' in graph
+        assert 'Device = prim::Constant[value="cuda"]' not in graph
+
+    def test_torchscript_module_translates_nested_cuda_device_constants(self):
+        """Test module methods and nested blocks translate indexed devices."""
+        import torchada
+
+        if not torchada.is_musa_platform():
+            pytest.skip("MUSA platform required with patched torch factories")
+
+        scripted = torch.jit.script(_ScriptFactoryModule())
+        graph = str(scripted.forward.graph)
+        assert 'Device = prim::Constant[value="musa"]' in graph
+        assert 'Device = prim::Constant[value="musa:0"]' in graph
+        assert 'Device = prim::Constant[value="cuda"]' not in graph
+        assert 'Device = prim::Constant[value="cuda:0"]' not in graph
+
+    def test_torchscript_keeps_plain_cuda_strings(self):
+        """Test graph rewriting does not change ordinary string constants."""
+        import torchada
+
+        if not torchada.is_musa_platform():
+            pytest.skip("MUSA platform required with patched torch factories")
+
+        scripted = torch.jit.script(_script_cuda_string)
+        assert scripted() == "cuda"
+
+    @pytest.mark.gpu
+    def test_torchscript_function_executes_on_musa(self):
+        """Test a scripted CUDA factory call executes on MUSA."""
+        import torchada
+
+        if not torchada.is_musa_platform():
+            pytest.skip("MUSA platform required with patched torch factories")
+
+        result = torch.jit.script(_script_arange_cuda)(4)
+        assert result.device.type == "musa"
+        assert torch.equal(result.cpu(), torch.arange(4))
+
+    @pytest.mark.gpu
+    def test_torchscript_module_executes_nested_device_branches_on_musa(self):
+        """Test rewritten module branches execute on the requested MUSA device."""
+        import torchada
+
+        if not torchada.is_musa_platform():
+            pytest.skip("MUSA platform required with patched torch factories")
+
+        scripted = torch.jit.script(_ScriptFactoryModule())
+        for indexed in (False, True):
+            result = scripted(4, indexed)
+            assert result.device.type == "musa"
+            assert result.device.index == 0
+            assert torch.equal(result.cpu(), torch.arange(4))
 
 
 class TestDeviceContextManager:

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -59,7 +59,7 @@ class TestPlatformDetection:
 
         version = torchada.get_version()
         assert version == torchada.__version__
-        assert version == "0.1.80"
+        assert version == "0.1.81"
         assert isinstance(version, str)
 
     def test_project_version_matches_runtime_version(self):


### PR DESCRIPTION
## Summary

- preserve the original TorchScript builtin mapping when torchada wraps torch factory functions;
- rewrite typed CUDA `Device` constants to MUSA immediately after `torch.jit.script` compiles a function or module;
- recurse through module methods and nested graph blocks while leaving ordinary strings such as `"cuda"` unchanged;
- add regression coverage for the issue reproducer, indexed devices, module branches, eager translation, and real MUSA execution.

## Motivation

Torchada wraps factory functions such as `torch.arange` so eager calls using `device="cuda"` transparently execute on MUSA. Replacing the Python function object removed its TorchScript builtin registration, causing issue #101. Simply restoring the builtin mapping is not sufficient because TorchScript then lowers the call directly to `aten::arange` and bypasses the eager Python wrapper, leaving a CUDA device constant in the graph.

This change restores the original aten builtin mapping and performs a narrow post-script graph rewrite. Only `prim::Constant` nodes whose output type is `Device` are translated, including `cuda:N`; regular string constants are preserved. The rewrite runs synchronously after `torch.jit.script` returns and does not install persistent Python callbacks in the JIT runtime.

## Tests

Focused S5000 tests using the issue case and explicit CUDA device runtime coverage:

```text
torch 2.9.1.post1+musa5.2.0:  7 passed, 32 deselected
torch 2.11.0.post1+musa5.2.0: 7 passed, 32 deselected
```

Full torchada pytest suite on one MTT S5000 with MUSA driver/runtime 5.2.0:

```text
torch 2.9.1.post1+musa5.2.0 / torch_musa 2.9.1.post1+musa5.2.0
437 passed, 19 skipped, 3 warnings in 54.84s

torch 2.11.0.post1+musa5.2.0 / torch_musa 2.11.0.post1+musa5.2.0
437 passed, 19 skipped, 5 warnings in 54.81s
```

Closes #101.
