### PR TITLE
compat: provide missing FA3 private forward

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ See `src/torchada/_mappings/` for 400+ mapping rules grouped by API domain.
 
 ```
 # pyproject.toml or requirements.txt
-torchada>=0.1.81
+torchada>=0.1.82
 ```
 
 ### Step 2: Conditional Import

--- a/README_CN.md
+++ b/README_CN.md
@@ -375,7 +375,7 @@ if torchada.is_gpu_device(device):  # 在 CUDA 和 MUSA 上都能工作
 
 ```
 # pyproject.toml 或 requirements.txt
-torchada>=0.1.81
+torchada>=0.1.82
 ```
 
 ### 步骤 2：条件导入

--- a/benchmarks/benchmark_history.json
+++ b/benchmarks/benchmark_history.json
@@ -3,7 +3,7 @@
   "description": "Historical benchmark results for torchada performance tracking",
   "results": [
     {
-      "version": "0.1.81",
+      "version": "0.1.82",
       "date": "2026-01-29",
       "platform": "MUSA",
       "pytorch_version": "2.7.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torchada"
-version = "0.1.81"
+version = "0.1.82"
 description = "Adapter package for torch_musa to act exactly like PyTorch CUDA"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/torchada/__init__.py
+++ b/src/torchada/__init__.py
@@ -24,7 +24,7 @@ Usage:
     from torch.utils.cpp_extension import CUDAExtension, BuildExtension, CUDA_HOME
 """
 
-__version__ = "0.1.81"
+__version__ = "0.1.82"
 
 from . import cuda, utils
 

--- a/src/torchada/_patch.py
+++ b/src/torchada/_patch.py
@@ -1587,6 +1587,55 @@ def _patch_flash_attn():
             continue
         setattr(flash_attn_interface, _name, _drop_only_qv(_func))
 
+    # Ring Attention imports the private forward API for its softmax LSE.
+    # Adapt the public output+LSE contract only when the provider omits it.
+    if not hasattr(flash_attn_interface, "_flash_attn_forward"):
+        _public_flash_attn = getattr(flash_attn_interface, "flash_attn_func", None)
+        try:
+            _public_parameters = inspect.signature(_public_flash_attn).parameters
+        except (TypeError, ValueError):
+            _public_parameters = {}
+
+        if callable(_public_flash_attn) and "return_softmax_lse" in _public_parameters:
+
+            def _flash_attn_forward(
+                q,
+                k,
+                v,
+                *,
+                softmax_scale=None,
+                causal=False,
+                window_size_left=-1,
+                window_size_right=-1,
+                softcap=0.0,
+            ):
+                """Adapt public FA3 output+LSE to its low-level Ring contract."""
+                result = _public_flash_attn(
+                    q,
+                    k,
+                    v,
+                    softmax_scale=softmax_scale,
+                    causal=causal,
+                    window_size=(window_size_left, window_size_right),
+                    softcap=softcap,
+                    return_softmax_lse=True,
+                )
+                if not isinstance(result, (tuple, list)) or len(result) < 2:
+                    raise RuntimeError(
+                        "flash_attn_func(return_softmax_lse=True) must return "
+                        "(output, softmax_lse)"
+                    )
+                output, softmax_lse = result[:2]
+                # Inference-only Ring consumers use output and LSE; the public
+                # API does not expose the private dropout auxiliaries.
+                return output, softmax_lse, None, None
+
+            _flash_attn_forward.__name__ = "_flash_attn_forward"
+            _flash_attn_forward.__qualname__ = "_flash_attn_forward"
+            _flash_attn_forward.__module__ = flash_attn_interface.__name__
+            _flash_attn_forward._torchada_compat_shim = True
+            flash_attn_interface._flash_attn_forward = _flash_attn_forward
+
 
 class _CDLLWrapper:
     """

--- a/tests/test_cuda_patching.py
+++ b/tests/test_cuda_patching.py
@@ -2755,6 +2755,128 @@ class TestFlashAttnPatching:
                 if mod is not None:
                     sys.modules[name] = mod
 
+    @staticmethod
+    def _install_fa3_test_provider(monkeypatch, flash_attn_func, native_forward=None):
+        import sys
+        from types import ModuleType
+
+        flash_attn = ModuleType("flash_attn_interface")
+        flash_attn.flash_attn_func = flash_attn_func
+        if native_forward is not None:
+            flash_attn._flash_attn_forward = native_forward
+        sgl_kernel = ModuleType("sgl_kernel")
+        sgl_kernel.__path__ = []
+        sgl_kernel.flash_attn = flash_attn
+        monkeypatch.setitem(sys.modules, "flash_attn_interface", flash_attn)
+        monkeypatch.setitem(sys.modules, "sgl_kernel", sgl_kernel)
+        monkeypatch.setitem(sys.modules, "sgl_kernel.flash_attn", flash_attn)
+        return flash_attn
+
+    def test_missing_fa3_private_forward_is_adapted(self, monkeypatch):
+        """Adapt the public output+LSE API to Ring's private FA3 contract."""
+        from torchada._patch import _patch_flash_attn
+
+        calls = []
+
+        def flash_attn_func(
+            q,
+            k,
+            v,
+            *,
+            softmax_scale=None,
+            causal=False,
+            window_size=(-1, -1),
+            softcap=0.0,
+            return_softmax_lse=False,
+        ):
+            calls.append(
+                {
+                    "q": q,
+                    "k": k,
+                    "v": v,
+                    "softmax_scale": softmax_scale,
+                    "causal": causal,
+                    "window_size": window_size,
+                    "softcap": softcap,
+                    "return_softmax_lse": return_softmax_lse,
+                }
+            )
+            return "output", "softmax_lse"
+
+        flash_attn = self._install_fa3_test_provider(monkeypatch, flash_attn_func)
+
+        _patch_flash_attn()
+        from flash_attn_interface import _flash_attn_forward
+
+        assert _flash_attn_forward is flash_attn._flash_attn_forward
+        result = flash_attn._flash_attn_forward(
+            "q",
+            "k",
+            "v",
+            softmax_scale=0.125,
+            causal=True,
+            window_size_left=32,
+            window_size_right=16,
+            softcap=4.0,
+        )
+
+        assert result == ("output", "softmax_lse", None, None)
+        assert calls == [
+            {
+                "q": "q",
+                "k": "k",
+                "v": "v",
+                "softmax_scale": 0.125,
+                "causal": True,
+                "window_size": (32, 16),
+                "softcap": 4.0,
+                "return_softmax_lse": True,
+            }
+        ]
+        assert flash_attn._flash_attn_forward.__name__ == "_flash_attn_forward"
+        assert flash_attn._flash_attn_forward._torchada_compat_shim is True
+        first = flash_attn._flash_attn_forward
+        _patch_flash_attn()
+        assert flash_attn._flash_attn_forward is first
+
+        def native_forward(q, k, v, **kwargs):
+            return q, k, v, kwargs
+
+        native_provider = self._install_fa3_test_provider(
+            monkeypatch, flash_attn_func, native_forward
+        )
+        _patch_flash_attn()
+        assert native_provider._flash_attn_forward is native_forward
+
+    def test_fa3_private_forward_fails_closed_without_lse(self, monkeypatch):
+        """Require both a public LSE parameter and a valid LSE result."""
+        from torchada._patch import _patch_flash_attn
+
+        def no_lse_support(q, k, v):
+            return q
+
+        flash_attn = self._install_fa3_test_provider(monkeypatch, no_lse_support)
+        _patch_flash_attn()
+        assert not hasattr(flash_attn, "_flash_attn_forward")
+
+        def invalid_lse_result(
+            q,
+            k,
+            v,
+            *,
+            softmax_scale=None,
+            causal=False,
+            window_size=(-1, -1),
+            softcap=0.0,
+            return_softmax_lse=False,
+        ):
+            return q
+
+        flash_attn = self._install_fa3_test_provider(monkeypatch, invalid_lse_result)
+        _patch_flash_attn()
+        with pytest.raises(RuntimeError, match="must return"):
+            flash_attn._flash_attn_forward("q", "k", "v")
+
 
 class TestAcceleratorModuleWrapper:
     """Test the _AcceleratorModuleWrapper priority / fallback logic in isolation.

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -59,7 +59,7 @@ class TestPlatformDetection:
 
         version = torchada.get_version()
         assert version == torchada.__version__
-        assert version == "0.1.81"
+        assert version == "0.1.82"
         assert isinstance(version, str)
 
     def test_project_version_matches_runtime_version(self):


### PR DESCRIPTION
## Summary

- add `flash_attn_interface._flash_attn_forward` only when the provider omits it
- adapt the public `flash_attn_func(..., return_softmax_lse=True)` result to the
  low-level `(output, softmax_lse, S_dmask, rng_state)` inference contract
- preserve a provider's native private implementation unchanged and keep the
  patch idempotent

## Motivation

vLLM-Omni Ring Attention imports `_flash_attn_forward` because it needs the
softmax LSE for partial-attention accumulation. The current MATE compatibility
module exposes the equivalent public output+LSE API but not that private
symbol, so the downstream FA3 availability probe evaluates false.

The adapter is deliberately conditional and version-independent. Once MATE or
another provider exposes `_flash_attn_forward`, torchada leaves the native
object untouched.

## Safety boundaries

- require the public callable to explicitly support `return_softmax_lse`
- translate only the keyword subset used by the Ring FA3 inference path
- fail closed if the public provider does not return at least output and LSE
- return `None` for dropout-only auxiliary values unavailable from the public
  inference API

## Validation

- `ruff check src/torchada/_patch.py tests/test_cuda_patching.py`
- focused compatibility tests: `2 passed, 212 deselected`
- full non-hardware test slice: `410 passed, 17 skipped, 41 deselected`
- wheel build: `torchada-0.1.81-py3-none-any.whl`
- S5000 downstream smoke in
  `vllm-omni:minimax-h3-20260815@sha256:23ae27867cd19ce848a27688dba262d0569c67ff3c3b599cc2a429f8ab184a8b`:
  - installed this exact commit editable over the image's torchada `0.1.79`
  - vLLM-MUSA platform-plugin import captured the shim before vLLM-Omni Ring
    globals; `HAS_FA3=True`
  - vLLM-Omni's unchanged FA3 selector resolved to
    `ring_kernels.fa3_forward`
  - BF16 `[1,1024,14,128]` output and LSE were finite; shim vs the public MATE
    output+LSE API had max absolute difference `0.0`
  - real two-rank MCCL Ring Attention completed on both ranks with
    `attn_type=fa3`, `ring_kernel=fa3_forward`, and finite
    `[1,512,14,128]` output
