### PR TITLE
[codex] sync MTT_S5000 E=160,N=192 MoE configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ See `src/torchada/_mappings/` for 400+ mapping rules grouped by API domain.
 
 ```
 # pyproject.toml or requirements.txt
-torchada>=0.1.83
+torchada>=0.1.84
 ```
 
 ### Step 2: Conditional Import

--- a/README_CN.md
+++ b/README_CN.md
@@ -376,7 +376,7 @@ if torchada.is_gpu_device(device):  # 在 CUDA 和 MUSA 上都能工作
 
 ```
 # pyproject.toml 或 requirements.txt
-torchada>=0.1.83
+torchada>=0.1.84
 ```
 
 ### 步骤 2：条件导入

--- a/benchmarks/benchmark_history.json
+++ b/benchmarks/benchmark_history.json
@@ -3,7 +3,7 @@
   "description": "Historical benchmark results for torchada performance tracking",
   "results": [
     {
-      "version": "0.1.83",
+      "version": "0.1.84",
       "date": "2026-01-29",
       "platform": "MUSA",
       "pytorch_version": "2.7.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torchada"
-version = "0.1.83"
+version = "0.1.84"
 description = "Adapter package for torch_musa to act exactly like PyTorch CUDA"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/torchada/__init__.py
+++ b/src/torchada/__init__.py
@@ -24,7 +24,7 @@ Usage:
     from torch.utils.cpp_extension import CUDAExtension, BuildExtension, CUDA_HOME
 """
 
-__version__ = "0.1.83"
+__version__ = "0.1.84"
 
 from . import cuda, utils
 

--- a/src/torchada/triton/autotune/fused_moe/configs/triton_3_2_0/E=160,N=192,device_name=MTT_S5000_down.json
+++ b/src/torchada/triton/autotune/fused_moe/configs/triton_3_2_0/E=160,N=192,device_name=MTT_S5000_down.json
@@ -26,8 +26,8 @@
     "8": {
         "BLOCK_SIZE_M": 16,
         "BLOCK_SIZE_N": 64,
-        "BLOCK_SIZE_K": 128,
-        "GROUP_SIZE_M": 16,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
         "num_warps": 4,
         "num_stages": 1
     },
@@ -57,26 +57,26 @@
     },
     "48": {
         "BLOCK_SIZE_M": 32,
-        "BLOCK_SIZE_N": 32,
-        "BLOCK_SIZE_K": 64,
-        "GROUP_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
         "num_warps": 4,
         "num_stages": 1
     },
     "64": {
         "BLOCK_SIZE_M": 32,
-        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_N": 64,
         "BLOCK_SIZE_K": 64,
-        "GROUP_SIZE_M": 64,
+        "GROUP_SIZE_M": 1,
         "num_warps": 4,
         "num_stages": 1
     },
     "96": {
         "BLOCK_SIZE_M": 32,
-        "BLOCK_SIZE_N": 32,
-        "BLOCK_SIZE_K": 128,
-        "GROUP_SIZE_M": 16,
-        "num_warps": 4,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
         "num_stages": 1
     },
     "128": {
@@ -106,23 +106,23 @@
     "1024": {
         "BLOCK_SIZE_M": 64,
         "BLOCK_SIZE_N": 128,
-        "BLOCK_SIZE_K": 64,
-        "GROUP_SIZE_M": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
         "num_warps": 8,
         "num_stages": 1
     },
     "1536": {
         "BLOCK_SIZE_M": 64,
-        "BLOCK_SIZE_N": 128,
-        "BLOCK_SIZE_K": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
         "GROUP_SIZE_M": 1,
-        "num_warps": 8,
+        "num_warps": 4,
         "num_stages": 1
     },
     "2048": {
         "BLOCK_SIZE_M": 128,
         "BLOCK_SIZE_N": 128,
-        "BLOCK_SIZE_K": 64,
+        "BLOCK_SIZE_K": 32,
         "GROUP_SIZE_M": 1,
         "num_warps": 16,
         "num_stages": 1

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -59,7 +59,7 @@ class TestPlatformDetection:
 
         version = torchada.get_version()
         assert version == torchada.__version__
-        assert version == "0.1.83"
+        assert version == "0.1.84"
         assert isinstance(version, str)
 
     def test_project_version_matches_runtime_version(self):


### PR DESCRIPTION
## Summary

- sync the latest SGLang Triton 3.2.0 MoE configs for `E=160,N=192` on `MTT_S5000` and `MTT_S5000_down`
- bump torchada version metadata to `0.1.84`

## Validation

- verified both config files byte-for-byte against SGLang commit `89ca41ba68`
- parsed both files successfully with `python -m json.tool`
- `git diff --check` passed
- pre-commit hooks passed for the committed changes
- `tests/test_moe_config_dir.py` could not be collected in the current environment because Torch raised a duplicate `TORCH_LIBRARY triton` registration error during import

