### PR TITLE
fix(musa): expose device index helper for TorchDynamo

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ See `src/torchada/_mappings/` for 400+ mapping rules grouped by API domain.
 
 ```
 # pyproject.toml or requirements.txt
-torchada>=0.1.84
+torchada>=0.1.85
 ```
 
 ### Step 2: Conditional Import

--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ See `src/torchada/_mappings/` for 400+ mapping rules grouped by API domain.
 
 ```
 # pyproject.toml or requirements.txt
-torchada>=0.1.85
+torchada>=0.1.86
 ```
 
 ### Step 2: Conditional Import

--- a/README_CN.md
+++ b/README_CN.md
@@ -376,7 +376,7 @@ if torchada.is_gpu_device(device):  # 在 CUDA 和 MUSA 上都能工作
 
 ```
 # pyproject.toml 或 requirements.txt
-torchada>=0.1.84
+torchada>=0.1.85
 ```
 
 ### 步骤 2：条件导入

--- a/README_CN.md
+++ b/README_CN.md
@@ -376,7 +376,7 @@ if torchada.is_gpu_device(device):  # 在 CUDA 和 MUSA 上都能工作
 
 ```
 # pyproject.toml 或 requirements.txt
-torchada>=0.1.85
+torchada>=0.1.86
 ```
 
 ### 步骤 2：条件导入

--- a/benchmarks/benchmark_history.json
+++ b/benchmarks/benchmark_history.json
@@ -3,7 +3,7 @@
   "description": "Historical benchmark results for torchada performance tracking",
   "results": [
     {
-      "version": "0.1.84",
+      "version": "0.1.85",
       "date": "2026-01-29",
       "platform": "MUSA",
       "pytorch_version": "2.7.1",

--- a/benchmarks/benchmark_history.json
+++ b/benchmarks/benchmark_history.json
@@ -3,7 +3,7 @@
   "description": "Historical benchmark results for torchada performance tracking",
   "results": [
     {
-      "version": "0.1.85",
+      "version": "0.1.86",
       "date": "2026-01-29",
       "platform": "MUSA",
       "pytorch_version": "2.7.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torchada"
-version = "0.1.84"
+version = "0.1.85"
 description = "Adapter package for torch_musa to act exactly like PyTorch CUDA"
 readme = "README.md"
 license = {text = "MIT"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torchada"
-version = "0.1.85"
+version = "0.1.86"
 description = "Adapter package for torch_musa to act exactly like PyTorch CUDA"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/torchada/__init__.py
+++ b/src/torchada/__init__.py
@@ -24,7 +24,7 @@ Usage:
     from torch.utils.cpp_extension import CUDAExtension, BuildExtension, CUDA_HOME
 """
 
-__version__ = "0.1.84"
+__version__ = "0.1.85"
 
 from . import cuda, utils
 

--- a/src/torchada/__init__.py
+++ b/src/torchada/__init__.py
@@ -24,7 +24,7 @@ Usage:
     from torch.utils.cpp_extension import CUDAExtension, BuildExtension, CUDA_HOME
 """
 
-__version__ = "0.1.85"
+__version__ = "0.1.86"
 
 from . import cuda, utils
 

--- a/src/torchada/_patch.py
+++ b/src/torchada/_patch.py
@@ -775,6 +775,10 @@ class _CudaModuleWrapper(ModuleType):
     _SPECIAL_ATTRS = {
         "StreamContext": "core.stream.StreamContext",
         "streams": "core.stream",
+        # torch._dynamo models ``torch.cuda.device`` through this private CUDA
+        # helper.  torch_musa exposes the equivalent helper below ``core``
+        # instead of at the module top level.
+        "_get_device_index": "core._utils._get_musa_device_index",
     }
 
     # Attribute name remappings (CUDA name -> MUSA name)

--- a/src/torchada/_patch.py
+++ b/src/torchada/_patch.py
@@ -775,9 +775,6 @@ class _CudaModuleWrapper(ModuleType):
     _SPECIAL_ATTRS = {
         "StreamContext": "core.stream.StreamContext",
         "streams": "core.stream",
-        # torch._dynamo models ``torch.cuda.device`` through this private CUDA
-        # helper.  torch_musa exposes the equivalent helper below ``core``
-        # instead of at the module top level.
         "_get_device_index": "core._utils._get_musa_device_index",
     }
 

--- a/tests/test_cuda_patching.py
+++ b/tests/test_cuda_patching.py
@@ -727,6 +727,17 @@ class TestStreamAndEvent:
             assert sys.modules["torch.cuda.streams"] is torch_musa.core.stream
             assert torch.cuda.streams.Stream is torch_musa.core.stream.Stream
 
+    def test_get_device_index_helper(self):
+        """Test the private CUDA device helper used by PyTorch Dynamo."""
+        import torch
+
+        import torchada
+
+        if torchada.is_musa_platform():
+            from torch_musa.core._utils import _get_musa_device_index
+
+            assert torch.cuda._get_device_index is _get_musa_device_index
+
     def test_stream_cuda_stream_property(self):
         """Test stream.cuda_stream returns same value as stream.musa_stream on MUSA."""
         import torch

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -59,7 +59,7 @@ class TestPlatformDetection:
 
         version = torchada.get_version()
         assert version == torchada.__version__
-        assert version == "0.1.84"
+        assert version == "0.1.85"
         assert isinstance(version, str)
 
     def test_project_version_matches_runtime_version(self):

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -59,7 +59,7 @@ class TestPlatformDetection:
 
         version = torchada.get_version()
         assert version == torchada.__version__
-        assert version == "0.1.85"
+        assert version == "0.1.86"
         assert isinstance(version, str)
 
     def test_project_version_matches_runtime_version(self):


### PR DESCRIPTION
## Summary

Map `torch.cuda._get_device_index` to
`torch_musa.core._utils._get_musa_device_index` in the CUDA module wrapper.

## Motivation

TorchDynamo models `torch.cuda.device(...)` by calling
`torch.cuda._get_device_index(...)`.

Without the mapping, TorchAda redirects the lookup to the top-level
`torch_musa` module, where the helper does not exist:

```text
InternalTorchDynamoError:
AttributeError: module 'torch_musa' has no attribute '_get_device_index' 
```
## Reproduction
```
import torch
import torchada

x = torch.ones(4, device="musa")

@torch.compile(backend="eager")
def f(t):
    with torch.cuda.device(t.device.index):
        return t + 1

print(f(x))
```