### PR TITLE
Add graph-safe ops and Inductor heuristics

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ See `src/torchada/_mappings/` for 400+ mapping rules grouped by API domain.
 
 ```
 # pyproject.toml or requirements.txt
-torchada>=0.1.83
+torchada>=0.1.84
 ```
 
 ### Step 2: Conditional Import

--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ See `src/torchada/_mappings/` for 400+ mapping rules grouped by API domain.
 
 ```
 # pyproject.toml or requirements.txt
-torchada>=0.1.84
+torchada>=0.1.85
 ```
 
 ### Step 2: Conditional Import

--- a/README_CN.md
+++ b/README_CN.md
@@ -376,7 +376,7 @@ if torchada.is_gpu_device(device):  # 在 CUDA 和 MUSA 上都能工作
 
 ```
 # pyproject.toml 或 requirements.txt
-torchada>=0.1.83
+torchada>=0.1.84
 ```
 
 ### 步骤 2：条件导入

--- a/README_CN.md
+++ b/README_CN.md
@@ -376,7 +376,7 @@ if torchada.is_gpu_device(device):  # 在 CUDA 和 MUSA 上都能工作
 
 ```
 # pyproject.toml 或 requirements.txt
-torchada>=0.1.84
+torchada>=0.1.85
 ```
 
 ### 步骤 2：条件导入

