### PR TITLE
perf: add MAGI-2 Preview S5000 fused MoE autotune configs

### DIFF
--- a/src/torchada/triton/autotune/fused_moe/configs/triton_3_2_0/E=768,N=1280,device_name=MTT_S5000.json
+++ b/src/torchada/triton/autotune/fused_moe/configs/triton_3_2_0/E=768,N=1280,device_name=MTT_S5000.json
@@ -14,5 +14,13 @@
     "GROUP_SIZE_M": 16,
     "num_warps": 16,
     "num_stages": 1
+  },
+  "45012": {
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 32,
+    "GROUP_SIZE_M": 16,
+    "num_warps": 16,
+    "num_stages": 1
   }
 }

--- a/src/torchada/triton/autotune/fused_moe/configs/triton_3_2_0/E=768,N=1280,device_name=MTT_S5000.json
+++ b/src/torchada/triton/autotune/fused_moe/configs/triton_3_2_0/E=768,N=1280,device_name=MTT_S5000.json
@@ -1,0 +1,18 @@
+{
+  "21996": {
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 32,
+    "GROUP_SIZE_M": 16,
+    "num_warps": 16,
+    "num_stages": 1
+  },
+  "24468": {
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 32,
+    "GROUP_SIZE_M": 16,
+    "num_warps": 16,
+    "num_stages": 1
+  }
+}

--- a/src/torchada/triton/autotune/fused_moe/configs/triton_3_2_0/E=768,N=1280,device_name=MTT_S5000_down.json
+++ b/src/torchada/triton/autotune/fused_moe/configs/triton_3_2_0/E=768,N=1280,device_name=MTT_S5000_down.json
@@ -1,0 +1,18 @@
+{
+  "21996": {
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 32,
+    "GROUP_SIZE_M": 16,
+    "num_warps": 16,
+    "num_stages": 1
+  },
+  "24468": {
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 32,
+    "GROUP_SIZE_M": 16,
+    "num_warps": 16,
+    "num_stages": 1
+  }
+}

--- a/src/torchada/triton/autotune/fused_moe/configs/triton_3_2_0/E=768,N=1280,device_name=MTT_S5000_down.json
+++ b/src/torchada/triton/autotune/fused_moe/configs/triton_3_2_0/E=768,N=1280,device_name=MTT_S5000_down.json
@@ -14,5 +14,13 @@
     "GROUP_SIZE_M": 16,
     "num_warps": 16,
     "num_stages": 1
+  },
+  "45012": {
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 64,
+    "GROUP_SIZE_M": 16,
+    "num_warps": 16,
+    "num_stages": 1
   }
 }

--- a/src/torchada/triton/autotune/fused_moe/configs/triton_3_6_0/E=768,N=1280,device_name=MTT_S5000,dtype=bf16.json
+++ b/src/torchada/triton/autotune/fused_moe/configs/triton_3_6_0/E=768,N=1280,device_name=MTT_S5000,dtype=bf16.json
@@ -1,0 +1,10 @@
+{
+  "45012": {
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 32,
+    "GROUP_SIZE_M": 16,
+    "num_warps": 16,
+    "num_stages": 1
+  }
+}

--- a/src/torchada/triton/runtime/fused_moe/config.py
+++ b/src/torchada/triton/runtime/fused_moe/config.py
@@ -71,7 +71,7 @@ def get_moe_configs(
     be picked and the associated configuration chosen to invoke the kernel.
     """
     # Supported Triton versions, should be sorted from the newest to the oldest
-    supported_triton_versions = ["3.4.0", "3.3.1", "3.2.0", "3.1.0"]
+    supported_triton_versions = ["3.6.0", "3.4.0", "3.3.1", "3.2.0", "3.1.0"]
 
     # First look up if an optimized configuration is available in the configs
     # directory

--- a/tests/test_magi2_s5000_moe_configs.py
+++ b/tests/test_magi2_s5000_moe_configs.py
@@ -1,0 +1,25 @@
+import json
+from pathlib import Path
+
+CONFIG_DIR = (
+    Path(__file__).parents[1] / "src/torchada/triton/autotune/fused_moe/configs/triton_3_2_0"
+)
+NAMES = (
+    "E=768,N=1280,device_name=MTT_S5000.json",
+    "E=768,N=1280,device_name=MTT_S5000_down.json",
+)
+
+
+def test_magi2_s5000_configs_have_tuned_runtime_shapes():
+    for name in NAMES:
+        data = json.loads((CONFIG_DIR / name).read_text())
+        assert set(data) == {"21996", "24468"}
+        for config in data.values():
+            assert config == {
+                "BLOCK_SIZE_M": 128,
+                "BLOCK_SIZE_N": 128,
+                "BLOCK_SIZE_K": 32,
+                "GROUP_SIZE_M": 16,
+                "num_warps": 16,
+                "num_stages": 1,
+            }

--- a/tests/test_magi2_s5000_moe_configs.py
+++ b/tests/test_magi2_s5000_moe_configs.py
@@ -13,13 +13,20 @@ NAMES = (
 def test_magi2_s5000_configs_have_tuned_runtime_shapes():
     for name in NAMES:
         data = json.loads((CONFIG_DIR / name).read_text())
-        assert set(data) == {"21996", "24468"}
-        for config in data.values():
-            assert config == {
-                "BLOCK_SIZE_M": 128,
-                "BLOCK_SIZE_N": 128,
-                "BLOCK_SIZE_K": 32,
-                "GROUP_SIZE_M": 16,
-                "num_warps": 16,
-                "num_stages": 1,
-            }
+        assert set(data) == {"21996", "24468", "45012"}
+        for shape in ("21996", "24468"):
+            assert data[shape] == _expected_config(block_size_k=32)
+
+        expected_k = 64 if name.endswith("_down.json") else 32
+        assert data["45012"] == _expected_config(block_size_k=expected_k)
+
+
+def _expected_config(*, block_size_k: int):
+    return {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": block_size_k,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 16,
+        "num_stages": 1,
+    }


### PR DESCRIPTION
## Summary

Add shape-specific Triton fused-MoE autotune configs for MAGI-2 Preview on MTT S5000.

- Local flattened experts: E=768 (EP4)
- Expert intermediate width: N=1280
- Tuned M buckets: M=21996, 24468, 45012
- W13/up: BLOCK_M=128, BLOCK_N=128, BLOCK_K=32, GROUP_M=16, num_warps=16, num_stages=1
- W2/down: K=32 for M=21996/24468; K=64 for M=45012

These configs are intended for the torchada Triton fused-MoE autotune loader. The vLLM-Omni MAGI-2 custom SGL path currently keeps its independently validated hand-tuned W13 K32/W2 K64 split.

## Validation

The files were generated and reviewed against the MAGI-2 EP4 shape. Runtime integration in vLLM-Omni was tested separately; no claim is made that the custom Omni path consumes these files automatically.
