### PR TITLE
Reuse CUDA Inductor template heuristics for MUSA

### DIFF
--- a/src/torchada/_patch.py
+++ b/src/torchada/_patch.py
@@ -108,6 +108,39 @@ def requires_import(*module_names: str) -> Callable[[Callable], Callable]:
     return decorator
 
 
+@patch_function
+@requires_import("torch._inductor.template_heuristics.registry")
+def _patch_inductor_template_heuristics():
+    """Reuse CUDA Inductor template heuristics for CUDA-compatible MUSA templates."""
+    if not is_musa_platform():
+        return
+
+    import torch._inductor.template_heuristics.registry as registry
+
+    heuristic_registry = getattr(registry, "_TEMPLATE_HEURISTIC_REGISTRY", None)
+    if not isinstance(heuristic_registry, dict):
+        return
+
+    changed = False
+    for key, heuristic_class in list(heuristic_registry.items()):
+        if len(key) != 3:
+            continue
+        template_name, device_type, op_name = key
+        if device_type != "cuda":
+            continue
+        if not isinstance(template_name, str) or not template_name.startswith("triton::"):
+            continue
+        musa_key = (template_name, "musa", op_name)
+        if musa_key not in heuristic_registry:
+            heuristic_registry[musa_key] = heuristic_class
+            changed = True
+
+    if changed:
+        heuristic_cache = getattr(registry, "_HEURISTIC_CACHE", None)
+        if isinstance(heuristic_cache, dict):
+            heuristic_cache.clear()
+
+
 # Cache for translated device strings - avoids repeated string operations
 _device_str_cache = {}
 


### PR DESCRIPTION
## Summary

Reuse PyTorch Inductor CUDA template heuristics for CUDA-compatible MUSA Triton templates.

On MUSA, Inductor can request template heuristics with keys such as:

```text
template_name=triton::mm, device_type=musa, op_name=mm
```

PyTorch already registers the corresponding CUDA template heuristics, but not MUSA-specific entries. This patch mirrors existing `triton::*` CUDA heuristic registrations to `device_type="musa"` during torchada patching, so Inductor can reuse the same heuristic class instead of falling back to the generic `TemplateConfigHeuristics` path.

## Scope

This is intentionally narrow:

- no change to `torch.cuda.is_available()` semantics
- no change to `torch.cuda.get_device_capability()` semantics
- no flash-attention import shims
- no `torch.load` map-location translation
- no aten op overrides

## Testing

```bash
pre-commit run --files src/torchada/_patch.py
```

Result: passed.

```bash
python3 -m py_compile src/torchada/_patch.py
```

Result: passed.

## Runtime context

This matches the minimal torchada delta used in the SGLang-Omni MUSA container for the Inductor warning path:

```text
No template heuristic found - template_name=triton::mm, device_type=musa, op_name=mm
```