--- a/benchmarks/benchmark_history.json
+++ b/benchmarks/benchmark_history.json
@@ -3,7 +3,7 @@
   "description": "Historical benchmark results for torchada performance tracking",
   "results": [
     {
-      "version": "0.1.83",
+      "version": "0.1.85",
       "date": "2026-01-29",
       "platform": "MUSA",
       "pytorch_version": "2.7.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torchada"
-version = "0.1.83"
+version = "0.1.84"
 description = "Adapter package for torch_musa to act exactly like PyTorch CUDA"
 readme = "README.md"
 license = {text = "MIT"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torchada"
-version = "0.1.84"
+version = "0.1.85"
 description = "Adapter package for torch_musa to act exactly like PyTorch CUDA"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/torchada/__init__.py
+++ b/src/torchada/__init__.py
@@ -24,7 +24,7 @@ Usage:
     from torch.utils.cpp_extension import CUDAExtension, BuildExtension, CUDA_HOME
 """
 
-__version__ = "0.1.83"
+__version__ = "0.1.84"
 
 from . import cuda, utils
 

--- a/src/torchada/__init__.py
+++ b/src/torchada/__init__.py
@@ -24,7 +24,7 @@ Usage:
     from torch.utils.cpp_extension import CUDAExtension, BuildExtension, CUDA_HOME
 """
 
-__version__ = "0.1.84"
+__version__ = "0.1.85"
 
 from . import cuda, utils
 

--- a/src/torchada/_cpp_ops.py
+++ b/src/torchada/_cpp_ops.py
@@ -93,16 +93,14 @@ def load_cpp_ops(force_reload: bool = False) -> Optional[object]:
     if not is_musa_platform():
         return None
 
-    # torch_musa 2.11.0.post2 contains the native graph-safe implementations.
-    # Do not build or load TorchAda's override extension on fixed releases;
-    # torch_musa/ATen must own dispatch directly.
     import torch
 
-    from ._patch import _musa_accelerator_overrides_required
+    from ._patch import _is_pre_torch_musa_2_11_0_post2
 
     musa_module = getattr(torch, "musa", None)
-    if not _musa_accelerator_overrides_required(getattr(musa_module, "__version__", None)):
-        return None
+    if not _is_pre_torch_musa_2_11_0_post2(getattr(musa_module, "__version__", None)):
+        for op_name in ("multinomial", "log", "log_"):
+            os.environ[f"TORCHADA_DISABLE_OP_OVERRIDE_{op_name}"] = "1"
 
     try:
         import os.path as osp

--- a/src/torchada/_cpp_ops.py
+++ b/src/torchada/_cpp_ops.py
@@ -93,6 +93,17 @@ def load_cpp_ops(force_reload: bool = False) -> Optional[object]:
     if not is_musa_platform():
         return None
 
+    # torch_musa 2.11.0.post2 contains the native graph-safe implementations.
+    # Do not build or load TorchAda's override extension on fixed releases;
+    # torch_musa/ATen must own dispatch directly.
+    import torch
+
+    from ._patch import _musa_accelerator_overrides_required
+
+    musa_module = getattr(torch, "musa", None)
+    if not _musa_accelerator_overrides_required(getattr(musa_module, "__version__", None)):
+        return None
+
     try:
         import os.path as osp
 

--- a/src/torchada/_patch.py
+++ b/src/torchada/_patch.py
@@ -124,7 +124,7 @@ def _patch_inductor_template_heuristics():
         return
 
     musa_module = getattr(torch, "musa", None)
-    if not _musa_accelerator_overrides_required(getattr(musa_module, "__version__", None)):
+    if not _is_pre_torch_musa_2_11_0_post2(getattr(musa_module, "__version__", None)):
         return
 
     from torch._inductor.codegen.common import init_backend_registration
@@ -1773,11 +1773,11 @@ class _CDLLWrapper:
 _original_ctypes_CDLL = None
 
 
-_TORCH_MUSA_ACCELERATOR_FIX_VERSION = "2.11.0.post2"
+_TORCH_MUSA_POST2_VERSION = "2.11.0.post2"
 
 
-def _musa_accelerator_overrides_required(version) -> bool:
-    """Return whether torch.accelerator still needs MUSA memory overrides.
+def _is_pre_torch_musa_2_11_0_post2(version) -> bool:
+    """Return whether the torch_musa version predates 2.11.0.post2.
 
     torch_musa 2.11.0.post2 fixes the unified accelerator memory APIs. Older
     releases still need torchada to force those calls through torch.musa.
@@ -1799,17 +1799,17 @@ def _musa_accelerator_overrides_required(version) -> bool:
         # If the parser is unavailable, keep the workaround enabled: disabling
         # it could re-expose the failure this gate fixes.
         logger.warning(
-            "Unable to parse torch_musa version %r; retaining accelerator memory overrides",
+            "Unable to parse torch_musa version %r; retaining compatibility patches",
             version,
         )
         return True
     try:
-        return Version(public_version) < Version(_TORCH_MUSA_ACCELERATOR_FIX_VERSION)
+        return Version(public_version) < Version(_TORCH_MUSA_POST2_VERSION)
     except InvalidVersion:
         # An unknown or malformed version must keep the workaround enabled:
         # disabling it could re-expose the failure this gate fixes.
         logger.warning(
-            "Unable to parse torch_musa version %r; retaining accelerator memory overrides",
+            "Unable to parse torch_musa version %r; retaining compatibility patches",
             version,
         )
         return True
@@ -1895,7 +1895,7 @@ class _AcceleratorModuleWrapper(ModuleType):
         # torch._C._accelerator_* without dispatching to the MUSA allocator.
         # Newer versions provide working unified accelerator implementations,
         # so preserve those instead of forcing the torch.musa compatibility path.
-        if _musa_accelerator_overrides_required(getattr(musa_module, "__version__", None)):
+        if _is_pre_torch_musa_2_11_0_post2(getattr(musa_module, "__version__", None)):
             for name in self._MUSA_OVERRIDES:
                 musa_name = self._REMAP_ATTRS.get(name, name)
                 if hasattr(original_accel, name) and hasattr(musa_module, musa_name):

--- a/src/torchada/_patch.py
+++ b/src/torchada/_patch.py
@@ -65,6 +65,17 @@ def patch_function(func: Callable[[], None]) -> Callable[[], None]:
     return func
 
 
+@patch_function
+def _patch_visible_devices_env():
+    if "CUDA_VISIBLE_DEVICES" not in os.environ and "MUSA_VISIBLE_DEVICES" in os.environ:
+        os.environ["CUDA_VISIBLE_DEVICES"] = os.environ["MUSA_VISIBLE_DEVICES"]
+    elif (
+        "MUSA_VISIBLE_DEVICES" not in os.environ
+        and "CUDA_VISIBLE_DEVICES" in os.environ
+    ):
+        os.environ["MUSA_VISIBLE_DEVICES"] = os.environ["CUDA_VISIBLE_DEVICES"]
+
+
 def requires_import(*module_names: str) -> Callable[[Callable], Callable]:
     """
     Decorator to guard a patch function with import checks.
@@ -106,6 +117,39 @@ def requires_import(*module_names: str) -> Callable[[Callable], Callable]:
         return wrapper
 
     return decorator
+
+
+@patch_function
+@requires_import("torch._inductor.template_heuristics.registry")
+def _patch_inductor_template_heuristics():
+    """Reuse CUDA Inductor template heuristics for CUDA-compatible MUSA templates."""
+    if not is_musa_platform():
+        return
+
+    import torch._inductor.template_heuristics.registry as registry
+
+    heuristic_registry = getattr(registry, "_TEMPLATE_HEURISTIC_REGISTRY", None)
+    if not isinstance(heuristic_registry, dict):
+        return
+
+    changed = False
+    for key, heuristic_class in list(heuristic_registry.items()):
+        if len(key) != 3:
+            continue
+        template_name, device_type, op_name = key
+        if device_type != "cuda":
+            continue
+        if not isinstance(template_name, str) or not template_name.startswith("triton::"):
+            continue
+        musa_key = (template_name, "musa", op_name)
+        if musa_key not in heuristic_registry:
+            heuristic_registry[musa_key] = heuristic_class
+            changed = True
+
+    if changed:
+        heuristic_cache = getattr(registry, "_HEURISTIC_CACHE", None)
+        if isinstance(heuristic_cache, dict):
+            heuristic_cache.clear()
 
 
 # Cache for translated device strings - avoids repeated string operations
@@ -2122,6 +2166,7 @@ def apply_patches():
     - torch.cuda.nccl -> torch.musa.mccl
     - torch.amp.autocast(device_type='cuda') -> 'musa'
     - torch.utils.cpp_extension (CUDAExtension, BuildExtension) -> MUSA versions
+    - CUDA_VISIBLE_DEVICES -> MUSA_VISIBLE_DEVICES environment fallback
     - torch._inductor.autotune_process.CUDA_VISIBLE_DEVICES -> MUSA_VISIBLE_DEVICES
     - torch.accelerator.synchronize() -> torch.musa.synchronize()
     - torch.accelerator context managers (device_index, stream) for forward compatibility

--- a/src/torchada/_patch.py
+++ b/src/torchada/_patch.py
@@ -69,8 +69,8 @@ def patch_function(func: Callable[[], None]) -> Callable[[], None]:
 def _patch_visible_devices_env():
     if "MUSA_VISIBLE_DEVICES" in os.environ:
         os.environ["CUDA_VISIBLE_DEVICES"] = os.environ["MUSA_VISIBLE_DEVICES"]
-    elif "CUDA_VISIBLE_DEVICES" in os.environ:
-        os.environ["MUSA_VISIBLE_DEVICES"] = os.environ["CUDA_VISIBLE_DEVICES"]
+    else:
+        os.environ.pop("CUDA_VISIBLE_DEVICES", None)
 
 
 def requires_import(*module_names: str) -> Callable[[Callable], Callable]:

--- a/src/torchada/_patch.py
+++ b/src/torchada/_patch.py
@@ -67,12 +67,9 @@ def patch_function(func: Callable[[], None]) -> Callable[[], None]:
 
 @patch_function
 def _patch_visible_devices_env():
-    if "CUDA_VISIBLE_DEVICES" not in os.environ and "MUSA_VISIBLE_DEVICES" in os.environ:
+    if "MUSA_VISIBLE_DEVICES" in os.environ:
         os.environ["CUDA_VISIBLE_DEVICES"] = os.environ["MUSA_VISIBLE_DEVICES"]
-    elif (
-        "MUSA_VISIBLE_DEVICES" not in os.environ
-        and "CUDA_VISIBLE_DEVICES" in os.environ
-    ):
+    elif "CUDA_VISIBLE_DEVICES" in os.environ:
         os.environ["MUSA_VISIBLE_DEVICES"] = os.environ["CUDA_VISIBLE_DEVICES"]
 
 
@@ -134,7 +131,7 @@ def _patch_inductor_template_heuristics():
 
     changed = False
     for key, heuristic_class in list(heuristic_registry.items()):
-        if len(key) != 3:
+        if not isinstance(key, tuple) or len(key) != 3:
             continue
         template_name, device_type, op_name = key
         if device_type != "cuda":

--- a/src/torchada/_patch.py
+++ b/src/torchada/_patch.py
@@ -123,6 +123,10 @@ def _patch_inductor_template_heuristics():
     if not is_musa_platform():
         return
 
+    musa_module = getattr(torch, "musa", None)
+    if not _musa_accelerator_overrides_required(getattr(musa_module, "__version__", None)):
+        return
+
     import torch._inductor.template_heuristics.registry as registry
 
     heuristic_registry = getattr(registry, "_TEMPLATE_HEURISTIC_REGISTRY", None)
@@ -1768,7 +1772,7 @@ _TORCH_MUSA_ACCELERATOR_FIX_VERSION = "2.11.0.post2"
 def _musa_accelerator_overrides_required(version) -> bool:
     """Return whether torch.accelerator still needs MUSA memory overrides.
 
-    torch_musa 2.11.0.post2 fixes the unified accelerator memory APIs.  Older
+    torch_musa 2.11.0.post2 fixes the unified accelerator memory APIs. Older
     releases still need torchada to force those calls through torch.musa.
     Ignore the local version suffix (for example ``+musa5.2.0``), because it
     identifies the MUSA stack build rather than the torch_musa fix level.
@@ -1786,7 +1790,7 @@ def _musa_accelerator_overrides_required(version) -> bool:
         from torch._vendor.packaging.version import InvalidVersion, Version
     except ImportError:
         # If the parser is unavailable, keep the workaround enabled: disabling
-        # it could re-expose the allocator failure this gate fixes.
+        # it could re-expose the failure this gate fixes.
         logger.warning(
             "Unable to parse torch_musa version %r; retaining accelerator memory overrides",
             version,
@@ -1796,7 +1800,7 @@ def _musa_accelerator_overrides_required(version) -> bool:
         return Version(public_version) < Version(_TORCH_MUSA_ACCELERATOR_FIX_VERSION)
     except InvalidVersion:
         # An unknown or malformed version must keep the workaround enabled:
-        # disabling it could re-expose the allocator failure this gate fixes.
+        # disabling it could re-expose the failure this gate fixes.
         logger.warning(
             "Unable to parse torch_musa version %r; retaining accelerator memory overrides",
             version,

--- a/src/torchada/_patch.py
+++ b/src/torchada/_patch.py
@@ -127,6 +127,13 @@ def _patch_inductor_template_heuristics():
     if not _musa_accelerator_overrides_required(getattr(musa_module, "__version__", None)):
         return
 
+    from torch._inductor.codegen.common import init_backend_registration
+
+    # torch_musa registers its native MUSA heuristics lazily from this entry
+    # point. Run it before inspecting the registry so TorchAda only fills keys
+    # that remain absent after native backend registration.
+    init_backend_registration()
+
     import torch._inductor.template_heuristics.registry as registry
 
     heuristic_registry = getattr(registry, "_TEMPLATE_HEURISTIC_REGISTRY", None)

--- a/src/torchada/csrc/musa_ops.mu
+++ b/src/torchada/csrc/musa_ops.mu
@@ -348,14 +348,9 @@ at::Tensor& log_inplace_musa_impl(at::Tensor& self) {
 // time. If set, the override is not registered and torch_musa's default
 // implementation is used.
 //
-// Uncomment m.impl() lines to activate custom implementations.
 // ============================================================================
 
 TORCH_LIBRARY_IMPL(aten, PrivateUse1, m) {
-    // Example: Register neg override only if not disabled
-    // if (torchada::is_override_enabled("neg")) {
-    //     m.impl("neg", torchada::neg_musa_impl);
-    // }
     if (torchada::is_override_enabled("multinomial")) {
         m.impl("multinomial", torchada::multinomial_musa_impl);
     }

--- a/src/torchada/csrc/musa_ops.mu
+++ b/src/torchada/csrc/musa_ops.mu
@@ -9,6 +9,11 @@
 
 #include "ops.h"
 #include <ATen/musa/MUSAContext.h>
+#include <ATen/ops/empty.h>
+#include <ATen/ops/empty_like.h>
+#include <c10/core/ScalarType.h>
+#include <c10/util/Optional.h>
+#include <limits>
 
 namespace torchada {
 
@@ -67,6 +72,273 @@ at::Tensor neg_musa_impl(const at::Tensor& self) {
     return output;
 }
 
+namespace {
+
+__device__ unsigned long long multinomial_counter = 0;
+
+__device__ __forceinline__ unsigned long long splitmix64(unsigned long long x) {
+    x += 0x9E3779B97F4A7C15ull;
+    x = (x ^ (x >> 30)) * 0xBF58476D1CE4E5B9ull;
+    x = (x ^ (x >> 27)) * 0x94D049BB133111EBull;
+    return x ^ (x >> 31);
+}
+
+__device__ __forceinline__ double uniform01(
+    unsigned long long seed,
+    int64_t row,
+    int64_t sample) {
+    unsigned long long x = splitmix64(
+        seed ^ (static_cast<unsigned long long>(row) * 0xD1B54A32D192ED03ull) ^
+        (static_cast<unsigned long long>(sample) * 0x94D049BB133111EBull));
+    constexpr double scale = 1.0 / 9007199254740992.0;
+    return static_cast<double>(x >> 11) * scale;
+}
+
+template <typename scalar_t>
+__device__ __forceinline__ double read_weight(
+    const scalar_t* input,
+    int64_t idx) {
+    double v = static_cast<double>(input[idx]);
+    return isfinite(v) && v > 0.0 ? v : 0.0;
+}
+
+__device__ __forceinline__ bool already_selected(
+    const int64_t* output,
+    int64_t row,
+    int64_t num_samples,
+    int64_t current_sample,
+    int64_t candidate) {
+    const int64_t base = row * num_samples;
+    for (int64_t i = 0; i < current_sample; ++i) {
+        if (output[base + i] == candidate) {
+            return true;
+        }
+    }
+    return false;
+}
+
+template <typename scalar_t, int BLOCK>
+__global__ void multinomial_kernel(
+    const scalar_t* __restrict__ input,
+    int64_t* __restrict__ output,
+    int64_t rows,
+    int64_t cols,
+    int64_t num_samples,
+    bool replacement,
+    unsigned long long seed_base) {
+    __shared__ double partial[BLOCK];
+    __shared__ double prefix[BLOCK];
+    __shared__ double total_sum;
+    __shared__ unsigned long long block_seed;
+
+    int64_t row = static_cast<int64_t>(blockIdx.x);
+    int tid = threadIdx.x;
+    if (row >= rows) {
+        return;
+    }
+
+    const int64_t row_offset = row * cols;
+    const int64_t chunk = (cols + BLOCK - 1) / BLOCK;
+    const int64_t begin = static_cast<int64_t>(tid) * chunk;
+    const int64_t end = min(begin + chunk, cols);
+
+    if (tid == 0) {
+        unsigned long long counter = atomicAdd(&multinomial_counter, 1ull);
+        block_seed = splitmix64(
+            seed_base ^ counter ^ static_cast<unsigned long long>(clock64()));
+    }
+    __syncthreads();
+    unsigned long long seed = block_seed;
+
+    for (int64_t sample = 0; sample < num_samples; ++sample) {
+        double sum = 0.0;
+        for (int64_t col = begin; col < end; ++col) {
+            if (replacement || !already_selected(output, row, num_samples, sample, col)) {
+                sum += read_weight(input, row_offset + col);
+            }
+        }
+        partial[tid] = sum;
+        __syncthreads();
+
+        if (tid == 0) {
+            double running = 0.0;
+            for (int i = 0; i < BLOCK; ++i) {
+                prefix[i] = running;
+                running += partial[i];
+            }
+            total_sum = running;
+        }
+        __syncthreads();
+
+        double total = total_sum;
+        int64_t selected = 0;
+        if (total > 0.0) {
+            double target = uniform01(seed, row, sample) * total;
+            double before = prefix[tid];
+            double after = before + partial[tid];
+            if (target >= before && target < after) {
+                double running = before;
+                for (int64_t col = begin; col < end; ++col) {
+                    if (!replacement && already_selected(output, row, num_samples, sample, col)) {
+                        continue;
+                    }
+                    running += read_weight(input, row_offset + col);
+                    if (target < running) {
+                        selected = col;
+                        break;
+                    }
+                }
+            } else {
+                selected = -1;
+            }
+        } else {
+            selected = tid == 0 ? 0 : -1;
+        }
+        partial[tid] = static_cast<double>(selected);
+        __syncthreads();
+
+        if (tid == 0) {
+            int64_t chosen = 0;
+            for (int i = 0; i < BLOCK; ++i) {
+                int64_t candidate = static_cast<int64_t>(partial[i]);
+                if (candidate >= 0) {
+                    chosen = candidate;
+                    break;
+                }
+            }
+            output[row * num_samples + sample] = chosen;
+        }
+        __syncthreads();
+    }
+}
+
+}  // namespace
+
+at::Tensor multinomial_musa_impl(
+    const at::Tensor& self,
+    int64_t num_samples,
+    bool replacement,
+    c10::optional<at::Generator> generator) {
+    log_op_call("multinomial");
+
+    TORCH_CHECK(self.dim() == 1 || self.dim() == 2, "prob_dist must be 1 or 2 dim");
+    TORCH_CHECK(num_samples >= 0, "cannot sample n_sample < 0 samples");
+
+    int64_t rows = self.dim() == 1 ? 1 : self.size(0);
+    int64_t cols = self.dim() == 1 ? self.size(0) : self.size(1);
+    if (!replacement) {
+        TORCH_CHECK(
+            num_samples <= cols,
+            "cannot sample n_sample > prob_dist.size(-1) samples without replacement");
+    }
+
+    auto options = self.options().dtype(at::kLong);
+    at::Tensor output = self.dim() == 1
+        ? at::empty({num_samples}, options)
+        : at::empty({rows, num_samples}, options);
+
+    if (num_samples == 0 || rows == 0) {
+        return output;
+    }
+
+    auto input = self.contiguous();
+    constexpr int BLOCK = 256;
+    musaStream_t stream = at::musa::getCurrentMUSAStream();
+    unsigned long long seed_base = generator.has_value()
+        ? static_cast<unsigned long long>(generator->current_seed())
+        : static_cast<unsigned long long>(clock());
+
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+        at::ScalarType::Half,
+        at::ScalarType::BFloat16,
+        input.scalar_type(),
+        "torchada_multinomial_musa",
+        [&] {
+            multinomial_kernel<scalar_t, BLOCK><<<rows, BLOCK, 0, stream>>>(
+                input.data_ptr<scalar_t>(),
+                output.data_ptr<int64_t>(),
+                rows,
+                cols,
+                num_samples,
+                replacement,
+                seed_base);
+        });
+
+    musaError_t err = musaGetLastError();
+    if (err != musaSuccess) {
+        TORCH_CHECK(false, "MUSA multinomial kernel launch failed: ", musaGetErrorString(err));
+    }
+
+    return output;
+}
+
+template <typename scalar_t>
+__global__ void log_kernel(
+    scalar_t* __restrict__ output,
+    const scalar_t* __restrict__ input,
+    int64_t numel) {
+    int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < numel) {
+        double value = static_cast<double>(input[idx]);
+        output[idx] = static_cast<scalar_t>(log(value));
+    }
+}
+
+at::Tensor log_musa_impl(const at::Tensor& self) {
+    log_op_call("log");
+    TORCH_CHECK(
+        at::isFloatingType(self.scalar_type()),
+        "torchada MUSA log only supports floating point tensors");
+
+    auto input = self.contiguous();
+    auto output = at::empty_like(input);
+    if (input.numel() == 0) {
+        return output;
+    }
+
+    constexpr int threads = 256;
+    const int64_t numel = input.numel();
+    const int blocks = static_cast<int>((numel + threads - 1) / threads);
+    musaStream_t stream = at::musa::getCurrentMUSAStream();
+
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+        at::ScalarType::Half,
+        at::ScalarType::BFloat16,
+        input.scalar_type(),
+        "torchada_log_musa",
+        [&] {
+            log_kernel<scalar_t><<<blocks, threads, 0, stream>>>(
+                output.data_ptr<scalar_t>(),
+                input.data_ptr<scalar_t>(),
+                numel);
+        });
+
+    musaError_t err = musaGetLastError();
+    if (err != musaSuccess) {
+        TORCH_CHECK(false, "MUSA log kernel launch failed: ", musaGetErrorString(err));
+    }
+
+    if (!self.is_contiguous()) {
+        return output.view(self.sizes());
+    }
+    return output;
+}
+
+at::Tensor& log_inplace_musa_impl(at::Tensor& self) {
+    log_op_call("log_");
+    TORCH_CHECK(
+        at::isFloatingType(self.scalar_type()),
+        "torchada MUSA log_ only supports floating point tensors");
+
+    if (self.numel() == 0) {
+        return self;
+    }
+
+    auto output = log_musa_impl(self);
+    self.copy_(output);
+    return self;
+}
+
 }  // namespace torchada
 
 // ============================================================================
@@ -84,4 +356,11 @@ TORCH_LIBRARY_IMPL(aten, PrivateUse1, m) {
     // if (torchada::is_override_enabled("neg")) {
     //     m.impl("neg", torchada::neg_musa_impl);
     // }
+    if (torchada::is_override_enabled("multinomial")) {
+        m.impl("multinomial", torchada::multinomial_musa_impl);
+    }
+    if (torchada::is_override_enabled("log")) {
+        m.impl("log", torchada::log_musa_impl);
+        m.impl("log_", torchada::log_inplace_musa_impl);
+    }
 }

--- a/src/torchada/csrc/musa_ops.mu
+++ b/src/torchada/csrc/musa_ops.mu
@@ -356,6 +356,8 @@ TORCH_LIBRARY_IMPL(aten, PrivateUse1, m) {
     }
     if (torchada::is_override_enabled("log")) {
         m.impl("log", torchada::log_musa_impl);
+    }
+    if (torchada::is_override_enabled("log_")) {
         m.impl("log_", torchada::log_inplace_musa_impl);
     }
 }

--- a/tests/test_cuda_patching.py
+++ b/tests/test_cuda_patching.py
@@ -1156,6 +1156,7 @@ class TestInductorTemplateHeuristics:
         assert ("cached",) in heuristic_cache
 
     def test_copies_only_cuda_triton_heuristics_and_clears_cache(self, monkeypatch):
+        from torch._inductor.codegen import common
         from torch._inductor.template_heuristics import registry
 
         from torchada import _patch
@@ -1172,13 +1173,20 @@ class TestInductorTemplateHeuristics:
             1: object(),
         }
         heuristic_cache = {("cached",): object()}
+        lazy_cuda_heuristic = object()
+
+        def register_lazy_heuristic():
+            heuristic_registry[("triton::lazy_mm", "cuda", None)] = lazy_cuda_heuristic
+
         monkeypatch.setattr(_patch, "is_musa_platform", lambda: True)
+        monkeypatch.setattr(common, "init_backend_registration", register_lazy_heuristic)
         monkeypatch.setattr(registry, "_TEMPLATE_HEURISTIC_REGISTRY", heuristic_registry)
         monkeypatch.setattr(registry, "_HEURISTIC_CACHE", heuristic_cache)
 
         _patch._patch_inductor_template_heuristics()
 
         assert heuristic_registry[("triton::bmm", "musa", None)] is cuda_heuristic
+        assert heuristic_registry[("triton::lazy_mm", "musa", None)] is lazy_cuda_heuristic
         assert heuristic_registry[("triton::mm", "musa", "addmm")] is existing_musa_heuristic
         assert ("aten::mm", "musa", None) not in heuristic_registry
         assert ("triton::mm", "cpu", None) in heuristic_registry

--- a/tests/test_cuda_patching.py
+++ b/tests/test_cuda_patching.py
@@ -1138,7 +1138,6 @@ class TestInductorTemplateHeuristics:
 
     def test_post2_uses_native_inductor_registration(self, monkeypatch):
         import torch
-
         from torch._inductor.template_heuristics import registry
 
         from torchada import _patch
@@ -2481,21 +2480,15 @@ class TestCppOpsInfrastructure:
         assert hasattr(_cpp_ops, "get_module")
 
     def test_cpp_ops_loaded_on_musa(self):
-        """Test that legacy C++ overrides load only before torch_musa post2."""
-        import torch
-
+        """C++ custom-op extension remains available on all supported versions."""
         import torchada
 
         if not torchada.is_musa_platform():
             pytest.skip("Only applicable on MUSA platform")
 
         from torchada._cpp_ops import is_loaded
-        from torchada._patch import _musa_accelerator_overrides_required
 
-        if _musa_accelerator_overrides_required(getattr(torch.musa, "__version__", None)):
-            assert is_loaded(), "Legacy C++ ops should load before torch_musa post2"
-        else:
-            assert not is_loaded(), "TorchAda C++ overrides must stay disabled on torch_musa post2+"
+        assert is_loaded(), "TorchAda C++ custom-op extension should be loaded"
 
     def test_cpp_ops_source_files_exist(self):
         """Test that the C++ source files are packaged correctly."""
@@ -3057,10 +3050,10 @@ class TestAcceleratorModuleWrapper:
             (None, True),
         ),
     )
-    def test_musa_accelerator_override_version_boundary(self, musa_version, expected):
-        from torchada._patch import _musa_accelerator_overrides_required
+    def test_torch_musa_version_boundary(self, musa_version, expected):
+        from torchada._patch import _is_pre_torch_musa_2_11_0_post2
 
-        assert _musa_accelerator_overrides_required(musa_version) is expected
+        assert _is_pre_torch_musa_2_11_0_post2(musa_version) is expected
 
     def _make_wrapper(
         self,
@@ -3303,11 +3296,11 @@ class TestTorchAcceleratorPatching:
         if not torchada.is_musa_platform():
             pytest.skip("Only applicable on MUSA platform")
 
-        from torchada._patch import _musa_accelerator_overrides_required
+        from torchada._patch import _is_pre_torch_musa_2_11_0_post2
 
         # Must not raise on either side of the torch_musa post2 boundary.
         torch.accelerator.empty_cache()
-        if _musa_accelerator_overrides_required(getattr(torch.musa, "__version__", None)):
+        if _is_pre_torch_musa_2_11_0_post2(getattr(torch.musa, "__version__", None)):
             assert torch.accelerator.empty_cache.__module__.startswith("torch_musa")
         else:
             assert torch.accelerator.empty_cache is torch.accelerator._original_accel.empty_cache

--- a/tests/test_cuda_patching.py
+++ b/tests/test_cuda_patching.py
@@ -1087,9 +1087,7 @@ class TestTensorIsCuda:
 class TestVisibleDevicesEnv:
     """Test CUDA_VISIBLE_DEVICES and MUSA_VISIBLE_DEVICES fallback."""
 
-    def test_cuda_visible_devices_env_falls_back_to_musa_visible_devices(
-        self, monkeypatch
-    ):
+    def test_cuda_visible_devices_env_falls_back_to_musa_visible_devices(self, monkeypatch):
         """Test CUDA_VISIBLE_DEVICES is copied to MUSA_VISIBLE_DEVICES."""
         from torchada import _patch
 
@@ -1100,9 +1098,7 @@ class TestVisibleDevicesEnv:
 
         assert os.environ["MUSA_VISIBLE_DEVICES"] == "1,3"
 
-    def test_musa_visible_devices_env_falls_back_to_cuda_visible_devices(
-        self, monkeypatch
-    ):
+    def test_musa_visible_devices_env_falls_back_to_cuda_visible_devices(self, monkeypatch):
         """Test MUSA_VISIBLE_DEVICES is copied to CUDA_VISIBLE_DEVICES."""
         from torchada import _patch
 
@@ -1113,8 +1109,8 @@ class TestVisibleDevicesEnv:
 
         assert os.environ["CUDA_VISIBLE_DEVICES"] == "0"
 
-    def test_existing_visible_devices_envs_are_not_overwritten(self, monkeypatch):
-        """Test explicit visible device envs have priority."""
+    def test_musa_visible_devices_overrides_cuda_visible_devices(self, monkeypatch):
+        """Test the MUSA setting wins when both variables are explicit."""
         from torchada import _patch
 
         monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "1,3")
@@ -1122,7 +1118,7 @@ class TestVisibleDevicesEnv:
 
         _patch._patch_visible_devices_env()
 
-        assert os.environ["CUDA_VISIBLE_DEVICES"] == "1,3"
+        assert os.environ["CUDA_VISIBLE_DEVICES"] == "0"
         assert os.environ["MUSA_VISIBLE_DEVICES"] == "0"
 
     def test_visible_devices_env_absent_noop(self, monkeypatch):
@@ -1136,6 +1132,74 @@ class TestVisibleDevicesEnv:
 
         assert "CUDA_VISIBLE_DEVICES" not in os.environ
         assert "MUSA_VISIBLE_DEVICES" not in os.environ
+
+
+class TestInductorTemplateHeuristics:
+    """Test CUDA-compatible Triton heuristic registration for MUSA."""
+
+    def test_copies_only_cuda_triton_heuristics_and_clears_cache(self, monkeypatch):
+        from torch._inductor.template_heuristics import registry
+
+        from torchada import _patch
+
+        cuda_heuristic = object()
+        existing_musa_heuristic = object()
+        heuristic_registry = {
+            ("triton::bmm", "cuda", None): cuda_heuristic,
+            ("triton::mm", "cuda", "addmm"): cuda_heuristic,
+            ("triton::mm", "musa", "addmm"): existing_musa_heuristic,
+            ("aten::mm", "cuda", None): object(),
+            ("triton::mm", "cpu", None): object(),
+            ("malformed", "cuda"): object(),
+            1: object(),
+        }
+        heuristic_cache = {("cached",): object()}
+        monkeypatch.setattr(_patch, "is_musa_platform", lambda: True)
+        monkeypatch.setattr(registry, "_TEMPLATE_HEURISTIC_REGISTRY", heuristic_registry)
+        monkeypatch.setattr(registry, "_HEURISTIC_CACHE", heuristic_cache)
+
+        _patch._patch_inductor_template_heuristics()
+
+        assert heuristic_registry[("triton::bmm", "musa", None)] is cuda_heuristic
+        assert heuristic_registry[("triton::mm", "musa", "addmm")] is existing_musa_heuristic
+        assert ("aten::mm", "musa", None) not in heuristic_registry
+        assert ("triton::mm", "cpu", None) in heuristic_registry
+        assert heuristic_cache == {}
+
+    def test_is_idempotent_and_preserves_cache_without_changes(self, monkeypatch):
+        from torch._inductor.template_heuristics import registry
+
+        from torchada import _patch
+
+        heuristic = object()
+        heuristic_registry = {("triton::mm", "cuda", None): heuristic}
+        heuristic_cache = {}
+        monkeypatch.setattr(_patch, "is_musa_platform", lambda: True)
+        monkeypatch.setattr(registry, "_TEMPLATE_HEURISTIC_REGISTRY", heuristic_registry)
+        monkeypatch.setattr(registry, "_HEURISTIC_CACHE", heuristic_cache)
+
+        _patch._patch_inductor_template_heuristics()
+        heuristic_cache[("after-first-patch",)] = object()
+        _patch._patch_inductor_template_heuristics()
+
+        assert heuristic_registry[("triton::mm", "musa", None)] is heuristic
+        assert ("after-first-patch",) in heuristic_cache
+
+    def test_non_musa_platform_is_noop(self, monkeypatch):
+        from torch._inductor.template_heuristics import registry
+
+        from torchada import _patch
+
+        heuristic_registry = {("triton::mm", "cuda", None): object()}
+        heuristic_cache = {("cached",): object()}
+        monkeypatch.setattr(_patch, "is_musa_platform", lambda: False)
+        monkeypatch.setattr(registry, "_TEMPLATE_HEURISTIC_REGISTRY", heuristic_registry)
+        monkeypatch.setattr(registry, "_HEURISTIC_CACHE", heuristic_cache)
+
+        _patch._patch_inductor_template_heuristics()
+
+        assert ("triton::mm", "musa", None) not in heuristic_registry
+        assert ("cached",) in heuristic_cache
 
 
 class TestAutotuneProcess:

--- a/tests/test_cuda_patching.py
+++ b/tests/test_cuda_patching.py
@@ -4,6 +4,8 @@ Tests for torch.cuda patching functionality.
 These tests verify that torch.cuda.* APIs work transparently on MUSA.
 """
 
+import os
+
 import pytest
 
 
@@ -1080,6 +1082,60 @@ class TestTensorIsCuda:
                 if "MUSA" in str(e) or "invalid device function" in str(e):
                     pytest.skip(f"MUSA driver issue: {e}")
                 raise
+
+
+class TestVisibleDevicesEnv:
+    """Test CUDA_VISIBLE_DEVICES and MUSA_VISIBLE_DEVICES fallback."""
+
+    def test_cuda_visible_devices_env_falls_back_to_musa_visible_devices(
+        self, monkeypatch
+    ):
+        """Test CUDA_VISIBLE_DEVICES is copied to MUSA_VISIBLE_DEVICES."""
+        from torchada import _patch
+
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "1,3")
+        monkeypatch.delenv("MUSA_VISIBLE_DEVICES", raising=False)
+
+        _patch._patch_visible_devices_env()
+
+        assert os.environ["MUSA_VISIBLE_DEVICES"] == "1,3"
+
+    def test_musa_visible_devices_env_falls_back_to_cuda_visible_devices(
+        self, monkeypatch
+    ):
+        """Test MUSA_VISIBLE_DEVICES is copied to CUDA_VISIBLE_DEVICES."""
+        from torchada import _patch
+
+        monkeypatch.setenv("MUSA_VISIBLE_DEVICES", "0")
+        monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+
+        _patch._patch_visible_devices_env()
+
+        assert os.environ["CUDA_VISIBLE_DEVICES"] == "0"
+
+    def test_existing_visible_devices_envs_are_not_overwritten(self, monkeypatch):
+        """Test explicit visible device envs have priority."""
+        from torchada import _patch
+
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "1,3")
+        monkeypatch.setenv("MUSA_VISIBLE_DEVICES", "0")
+
+        _patch._patch_visible_devices_env()
+
+        assert os.environ["CUDA_VISIBLE_DEVICES"] == "1,3"
+        assert os.environ["MUSA_VISIBLE_DEVICES"] == "0"
+
+    def test_visible_devices_env_absent_noop(self, monkeypatch):
+        """Test no visible device envs are added when both are absent."""
+        from torchada import _patch
+
+        monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+        monkeypatch.delenv("MUSA_VISIBLE_DEVICES", raising=False)
+
+        _patch._patch_visible_devices_env()
+
+        assert "CUDA_VISIBLE_DEVICES" not in os.environ
+        assert "MUSA_VISIBLE_DEVICES" not in os.environ
 
 
 class TestAutotuneProcess:

--- a/tests/test_cuda_patching.py
+++ b/tests/test_cuda_patching.py
@@ -1136,6 +1136,25 @@ class TestVisibleDevicesEnv:
 class TestInductorTemplateHeuristics:
     """Test CUDA-compatible Triton heuristic registration for MUSA."""
 
+    def test_post2_uses_native_inductor_registration(self, monkeypatch):
+        import torch
+
+        from torch._inductor.template_heuristics import registry
+
+        from torchada import _patch
+
+        heuristic_registry = {("triton::mm", "cuda", None): object()}
+        heuristic_cache = {("cached",): object()}
+        monkeypatch.setattr(_patch, "is_musa_platform", lambda: True)
+        monkeypatch.setattr(torch.musa, "__version__", "2.11.0.post2+musa5.2.0")
+        monkeypatch.setattr(registry, "_TEMPLATE_HEURISTIC_REGISTRY", heuristic_registry)
+        monkeypatch.setattr(registry, "_HEURISTIC_CACHE", heuristic_cache)
+
+        _patch._patch_inductor_template_heuristics()
+
+        assert ("triton::mm", "musa", None) not in heuristic_registry
+        assert ("cached",) in heuristic_cache
+
     def test_copies_only_cuda_triton_heuristics_and_clears_cache(self, monkeypatch):
         from torch._inductor.template_heuristics import registry
 
@@ -2454,16 +2473,21 @@ class TestCppOpsInfrastructure:
         assert hasattr(_cpp_ops, "get_module")
 
     def test_cpp_ops_loaded_on_musa(self):
-        """Test that C++ ops are automatically loaded on MUSA platform."""
+        """Test that legacy C++ overrides load only before torch_musa post2."""
+        import torch
+
         import torchada
 
         if not torchada.is_musa_platform():
             pytest.skip("Only applicable on MUSA platform")
 
         from torchada._cpp_ops import is_loaded
+        from torchada._patch import _musa_accelerator_overrides_required
 
-        # C++ ops should be automatically loaded on MUSA platform
-        assert is_loaded(), "C++ ops should be loaded automatically on MUSA"
+        if _musa_accelerator_overrides_required(getattr(torch.musa, "__version__", None)):
+            assert is_loaded(), "Legacy C++ ops should load before torch_musa post2"
+        else:
+            assert not is_loaded(), "TorchAda C++ overrides must stay disabled on torch_musa post2+"
 
     def test_cpp_ops_source_files_exist(self):
         """Test that the C++ source files are packaged correctly."""

--- a/tests/test_cuda_patching.py
+++ b/tests/test_cuda_patching.py
@@ -1087,8 +1087,19 @@ class TestTensorIsCuda:
 class TestVisibleDevicesEnv:
     """Test CUDA_VISIBLE_DEVICES and MUSA_VISIBLE_DEVICES fallback."""
 
-    def test_cuda_visible_devices_env_falls_back_to_musa_visible_devices(self, monkeypatch):
-        """Test CUDA_VISIBLE_DEVICES is copied to MUSA_VISIBLE_DEVICES."""
+    def test_musa_visible_devices_syncs_to_cuda_visible_devices(self, monkeypatch):
+        """Test CUDA_VISIBLE_DEVICES mirrors MUSA_VISIBLE_DEVICES."""
+        from torchada import _patch
+
+        monkeypatch.setenv("MUSA_VISIBLE_DEVICES", "1,3")
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0")
+
+        _patch._patch_visible_devices_env()
+
+        assert os.environ["CUDA_VISIBLE_DEVICES"] == "1,3"
+
+    def test_cuda_visible_devices_is_cleared_when_musa_is_absent(self, monkeypatch):
+        """Test CUDA_VISIBLE_DEVICES is removed when MUSA is not configured."""
         from torchada import _patch
 
         monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "1,3")
@@ -1096,30 +1107,18 @@ class TestVisibleDevicesEnv:
 
         _patch._patch_visible_devices_env()
 
-        assert os.environ["MUSA_VISIBLE_DEVICES"] == "1,3"
+        assert "CUDA_VISIBLE_DEVICES" not in os.environ
 
-    def test_musa_visible_devices_env_falls_back_to_cuda_visible_devices(self, monkeypatch):
-        """Test MUSA_VISIBLE_DEVICES is copied to CUDA_VISIBLE_DEVICES."""
+    def test_empty_musa_visible_devices_clears_cuda_value(self, monkeypatch):
+        """Test an explicitly empty MUSA value is mirrored exactly."""
         from torchada import _patch
 
-        monkeypatch.setenv("MUSA_VISIBLE_DEVICES", "0")
-        monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+        monkeypatch.setenv("MUSA_VISIBLE_DEVICES", "")
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0")
 
         _patch._patch_visible_devices_env()
 
-        assert os.environ["CUDA_VISIBLE_DEVICES"] == "0"
-
-    def test_musa_visible_devices_overrides_cuda_visible_devices(self, monkeypatch):
-        """Test the MUSA setting wins when both variables are explicit."""
-        from torchada import _patch
-
-        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "1,3")
-        monkeypatch.setenv("MUSA_VISIBLE_DEVICES", "0")
-
-        _patch._patch_visible_devices_env()
-
-        assert os.environ["CUDA_VISIBLE_DEVICES"] == "0"
-        assert os.environ["MUSA_VISIBLE_DEVICES"] == "0"
+        assert os.environ["CUDA_VISIBLE_DEVICES"] == ""
 
     def test_visible_devices_env_absent_noop(self, monkeypatch):
         """Test no visible device envs are added when both are absent."""
@@ -1130,8 +1129,8 @@ class TestVisibleDevicesEnv:
 
         _patch._patch_visible_devices_env()
 
-        assert "CUDA_VISIBLE_DEVICES" not in os.environ
         assert "MUSA_VISIBLE_DEVICES" not in os.environ
+        assert "CUDA_VISIBLE_DEVICES" not in os.environ
 
 
 class TestInductorTemplateHeuristics:

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,0 +1,66 @@
+import pytest
+import torch
+
+
+def _require_musa():
+    import torchada
+
+    if not torchada.is_musa_platform():
+        pytest.skip("MUSA platform required")
+
+    if not hasattr(torch, "musa") or not torch.musa.is_available():
+        pytest.skip("MUSA platform required")
+
+
+def test_log_float64_privateuse1_smoke():
+    _require_musa()
+    from torchada import _cpp_ops
+
+    _cpp_ops.load_cpp_ops(force_reload=True)
+    x = torch.linspace(0.1, 2.0, 128, device="cuda", dtype=torch.float64)
+
+    out = torch.log(x)
+    torch.cuda.synchronize()
+
+    expected = torch.log(x.cpu())
+    torch.testing.assert_close(out.cpu(), expected, rtol=1e-12, atol=1e-12)
+
+
+def test_log_inplace_float64_privateuse1_smoke():
+    _require_musa()
+    from torchada import _cpp_ops
+
+    _cpp_ops.load_cpp_ops(force_reload=True)
+    x = torch.linspace(0.1, 2.0, 128, device="cuda", dtype=torch.float64)
+    expected = torch.log(x.cpu())
+
+    ret = x.log_()
+    torch.cuda.synchronize()
+
+    assert ret is x
+    torch.testing.assert_close(x.cpu(), expected, rtol=1e-12, atol=1e-12)
+
+
+def test_log_inplace_float64_graph_capture_replay():
+    _require_musa()
+    from torchada import _cpp_ops
+
+    _cpp_ops.load_cpp_ops(force_reload=True)
+    x = torch.linspace(0.1, 2.0, 128, device="cuda", dtype=torch.float64)
+    work = x.clone()
+    for _ in range(3):
+        work.copy_(x)
+        work.log_()
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        work.copy_(x)
+        work.log_()
+
+    for _ in range(5):
+        graph.replay()
+    torch.cuda.synchronize()
+
+    expected = torch.log(x.cpu())
+    torch.testing.assert_close(work.cpu(), expected, rtol=1e-12, atol=1e-12)

--- a/tests/test_multinomial.py
+++ b/tests/test_multinomial.py
@@ -1,0 +1,100 @@
+import pytest
+import torch
+
+
+def _require_musa():
+    import torchada
+
+    if (
+        not torchada.is_musa_platform()
+        or not hasattr(torch, "musa")
+        or not torch.musa.is_available()
+    ):
+        pytest.skip("MUSA platform required")
+
+
+def test_multinomial_privateuse1_smoke():
+    _require_musa()
+    from torchada import _cpp_ops
+
+    _cpp_ops.load_cpp_ops(force_reload=True)
+    probs = torch.softmax(torch.randn(4, 64, device="cuda"), dim=-1)
+
+    out = torch.multinomial(probs, 1)
+    torch.cuda.synchronize()
+
+    assert out.shape == (4, 1)
+    assert out.dtype == torch.long
+    assert out.device.type in ("cuda", "musa")
+    assert int(out.min()) >= 0
+    assert int(out.max()) < 64
+
+
+def test_multinomial_without_replacement_unique():
+    _require_musa()
+    from torchada import _cpp_ops
+
+    _cpp_ops.load_cpp_ops(force_reload=True)
+    probs = torch.full((128, 16), 1.0 / 16, device="cuda")
+
+    out = torch.multinomial(probs, 8, replacement=False).cpu()
+
+    assert all(len(set(row.tolist())) == 8 for row in out)
+
+
+def test_multinomial_distribution_sanity():
+    _require_musa()
+    from torchada import _cpp_ops
+
+    _cpp_ops.load_cpp_ops(force_reload=True)
+    rows = 4096
+    weights = torch.tensor(
+        [0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.37],
+        device="cuda",
+    ).repeat(rows, 1)
+
+    out = torch.multinomial(weights, 1).flatten()
+    counts = torch.bincount(out.cpu(), minlength=weights.shape[1])
+
+    assert int(counts.argmax()) == 6
+    assert counts[-1] > counts[-2] > counts[-3]
+
+
+def test_multinomial_graph_capture_replay():
+    _require_musa()
+    from torchada import _cpp_ops
+
+    _cpp_ops.load_cpp_ops(force_reload=True)
+    probs = torch.softmax(torch.randn(2, 128, device="cuda"), dim=-1)
+    for _ in range(3):
+        out = torch.multinomial(probs, 1)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        out = torch.multinomial(probs, 1)
+
+    for _ in range(5):
+        graph.replay()
+    torch.cuda.synchronize()
+
+    assert out.shape == (2, 1)
+    assert int(out.min()) >= 0
+    assert int(out.max()) < 128
+
+
+def test_multinomial_accepts_generator_argument():
+    _require_musa()
+    from torchada import _cpp_ops
+
+    _cpp_ops.load_cpp_ops(force_reload=True)
+    probs = torch.full((4, 32), 1.0 / 32, device="cuda")
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(1234)
+
+    out = torch.multinomial(probs, 1, generator=generator)
+    torch.cuda.synchronize()
+
+    assert out.shape == (4, 1)
+    assert int(out.min()) >= 0
+    assert int(out.max()) < 32

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -59,7 +59,7 @@ class TestPlatformDetection:
 
         version = torchada.get_version()
         assert version == torchada.__version__
-        assert version == "0.1.83"
+        assert version == "0.1.84"
         assert isinstance(version, str)
 
     def test_project_version_matches_runtime_version(self):

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -59,7 +59,7 @@ class TestPlatformDetection:
 
         version = torchada.get_version()
         assert version == torchada.__version__
-        assert version == "0.1.84"
+        assert version == "0.1.85"
         assert isinstance(version, str)
 
     def test_project_version_matches_runtime_version(self):


### PR DESCRIPTION
## Summary

Add the graph-safe MUSA compatibility required by CUDA-facing inference paths and bump torchada from `0.1.83` to `0.1.85`:

- add MUSA `PrivateUse1` overrides for `aten::multinomial`, `aten::log`, and `aten::log_` on affected torch_musa releases
- reuse CUDA Inductor Triton template heuristics for MUSA matmul templates
- mirror `MUSA_VISIBLE_DEVICES` to `CUDA_VISIBLE_DEVICES` when both are present
- add focused correctness and CUDA-graph replay coverage for the new operators

## torch_musa version boundary

The TorchAda graph-safe compatibility is temporary and is limited to torch_musa versions before `2.11.0.post2`:

```text
torch_musa < 2.11.0.post2  -> keep TorchAda compatibility patches
torch_musa >= 2.11.0.post2 -> use torch_musa/ATen native implementations
```

The existing `_TORCH_MUSA_ACCELERATOR_FIX_VERSION = "2.11.0.post2"` is reused for this decision. The version is read from the existing `torch.musa.__version__` surface; no extra package-version helper or unconditional `import torch_musa` is added just for version detection.

On `torch_musa >= 2.11.0.post2`:

- `load_cpp_ops()` returns before building/loading TorchAda's C++ override extension
- the Inductor heuristic compatibility patch is skipped
- `torch_musa`/ATen owns `log`, `log_`, and `multinomial` dispatch directly
- no compile-time macro or version check is kept in `musa_ops.mu`

The currently published vLLM-MUSA image is still based on `torch_musa 2.11.0.post1+musa5.2.0`, so it remains on the compatibility side of this boundary.

## Scope

This PR does not change global CUDA platform semantics:

- does not patch `torch.cuda.is_available()`
- does not fake `torch.cuda.get_device_capability()`
- does not globally rewrite `torch.load` map locations
- does not add a flash-attention import shim
- does not add SGLang-Omni-specific model logic

## Testing

Focused validation was run with the PR source overlaid in the MUSA-enabled vLLM-MUSA image:

```bash
PYTHONPATH=src python -m pytest -q tests/test_cuda_patching.py \
  -k "VisibleDevicesEnv or InductorTemplateHeuristics or TestAcceleratorModuleWrapper or test_cpp_ops_loaded_on_musa"
```

```text
36 passed, 202 deselected
```

Operator correctness and graph replay tests on the same post1 MUSA runtime:

```bash
PYTHONPATH=src python -m pytest -q tests/test_log.py tests/test_multinomial.py
```

```text
8 passed
```

The version-boundary tests cover the existing post2 accelerator gate, post2 native Inductor registration behavior, local-version suffixes such as `+musa5.2.0`, and the post2+ no-C++-override behavior. `git diff --check` and Python syntax compilation also pass.

## Downstream image validation

| Downstream image | torch / torch_musa | Triton keys | Missing MUSA keys | Result |
| --- | --- | ---: | ---: | --- |
| `registry.mthreads.com/mcconline/inference/sglang:v0.5.12.post1-ph1-4.3.5-torch2.9.0-20260819` | `2.9.0` / `40305` | 11 | 0 | SGLang import and MUSA matmul passed after installing the image's optional runtime dependencies |
| `registry.mthreads.com/mcconline/inference/vllm:v0.24.0-ph1-5.2.0-torch2.11.0.post1-20260827` | `2.11.0.post1+musa5.2.0` / `50200` | 15 | 0 | vLLM import, MUSA platform plugin loading, and MUSA matmul passed |

A direct runtime probe in the latest image confirmed:

```text
torch_musa = 2.11.0.post1+musa5.2.0
torch.musa.is_available() = True
torch.musa.device_count() = 1
aten::log PrivateUse1 kernel = present
aten::log_ PrivateUse1 kernel = present
aten::multinomial PrivateUse1 kernel = present
```

## Request-level vLLM compile smoke

A request-level Qwen3-0.6B vLLM compile and GSM8K follow-up was run on MUSA with `CompilationMode.VLLM_COMPILE` (`mode=3`) using the compatible image `registry.mthreads.com/mcconline/inference/vllm:v0.24.0-ph1-5.2.0-torch2.9.1.post1-20260805`.

The service completed compilation, graph capture, a direct completion request, and the official 200-question GSM8K evaluator:

```text
Accuracy: 0.380
Invalid responses: 0.000
All 200 requests returned HTTP 200
```

The server log contained no runtime exception, backend compiler failure, graph break, or eager fallback during evaluation.

## Limitations

- No public `torch_musa 2.11.0.post2` wheel/tag is available yet; post2 behavior is covered by version-boundary tests and the code path is fail-safe for unknown versions.
- The `20260819` and `20260824` Qwen3 startup attempts hit a pre-existing vLLM-MUSA `is_neox` signature mismatch, so request-level evaluation used the compatible `20260805` image.
- The request-level run validates the Python Inductor path and downstream service behavior; it should not be interpreted as C++ override coverage for a post2 wheel.